### PR TITLE
chore: remove unsafe JWT cast, extract bcrypt rounds to env, simplify favoritedIds

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "@types/jsonwebtoken": "^9.0.10",
+    "@types/ms": "^2.1.0",
     "@types/node": "^25.5.0",
     "pino-pretty": "^13.1.3"
   }

--- a/apps/backend/src/common/utils/jwt.ts
+++ b/apps/backend/src/common/utils/jwt.ts
@@ -1,5 +1,6 @@
 import jwt from "jsonwebtoken";
-import { env } from "../../config/env.js";
+import type { StringValue } from "ms";
+import { env } from "@/config/env.js";
 
 export interface JwtPayload {
   userId: string;
@@ -8,8 +9,8 @@ export interface JwtPayload {
 
 export function signToken(payload: JwtPayload): string {
   return jwt.sign(payload, env.JWT_SECRET, {
-    expiresIn: env.JWT_EXPIRES_IN,
-  } as jwt.SignOptions);
+    expiresIn: env.JWT_EXPIRES_IN as StringValue,
+  });
 }
 
 export function verifyToken(token: string): JwtPayload {

--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -9,6 +9,7 @@ const envSchema = z.object({
   MONGO_URI: z.string(),
   JWT_SECRET: z.string(),
   JWT_EXPIRES_IN: z.string().default("7d"),
+  BCRYPT_SALT_ROUNDS: z.coerce.number().default(10),
   RATE_LIMIT_AUTH_MAX: z.coerce.number().default(5),
   RATE_LIMIT_AUTH_WINDOW: z.string().default("3 minutes"),
   RATE_LIMIT_GLOBAL_MAX: z.coerce.number().default(100),

--- a/apps/backend/src/modules/recipes/recipe.service.ts
+++ b/apps/backend/src/modules/recipes/recipe.service.ts
@@ -74,17 +74,19 @@ export function createRecipeService(
       ]);
 
       // Get favorited recipe IDs for current user
-      let favoritedIds = new Set<string>();
-      if (userId && items.length > 0) {
-        const recipeIds = items.map((item) => String(item._id));
-        const favorites = await favoriteModel
-          .find({
-            user: userId,
-            recipe: { $in: recipeIds },
-          })
-          .lean();
-        favoritedIds = new Set(favorites.map((f) => String(f.recipe)));
-      }
+      const favoritedIds =
+        userId && items.length > 0
+          ? new Set(
+              (
+                await favoriteModel
+                  .find({
+                    user: userId,
+                    recipe: { $in: items.map((item) => String(item._id)) },
+                  })
+                  .lean()
+              ).map((f) => String(f.recipe)),
+            )
+          : new Set<string>();
 
       return withPagination(
         items.map((item) => toRecipe(item, favoritedIds.has(String(item._id)))),

--- a/apps/backend/src/modules/users/user.model.ts
+++ b/apps/backend/src/modules/users/user.model.ts
@@ -1,6 +1,7 @@
 import bcrypt from "bcryptjs";
 import { model, Schema } from "mongoose";
 import type { BaseDocument } from "@/common/types/mongoose.js";
+import { env } from "@/config/env.js";
 
 export interface UserDocument extends BaseDocument {
   email: string;
@@ -28,7 +29,7 @@ const userSchema = new Schema<UserDocument>(
 
 userSchema.pre("save", async function () {
   if (!this.isModified("password")) return;
-  this.password = await bcrypt.hash(this.password, 10);
+  this.password = await bcrypt.hash(this.password, env.BCRYPT_SALT_ROUNDS);
 });
 
 userSchema.methods.comparePassword = async function (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,6 +70,9 @@ importers:
       '@types/jsonwebtoken':
         specifier: ^9.0.10
         version: 9.0.10
+      '@types/ms':
+        specifier: ^2.1.0
+        version: 2.1.0
       '@types/node':
         specifier: ^25.5.0
         version: 25.5.0


### PR DESCRIPTION
## Code Cleanup

1. **JWT** — Removed the unnecessary `as jwt.SignOptions` type cast
2. **bcrypt rounds** — Moved the hardcoded `10` to the `BCRYPT_SALT_ROUNDS` environment variable (default 10)
3. **`let favoritedIds`** — Replaced with `const` using a conditional expression