### PR TITLE
refactor: renamed mongoose models and documents

### DIFF
--- a/apps/backend/src/modules/auth/auth.service.ts
+++ b/apps/backend/src/modules/auth/auth.service.ts
@@ -3,7 +3,7 @@ import { AppError } from "@/common/errors.js";
 import type { JwtPayload } from "@/common/utils/jwt.js";
 import { signToken } from "@/common/utils/jwt.js";
 import type { LoginBody, RegisterBody } from "@/modules/auth/auth.schema.js";
-import { User as UserModel } from "@/modules/auth/user.model.js";
+import { UserModel } from "@/modules/auth/user.model.js";
 
 function toUser(doc: unknown): User {
   const d = doc as Record<string, unknown>;

--- a/apps/backend/src/modules/auth/user.model.ts
+++ b/apps/backend/src/modules/auth/user.model.ts
@@ -2,7 +2,7 @@ import bcrypt from "bcryptjs";
 import type { Document } from "mongoose";
 import mongoose, { Schema } from "mongoose";
 
-export interface IUser extends Document {
+export interface IUserDocument extends Document {
   email: string;
   password: string;
   name: string;
@@ -11,7 +11,7 @@ export interface IUser extends Document {
   comparePassword(candidate: string): Promise<boolean>;
 }
 
-const userSchema = new Schema<IUser>(
+const userSchema = new Schema<IUserDocument>(
   {
     email: {
       type: String,
@@ -48,4 +48,4 @@ userSchema.methods.comparePassword = async function (
   return bcrypt.compare(candidate, this.password);
 };
 
-export const User = mongoose.model<IUser>("User", userSchema);
+export const UserModel = mongoose.model<IUserDocument>("User", userSchema);

--- a/apps/backend/src/modules/categories/__tests__/category.service.test.ts
+++ b/apps/backend/src/modules/categories/__tests__/category.service.test.ts
@@ -3,14 +3,14 @@ import { mockCreate, mockFind } from "@/common/utils/test-helpers.js";
 import { CategoryService } from "../category.service.js";
 
 vi.mock("../category.model.js", () => ({
-  Category: {
+  CategoryModel: {
     find: vi.fn(),
     create: vi.fn(),
     findByIdAndDelete: vi.fn(),
   },
 }));
 
-const { Category } = await import("../category.model.js");
+const { CategoryModel } = await import("../category.model.js");
 
 describe("CategoryService", () => {
   let service: CategoryService;
@@ -40,7 +40,7 @@ describe("CategoryService", () => {
         },
       ];
 
-      vi.mocked(Category.find).mockReturnValue(
+      vi.mocked(CategoryModel.find).mockReturnValue(
         mockFind(mockCategories) as never,
       );
 
@@ -55,11 +55,11 @@ describe("CategoryService", () => {
         createdAt: mockDate.toISOString(),
         updatedAt: mockDate.toISOString(),
       });
-      expect(Category.find).toHaveBeenCalled();
+      expect(CategoryModel.find).toHaveBeenCalled();
     });
 
     it("should return empty array when no categories exist", async () => {
-      vi.mocked(Category.find).mockReturnValue(mockFind([]) as never);
+      vi.mocked(CategoryModel.find).mockReturnValue(mockFind([]) as never);
 
       const result = await service.findAll();
 
@@ -79,7 +79,7 @@ describe("CategoryService", () => {
         updatedAt: mockDate,
       };
 
-      vi.mocked(Category.create).mockResolvedValue(
+      vi.mocked(CategoryModel.create).mockResolvedValue(
         mockCreate(mockDoc) as never,
       );
 
@@ -93,22 +93,22 @@ describe("CategoryService", () => {
         createdAt: mockDate.toISOString(),
         updatedAt: mockDate.toISOString(),
       });
-      expect(Category.create).toHaveBeenCalledWith(input);
+      expect(CategoryModel.create).toHaveBeenCalledWith(input);
     });
   });
 
   describe("deleteById", () => {
     it("should delete category by id", async () => {
-      vi.mocked(Category.findByIdAndDelete).mockResolvedValue({
+      vi.mocked(CategoryModel.findByIdAndDelete).mockResolvedValue({
         _id: "1",
       } as never);
 
       await expect(service.deleteById("1")).resolves.toBeUndefined();
-      expect(Category.findByIdAndDelete).toHaveBeenCalledWith("1");
+      expect(CategoryModel.findByIdAndDelete).toHaveBeenCalledWith("1");
     });
 
     it("should throw 404 error when category not found", async () => {
-      vi.mocked(Category.findByIdAndDelete).mockResolvedValue(null);
+      vi.mocked(CategoryModel.findByIdAndDelete).mockResolvedValue(null);
 
       await expect(service.deleteById("999")).rejects.toMatchObject({
         message: "Category not found",

--- a/apps/backend/src/modules/categories/category.model.ts
+++ b/apps/backend/src/modules/categories/category.model.ts
@@ -1,7 +1,7 @@
 import type { Document } from "mongoose";
 import mongoose, { Schema } from "mongoose";
 
-export interface ICategory extends Document {
+export interface ICategoryDocument extends Document {
   name: string;
   slug: string;
   description?: string;
@@ -9,7 +9,7 @@ export interface ICategory extends Document {
   updatedAt: Date;
 }
 
-const categorySchema = new Schema<ICategory>(
+const categorySchema = new Schema<ICategoryDocument>(
   {
     name: { type: String, required: true, unique: true, trim: true },
     slug: { type: String, required: true, unique: true, lowercase: true },
@@ -39,4 +39,7 @@ categorySchema.pre("validate", async function () {
   }
 });
 
-export const Category = mongoose.model<ICategory>("Category", categorySchema);
+export const CategoryModel = mongoose.model<ICategoryDocument>(
+  "Category",
+  categorySchema,
+);

--- a/apps/backend/src/modules/categories/category.service.ts
+++ b/apps/backend/src/modules/categories/category.service.ts
@@ -1,6 +1,6 @@
 import type { Category } from "@recipes/shared";
 import { AppError } from "@/common/errors.js";
-import { Category as CategoryModel } from "@/modules/categories/category.model.js";
+import { CategoryModel } from "@/modules/categories/category.model.js";
 import type { CreateCategoryBody } from "@/modules/categories/category.schema.js";
 
 function toCategory(doc: unknown): Category {

--- a/apps/backend/src/modules/comments/__tests__/comment.service.test.ts
+++ b/apps/backend/src/modules/comments/__tests__/comment.service.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CommentService } from "../comment.service.js";
 
 vi.mock("@/modules/comments/comment.model.js", () => ({
-  Comment: {
+  CommentModel: {
     find: vi.fn(),
     findById: vi.fn(),
     countDocuments: vi.fn(),
@@ -11,20 +11,20 @@ vi.mock("@/modules/comments/comment.model.js", () => ({
 }));
 
 vi.mock("@/modules/recipes/recipe.model.js", () => ({
-  Recipe: {
+  RecipeModel: {
     findById: vi.fn(),
   },
 }));
 
 vi.mock("@/modules/auth/user.model.js", () => ({
-  User: {
+  UserModel: {
     findById: vi.fn(),
   },
 }));
 
-const { Comment } = await import("@/modules/comments/comment.model.js");
-const { Recipe } = await import("@/modules/recipes/recipe.model.js");
-const { User } = await import("@/modules/auth/user.model.js");
+const { CommentModel } = await import("@/modules/comments/comment.model.js");
+const { RecipeModel } = await import("@/modules/recipes/recipe.model.js");
+const { UserModel } = await import("@/modules/auth/user.model.js");
 
 describe("CommentService", () => {
   let service: CommentService;
@@ -56,7 +56,9 @@ describe("CommentService", () => {
 
   describe("findByRecipe", () => {
     it("should return paginated comments for a recipe", async () => {
-      vi.mocked(Recipe.findById).mockResolvedValue({ _id: recipeId } as never);
+      vi.mocked(RecipeModel.findById).mockResolvedValue({
+        _id: recipeId,
+      } as never);
 
       const mockLean = vi.fn().mockResolvedValue([mockLeanComment]);
       const mockLimit = vi.fn().mockReturnValue({ lean: mockLean });
@@ -64,10 +66,10 @@ describe("CommentService", () => {
       const mockSort = vi.fn().mockReturnValue({ skip: mockSkip });
       const mockPopulate = vi.fn().mockReturnValue({ sort: mockSort });
 
-      vi.mocked(Comment.find).mockReturnValue({
+      vi.mocked(CommentModel.find).mockReturnValue({
         populate: mockPopulate,
       } as never);
-      vi.mocked(Comment.countDocuments).mockResolvedValue(1);
+      vi.mocked(CommentModel.countDocuments).mockResolvedValue(1);
 
       const result = await service.findByRecipe(
         { recipeId },
@@ -98,11 +100,13 @@ describe("CommentService", () => {
         hasNext: false,
         hasPrev: false,
       });
-      expect(Comment.find).toHaveBeenCalledWith({ recipe: recipeId });
+      expect(CommentModel.find).toHaveBeenCalledWith({ recipe: recipeId });
     });
 
     it("should return correct pagination for multiple pages", async () => {
-      vi.mocked(Recipe.findById).mockResolvedValue({ _id: recipeId } as never);
+      vi.mocked(RecipeModel.findById).mockResolvedValue({
+        _id: recipeId,
+      } as never);
 
       const mockLean = vi.fn().mockResolvedValue([]);
       const mockLimit = vi.fn().mockReturnValue({ lean: mockLean });
@@ -110,10 +114,10 @@ describe("CommentService", () => {
       const mockSort = vi.fn().mockReturnValue({ skip: mockSkip });
       const mockPopulate = vi.fn().mockReturnValue({ sort: mockSort });
 
-      vi.mocked(Comment.find).mockReturnValue({
+      vi.mocked(CommentModel.find).mockReturnValue({
         populate: mockPopulate,
       } as never);
-      vi.mocked(Comment.countDocuments).mockResolvedValue(45);
+      vi.mocked(CommentModel.countDocuments).mockResolvedValue(45);
 
       const result = await service.findByRecipe(
         { recipeId },
@@ -134,7 +138,7 @@ describe("CommentService", () => {
     });
 
     it("should throw 404 when recipe not found", async () => {
-      vi.mocked(Recipe.findById).mockResolvedValue(null);
+      vi.mocked(RecipeModel.findById).mockResolvedValue(null);
 
       await expect(
         service.findByRecipe(
@@ -150,17 +154,21 @@ describe("CommentService", () => {
 
   describe("create", () => {
     it("should create and return a comment", async () => {
-      vi.mocked(Recipe.findById).mockResolvedValue({ _id: recipeId } as never);
+      vi.mocked(RecipeModel.findById).mockResolvedValue({
+        _id: recipeId,
+      } as never);
 
       const mockPopulate = vi.fn().mockResolvedValue({
         toObject: () => mockLeanComment,
       });
 
-      vi.mocked(Comment.create).mockResolvedValue({
+      vi.mocked(CommentModel.create).mockResolvedValue({
         populate: mockPopulate,
       } as never);
 
-      vi.mocked(User.findById).mockResolvedValue({ _id: authorId } as never);
+      vi.mocked(UserModel.findById).mockResolvedValue({
+        _id: authorId,
+      } as never);
 
       const result = await service.create(recipeId, authorId, {
         text: "Great recipe!",
@@ -178,7 +186,7 @@ describe("CommentService", () => {
         createdAt: mockDate.toISOString(),
         updatedAt: mockDate.toISOString(),
       });
-      expect(Comment.create).toHaveBeenCalledWith({
+      expect(CommentModel.create).toHaveBeenCalledWith({
         text: "Great recipe!",
         recipe: recipeId,
         author: authorId,
@@ -186,7 +194,7 @@ describe("CommentService", () => {
     });
 
     it("should throw 404 when recipe not found", async () => {
-      vi.mocked(Recipe.findById).mockResolvedValue(null);
+      vi.mocked(RecipeModel.findById).mockResolvedValue(null);
 
       await expect(
         service.create("nonexistent", authorId, { text: "Hello" }),
@@ -201,7 +209,7 @@ describe("CommentService", () => {
     it("should delete comment when user is the author", async () => {
       const mockDeleteOne = vi.fn().mockResolvedValue(undefined);
 
-      vi.mocked(Comment.findById).mockResolvedValue({
+      vi.mocked(CommentModel.findById).mockResolvedValue({
         _id: commentId,
         author: { toString: () => authorId },
         deleteOne: mockDeleteOne,
@@ -209,12 +217,12 @@ describe("CommentService", () => {
 
       await service.delete(commentId, authorId);
 
-      expect(Comment.findById).toHaveBeenCalledWith(commentId);
+      expect(CommentModel.findById).toHaveBeenCalledWith(commentId);
       expect(mockDeleteOne).toHaveBeenCalled();
     });
 
     it("should throw 404 when comment not found", async () => {
-      vi.mocked(Comment.findById).mockResolvedValue(null);
+      vi.mocked(CommentModel.findById).mockResolvedValue(null);
 
       await expect(
         service.delete("nonexistent", authorId),
@@ -225,7 +233,7 @@ describe("CommentService", () => {
     });
 
     it("should throw 403 when user is not the author", async () => {
-      vi.mocked(Comment.findById).mockResolvedValue({
+      vi.mocked(CommentModel.findById).mockResolvedValue({
         _id: commentId,
         author: { toString: () => authorId },
         deleteOne: vi.fn(),

--- a/apps/backend/src/modules/comments/comment.model.ts
+++ b/apps/backend/src/modules/comments/comment.model.ts
@@ -1,7 +1,7 @@
 import type { Document, Types } from "mongoose";
 import mongoose, { Schema } from "mongoose";
 
-export interface IComment extends Document {
+export interface ICommentDocument extends Document {
   text: string;
   recipe: Types.ObjectId;
   author: Types.ObjectId;
@@ -9,7 +9,7 @@ export interface IComment extends Document {
   updatedAt: Date;
 }
 
-const commentSchema = new Schema<IComment>(
+const commentSchema = new Schema<ICommentDocument>(
   {
     text: {
       type: String,
@@ -37,4 +37,7 @@ const commentSchema = new Schema<IComment>(
 
 commentSchema.index({ recipe: 1, createdAt: -1 });
 
-export const Comment = mongoose.model<IComment>("Comment", commentSchema);
+export const CommentModel = mongoose.model<ICommentDocument>(
+  "Comment",
+  commentSchema,
+);

--- a/apps/backend/src/modules/comments/comment.service.ts
+++ b/apps/backend/src/modules/comments/comment.service.ts
@@ -1,21 +1,17 @@
-import type {
-  Comment as CommentType,
-  PaginatedResult,
-  UserSummary,
-} from "@recipes/shared";
+import type { Comment, PaginatedResult, UserSummary } from "@recipes/shared";
 import type { QueryFilter } from "mongoose";
 import { AppError } from "@/common/errors.js";
-import type { IComment } from "@/modules/comments/comment.model.js";
-import { Comment as CommentModel } from "@/modules/comments/comment.model.js";
+import type { ICommentDocument } from "@/modules/comments/comment.model.js";
+import { CommentModel } from "@/modules/comments/comment.model.js";
 import type {
   CommentQuery,
   CreateCommentBody,
   RecipeCommentsParams,
 } from "@/modules/comments/comment.schema.js";
-import { Recipe as RecipeModel } from "@/modules/recipes/recipe.model.js";
-import { User as UserModel } from "../auth/user.model.js";
+import { RecipeModel } from "@/modules/recipes/recipe.model.js";
+import { UserModel } from "../auth/user.model.js";
 
-function toComment(doc: unknown): CommentType {
+function toComment(doc: unknown): Comment {
   const d = doc as Record<string, unknown>;
   const author = d.author as Record<string, unknown>;
   return {
@@ -36,7 +32,7 @@ export class CommentService {
   async findByRecipe(
     params: RecipeCommentsParams,
     query: CommentQuery,
-  ): Promise<PaginatedResult<CommentType>> {
+  ): Promise<PaginatedResult<Comment>> {
     const { page, limit } = query;
     const { recipeId } = params;
 
@@ -45,7 +41,7 @@ export class CommentService {
       throw new AppError("Recipe not found", 404);
     }
 
-    const filter: QueryFilter<IComment> = { recipe: recipeId };
+    const filter: QueryFilter<ICommentDocument> = { recipe: recipeId };
 
     const [items, total] = await Promise.all([
       CommentModel.find(filter)
@@ -75,7 +71,7 @@ export class CommentService {
     recipeId: string,
     authorId: string,
     data: CreateCommentBody,
-  ): Promise<CommentType> {
+  ): Promise<Comment> {
     const recipe = await RecipeModel.findById(recipeId);
     if (!recipe) {
       throw new AppError("Recipe not found", 404);

--- a/apps/backend/src/modules/recipes/recipe.model.ts
+++ b/apps/backend/src/modules/recipes/recipe.model.ts
@@ -8,7 +8,7 @@ export interface IIngredient {
   unit: string;
 }
 
-export interface IRecipe extends Document {
+export interface IRecipeDocument extends Document {
   title: string;
   description: string;
   ingredients: IIngredient[];
@@ -30,7 +30,7 @@ const ingredientSchema = new Schema<IIngredient>(
   { _id: false },
 );
 
-const recipeSchema = new Schema<IRecipe>(
+const recipeSchema = new Schema<IRecipeDocument>(
   {
     title: { type: String, required: true, trim: true, index: "text" },
     description: { type: String, required: true, trim: true },
@@ -72,4 +72,7 @@ const recipeSchema = new Schema<IRecipe>(
 recipeSchema.index({ title: "text", description: "text" });
 recipeSchema.index({ category: 1, createdAt: -1 });
 
-export const Recipe = mongoose.model<IRecipe>("Recipe", recipeSchema);
+export const RecipeModel = mongoose.model<IRecipeDocument>(
+  "Recipe",
+  recipeSchema,
+);

--- a/apps/backend/src/modules/recipes/recipe.service.ts
+++ b/apps/backend/src/modules/recipes/recipe.service.ts
@@ -7,10 +7,10 @@ import type {
 } from "@recipes/shared";
 import type { QueryFilter } from "mongoose";
 import { AppError } from "@/common/errors.js";
-import { User as UserModel } from "@/modules/auth/user.model.js";
-import { Category as CategoryModel } from "@/modules/categories/category.model.js";
-import type { IRecipe } from "@/modules/recipes/recipe.model.js";
-import { Recipe as RecipeModel } from "@/modules/recipes/recipe.model.js";
+import { UserModel } from "@/modules/auth/user.model.js";
+import { CategoryModel } from "@/modules/categories/category.model.js";
+import type { IRecipeDocument } from "@/modules/recipes/recipe.model.js";
+import { RecipeModel } from "@/modules/recipes/recipe.model.js";
 import type {
   CreateRecipeBody,
   SearchRecipeQuery,
@@ -47,7 +47,7 @@ function toRecipe(doc: unknown): Recipe {
 export class RecipeService {
   async findAll(query: SearchRecipeQuery): Promise<PaginatedResult<Recipe>> {
     const { page, limit, sort, category, search } = query;
-    const filter: QueryFilter<IRecipe> = {};
+    const filter: QueryFilter<IRecipeDocument> = {};
 
     if (category) {
       filter.category = category;


### PR DESCRIPTION
## Summary
- Renamed Mongoose models and document interfaces for consistency

## Changes
- Renamed model interfaces and exports for clearer naming conventions

## Testing
- ✅ `pnpm typecheck` — passes
- ✅ `pnpm test` — all tests pass
- ✅ `pnpm check` — no lint errors