### PR TITLE
fix: patch optionalAuth await, category dependency check, comment ID validation

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -103,7 +103,7 @@ export function buildApp() {
     prefix: "/api/recipes",
   });
   app.register(categoryRoutes, {
-    service: createCategoryService(CategoryModel),
+    service: createCategoryService(CategoryModel, RecipeModel),
     prefix: "/api/categories",
   });
 

--- a/apps/backend/src/common/middleware/auth.guard.ts
+++ b/apps/backend/src/common/middleware/auth.guard.ts
@@ -57,5 +57,5 @@ export async function optionalAuth(
     return;
   }
 
-  authGuard(request, reply);
+  return authGuard(request, reply);
 }

--- a/apps/backend/src/modules/categories/category.service.ts
+++ b/apps/backend/src/modules/categories/category.service.ts
@@ -6,6 +6,7 @@ import type {
   CategoryDocument,
   CreateCategoryBody,
 } from "@/modules/categories/index.js";
+import type { RecipeDocument } from "@/modules/recipes/index.js";
 
 export interface CategoryService {
   findAll(): Promise<Category[]>;
@@ -15,6 +16,7 @@ export interface CategoryService {
 
 export function createCategoryService(
   categoryModel: Model<CategoryDocument>,
+  recipeModel: Model<RecipeDocument>,
 ): CategoryService {
   return {
     findAll: async () => {
@@ -26,6 +28,11 @@ export function createCategoryService(
       return toCategory(category.toObject());
     },
     deleteById: async (id) => {
+      const recipeCount = await recipeModel.countDocuments({ category: id });
+      if (recipeCount > 0) {
+        throw new AppError("Cannot delete category with existing recipes", 409);
+      }
+
       const result = await categoryModel.findByIdAndDelete(id);
       if (!result) {
         throw new AppError("Category not found", 404);

--- a/apps/backend/src/modules/comments/comment.service.ts
+++ b/apps/backend/src/modules/comments/comment.service.ts
@@ -128,6 +128,10 @@ export function createCommentService(
     },
 
     delete: async (id, userId) => {
+      if (!mongoose.isValidObjectId(id)) {
+        throw new AppError("Invalid comment ID", 400);
+      }
+
       const comment = await commentModel.findById(id);
       if (!comment) {
         throw new AppError("Comment not found", 404);


### PR DESCRIPTION
## Bugs Fixed

1. **`optionalAuth` without `await`** — `authGuard` was called without `await`, so token errors were ignored and the user was treated as unauthenticated
2. **Deleting a category without checking dependencies** — now returns a 409 error if the category has recipes
3. **`comment.delete` without ID validation** — Added an `isValidObjectId` check to prevent a CastError from being thrown