### PR TITLE
refactor: add BaseDocument types, remove unused toObject options, clean up model schemas

### DIFF
--- a/apps/backend/src/common/types/mongoose.ts
+++ b/apps/backend/src/common/types/mongoose.ts
@@ -1,0 +1,12 @@
+import type { Types } from "mongoose";
+
+export interface BaseDocument {
+  _id: Types.ObjectId;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface BaseDocumentWithoutUpdate {
+  _id: Types.ObjectId;
+  createdAt: Date;
+}

--- a/apps/backend/src/modules/categories/category.model.ts
+++ b/apps/backend/src/modules/categories/category.model.ts
@@ -1,13 +1,10 @@
-import type { Types } from "mongoose";
 import { model, Schema } from "mongoose";
+import type { BaseDocument } from "@/common/types/mongoose.js";
 
-export interface CategoryDocument {
-  _id: Types.ObjectId;
+export interface CategoryDocument extends BaseDocument {
   name: string;
   slug: string;
   description?: string;
-  createdAt: Date;
-  updatedAt: Date;
 }
 
 const categorySchema = new Schema<CategoryDocument>(
@@ -18,11 +15,10 @@ const categorySchema = new Schema<CategoryDocument>(
   },
   {
     timestamps: true,
-    toObject: { virtuals: true },
   },
 );
 
-categorySchema.pre("validate", async function () {
+categorySchema.pre("validate", function () {
   if (this.isModified("name") && !this.slug) {
     this.slug = this.name
       .toLowerCase()

--- a/apps/backend/src/modules/comments/comment.model.ts
+++ b/apps/backend/src/modules/comments/comment.model.ts
@@ -1,15 +1,13 @@
 import type { Types } from "mongoose";
 import { model, Schema } from "mongoose";
+import type { BaseDocument } from "@/common/types/mongoose.js";
 import { RECIPE_MODEL_NAME } from "@/modules/recipes/index.js";
 import { USER_MODEL_NAME } from "@/modules/users/index.js";
 
-export interface CommentDocument {
-  _id: Types.ObjectId;
+export interface CommentDocument extends BaseDocument {
   text: string;
   recipe: Types.ObjectId;
   author: Types.ObjectId;
-  createdAt: Date;
-  updatedAt: Date;
 }
 
 const commentSchema = new Schema<CommentDocument>(
@@ -34,7 +32,6 @@ const commentSchema = new Schema<CommentDocument>(
   },
   {
     timestamps: true,
-    toObject: { virtuals: true },
   },
 );
 

--- a/apps/backend/src/modules/favorites/favorite.model.ts
+++ b/apps/backend/src/modules/favorites/favorite.model.ts
@@ -1,13 +1,12 @@
 import type { Types } from "mongoose";
 import { model, Schema } from "mongoose";
+import type { BaseDocumentWithoutUpdate } from "@/common/types/mongoose.js";
 import { RECIPE_MODEL_NAME } from "@/modules/recipes/index.js";
 import { USER_MODEL_NAME } from "@/modules/users/index.js";
 
-export interface FavoriteDocument {
-  _id: Types.ObjectId;
+export interface FavoriteDocument extends BaseDocumentWithoutUpdate {
   user: Types.ObjectId;
   recipe: Types.ObjectId;
-  createdAt: Date;
 }
 
 const favoriteSchema = new Schema<FavoriteDocument>(
@@ -21,7 +20,6 @@ const favoriteSchema = new Schema<FavoriteDocument>(
   },
   {
     timestamps: { createdAt: true, updatedAt: false },
-    toObject: { virtuals: true },
   },
 );
 

--- a/apps/backend/src/modules/recipes/recipe.model.ts
+++ b/apps/backend/src/modules/recipes/recipe.model.ts
@@ -1,6 +1,7 @@
 import type { Difficulty, Minutes } from "@recipes/shared";
 import type { Types } from "mongoose";
 import { model, Schema } from "mongoose";
+import type { BaseDocument } from "@/common/types/mongoose.js";
 import { CATEGORY_MODEL_NAME } from "@/modules/categories/index.js";
 import { USER_MODEL_NAME } from "@/modules/users/index.js";
 
@@ -10,8 +11,7 @@ export interface IngredientDocument {
   unit: string;
 }
 
-export interface RecipeDocument {
-  _id: Types.ObjectId;
+export interface RecipeDocument extends BaseDocument {
   title: string;
   description: string;
   ingredients: IngredientDocument[];
@@ -22,8 +22,6 @@ export interface RecipeDocument {
   cookingTime: Minutes;
   servings: number;
   isPublic: boolean;
-  createdAt: Date;
-  updatedAt: Date;
 }
 
 const ingredientSchema = new Schema<IngredientDocument>(
@@ -37,7 +35,7 @@ const ingredientSchema = new Schema<IngredientDocument>(
 
 const recipeSchema = new Schema<RecipeDocument>(
   {
-    title: { type: String, required: true, trim: true, index: "text" },
+    title: { type: String, required: true, trim: true },
     description: { type: String, required: true, trim: true },
     ingredients: {
       type: [ingredientSchema],
@@ -76,7 +74,6 @@ const recipeSchema = new Schema<RecipeDocument>(
   },
   {
     timestamps: true,
-    toObject: { virtuals: true },
   },
 );
 

--- a/apps/backend/src/modules/users/user.model.ts
+++ b/apps/backend/src/modules/users/user.model.ts
@@ -1,14 +1,11 @@
 import bcrypt from "bcryptjs";
-import type { Types } from "mongoose";
 import { model, Schema } from "mongoose";
+import type { BaseDocument } from "@/common/types/mongoose.js";
 
-export interface UserDocument {
-  _id: Types.ObjectId;
+export interface UserDocument extends BaseDocument {
   email: string;
   password: string;
   name: string;
-  createdAt: Date;
-  updatedAt: Date;
   comparePassword(candidate: string): Promise<boolean>;
 }
 
@@ -26,7 +23,6 @@ const userSchema = new Schema<UserDocument>(
   },
   {
     timestamps: true,
-    toObject: { virtuals: true },
   },
 );
 


### PR DESCRIPTION
## What's Changed

### New: `common/types/mongoose.ts`
- `BaseDocument` — shared interface with `_id`, `createdAt`, `updatedAt`
- `BaseDocumentWithoutUpdate` — for models without `updatedAt` (Favorite)

### Model changes
- All 5 models now extend `BaseDocument` or `BaseDocumentWithoutUpdate` instead of declaring `_id`, `createdAt`, `updatedAt` inline
- Removed `toObject: { virtuals: true }` from all schemas (no-op — no virtuals defined, DTO conversion is manual via `mongo.ts` converters)
- Removed redundant `index: "text"` on `title` field in `recipe.model.ts` (compound text index already covers this)
- Removed unnecessary `async` from `categorySchema.pre("validate")` (sync operations only)