### PR TITLE
refactor: add ModelType interfaces for all models, replace Model<XxxDocument> in services

### DIFF
--- a/apps/backend/src/modules/auth/auth.service.ts
+++ b/apps/backend/src/modules/auth/auth.service.ts
@@ -1,16 +1,15 @@
 import type { AuthResponse, LoginBody, RegisterBody } from "@recipes/shared";
-import type { Model } from "mongoose";
 import { AppError } from "@/common/errors.js";
 import { signToken } from "@/common/utils/jwt.js";
 import { toUser } from "@/common/utils/mongo.js";
-import type { UserDocument } from "@/modules/users/index.js";
+import type { UserModelType } from "@/modules/users/index.js";
 
 export interface AuthService {
   register(data: RegisterBody): Promise<AuthResponse>;
   login(data: LoginBody): Promise<AuthResponse>;
 }
 
-export function createAuthService(userModel: Model<UserDocument>): AuthService {
+export function createAuthService(userModel: UserModelType): AuthService {
   return {
     register: async (data) => {
       const exists = await userModel.exists({ email: data.email });

--- a/apps/backend/src/modules/categories/category.model.ts
+++ b/apps/backend/src/modules/categories/category.model.ts
@@ -1,3 +1,4 @@
+import type { Model } from "mongoose";
 import { model, Schema } from "mongoose";
 import type { BaseDocument } from "@/common/types/mongoose.js";
 
@@ -7,7 +8,9 @@ export interface CategoryDocument extends BaseDocument {
   description?: string;
 }
 
-const categorySchema = new Schema<CategoryDocument>(
+export interface CategoryModelType extends Model<CategoryDocument> {}
+
+const categorySchema = new Schema<CategoryDocument, CategoryModelType>(
   {
     name: { type: String, required: true, unique: true, trim: true },
     slug: { type: String, required: true, unique: true, lowercase: true },
@@ -29,7 +32,7 @@ categorySchema.pre("validate", function () {
 });
 
 export const CATEGORY_MODEL_NAME = "Category";
-export const CategoryModel = model<CategoryDocument>(
+export const CategoryModel = model<CategoryDocument, CategoryModelType>(
   CATEGORY_MODEL_NAME,
   categorySchema,
 );

--- a/apps/backend/src/modules/categories/category.service.ts
+++ b/apps/backend/src/modules/categories/category.service.ts
@@ -1,12 +1,11 @@
 import type { Category } from "@recipes/shared";
-import type { Model } from "mongoose";
 import { AppError } from "@/common/errors.js";
 import { toCategory } from "@/common/utils/mongo.js";
 import type {
-  CategoryDocument,
+  CategoryModelType,
   CreateCategoryBody,
 } from "@/modules/categories/index.js";
-import type { RecipeDocument } from "@/modules/recipes/index.js";
+import type { RecipeModelType } from "@/modules/recipes/index.js";
 
 export interface CategoryService {
   findAll(): Promise<Category[]>;
@@ -15,8 +14,8 @@ export interface CategoryService {
 }
 
 export function createCategoryService(
-  categoryModel: Model<CategoryDocument>,
-  recipeModel: Model<RecipeDocument>,
+  categoryModel: CategoryModelType,
+  recipeModel: RecipeModelType,
 ): CategoryService {
   return {
     findAll: async () => {

--- a/apps/backend/src/modules/comments/comment.model.ts
+++ b/apps/backend/src/modules/comments/comment.model.ts
@@ -1,4 +1,4 @@
-import type { Types } from "mongoose";
+import type { Model, Types } from "mongoose";
 import { model, Schema } from "mongoose";
 import type { BaseDocument } from "@/common/types/mongoose.js";
 import { RECIPE_MODEL_NAME } from "@/modules/recipes/index.js";
@@ -10,7 +10,9 @@ export interface CommentDocument extends BaseDocument {
   author: Types.ObjectId;
 }
 
-const commentSchema = new Schema<CommentDocument>(
+export interface CommentModelType extends Model<CommentDocument> {}
+
+const commentSchema = new Schema<CommentDocument, CommentModelType>(
   {
     text: {
       type: String,
@@ -38,7 +40,7 @@ const commentSchema = new Schema<CommentDocument>(
 commentSchema.index({ recipe: 1, createdAt: -1 });
 
 export const COMMENT_MODEL_NAME = "Comment";
-export const CommentModel = model<CommentDocument>(
+export const CommentModel = model<CommentDocument, CommentModelType>(
   COMMENT_MODEL_NAME,
   commentSchema,
 );

--- a/apps/backend/src/modules/comments/comment.service.ts
+++ b/apps/backend/src/modules/comments/comment.service.ts
@@ -1,17 +1,21 @@
 import type { Comment, CommentForRecipe, Paginated } from "@recipes/shared";
 import { withPagination } from "@recipes/shared";
-import type { Model, QueryFilter } from "mongoose";
+import type { QueryFilter } from "mongoose";
 import mongoose from "mongoose";
 import { AppError } from "@/common/errors.js";
 import { toComment, toCommentForRecipe } from "@/common/utils/mongo.js";
 import type {
   CommentDocument,
+  CommentModelType,
   CommentQuery,
   CreateCommentBody,
   RecipeCommentsParams,
 } from "@/modules/comments/index.js";
-import type { RecipeDocument } from "@/modules/recipes/index.js";
-import type { UserDocument } from "@/modules/users/index.js";
+import type {
+  RecipeDocument,
+  RecipeModelType,
+} from "@/modules/recipes/index.js";
+import type { UserDocument, UserModelType } from "@/modules/users/index.js";
 
 export interface CommentService {
   findByRecipe(
@@ -28,9 +32,9 @@ export interface CommentService {
 }
 
 export function createCommentService(
-  commentModel: Model<CommentDocument>,
-  recipeModel: Model<RecipeDocument>,
-  userModel: Model<UserDocument>,
+  commentModel: CommentModelType,
+  recipeModel: RecipeModelType,
+  userModel: UserModelType,
 ): CommentService {
   return {
     findByRecipe: async (params, query) => {

--- a/apps/backend/src/modules/favorites/favorite.model.ts
+++ b/apps/backend/src/modules/favorites/favorite.model.ts
@@ -1,4 +1,4 @@
-import type { Types } from "mongoose";
+import type { Model, Types } from "mongoose";
 import { model, Schema } from "mongoose";
 import type { BaseDocumentWithoutUpdate } from "@/common/types/mongoose.js";
 import { RECIPE_MODEL_NAME } from "@/modules/recipes/index.js";
@@ -9,7 +9,9 @@ export interface FavoriteDocument extends BaseDocumentWithoutUpdate {
   recipe: Types.ObjectId;
 }
 
-const favoriteSchema = new Schema<FavoriteDocument>(
+export interface FavoriteModelType extends Model<FavoriteDocument> {}
+
+const favoriteSchema = new Schema<FavoriteDocument, FavoriteModelType>(
   {
     user: { type: Schema.Types.ObjectId, ref: USER_MODEL_NAME, required: true },
     recipe: {
@@ -27,7 +29,7 @@ favoriteSchema.index({ user: 1, recipe: 1 }, { unique: true });
 favoriteSchema.index({ user: 1, createdAt: -1 });
 
 export const FAVORITE_MODEL_NAME = "Favorite";
-export const FavoriteModel = model<FavoriteDocument>(
+export const FavoriteModel = model<FavoriteDocument, FavoriteModelType>(
   FAVORITE_MODEL_NAME,
   favoriteSchema,
 );

--- a/apps/backend/src/modules/favorites/favorite.service.ts
+++ b/apps/backend/src/modules/favorites/favorite.service.ts
@@ -1,16 +1,18 @@
 import type { Paginated, Recipe, Replace } from "@recipes/shared";
 import { withPagination } from "@recipes/shared";
-import type { Model } from "mongoose";
 import mongoose from "mongoose";
 import { AppError } from "@/common/errors.js";
 import { toRecipe } from "@/common/utils/mongo.js";
 import type { CategoryDocument } from "@/modules/categories/index.js";
 import type {
-  FavoriteDocument,
+  FavoriteModelType,
   FavoriteQuery,
 } from "@/modules/favorites/index.js";
-import type { RecipeDocument } from "@/modules/recipes/index.js";
-import type { UserDocument } from "@/modules/users/index.js";
+import type {
+  RecipeDocument,
+  RecipeModelType,
+} from "@/modules/recipes/index.js";
+import type { UserDocument, UserModelType } from "@/modules/users/index.js";
 
 export interface FavoriteService {
   add(userId: string, recipeId: string): Promise<{ favorited: true }>;
@@ -20,9 +22,9 @@ export interface FavoriteService {
 }
 
 export function createFavoriteService(
-  favoriteModel: Model<FavoriteDocument>,
-  recipeModel: Model<RecipeDocument>,
-  userModel: Model<UserDocument>,
+  favoriteModel: FavoriteModelType,
+  recipeModel: RecipeModelType,
+  userModel: UserModelType,
 ): FavoriteService {
   async function validateUser(userId: string): Promise<void> {
     if (!mongoose.isValidObjectId(userId)) {

--- a/apps/backend/src/modules/recipes/recipe.model.ts
+++ b/apps/backend/src/modules/recipes/recipe.model.ts
@@ -1,5 +1,5 @@
 import type { Difficulty, Minutes } from "@recipes/shared";
-import type { Types } from "mongoose";
+import type { Model, Types } from "mongoose";
 import { model, Schema } from "mongoose";
 import type { BaseDocument } from "@/common/types/mongoose.js";
 import { CATEGORY_MODEL_NAME } from "@/modules/categories/index.js";
@@ -24,6 +24,8 @@ export interface RecipeDocument extends BaseDocument {
   isPublic: boolean;
 }
 
+export interface RecipeModelType extends Model<RecipeDocument> {}
+
 const ingredientSchema = new Schema<IngredientDocument>(
   {
     name: { type: String, required: true, trim: true },
@@ -33,7 +35,7 @@ const ingredientSchema = new Schema<IngredientDocument>(
   { _id: false },
 );
 
-const recipeSchema = new Schema<RecipeDocument>(
+const recipeSchema = new Schema<RecipeDocument, RecipeModelType>(
   {
     title: { type: String, required: true, trim: true },
     description: { type: String, required: true, trim: true },
@@ -81,7 +83,7 @@ recipeSchema.index({ title: "text", description: "text" });
 recipeSchema.index({ category: 1, createdAt: -1 });
 
 export const RECIPE_MODEL_NAME = "Recipe";
-export const RecipeModel = model<RecipeDocument>(
+export const RecipeModel = model<RecipeDocument, RecipeModelType>(
   RECIPE_MODEL_NAME,
   recipeSchema,
 );

--- a/apps/backend/src/modules/recipes/recipe.service.ts
+++ b/apps/backend/src/modules/recipes/recipe.service.ts
@@ -1,14 +1,16 @@
 import type { Paginated, Recipe } from "@recipes/shared";
 import { withPagination } from "@recipes/shared";
-import type { Model } from "mongoose";
-import mongoose from "mongoose";
+import { isValidObjectId } from "mongoose";
 import { AppError } from "@/common/errors.js";
 import { toRecipe } from "@/common/utils/mongo.js";
-import type { CategoryDocument } from "@/modules/categories/index.js";
-import type { FavoriteDocument } from "@/modules/favorites/index.js";
+import type {
+  CategoryDocument,
+  CategoryModelType,
+} from "@/modules/categories/index.js";
+import type { FavoriteModelType } from "@/modules/favorites/index.js";
 import type {
   CreateRecipeBody,
-  RecipeDocument,
+  RecipeModelType,
   SearchRecipeQuery,
   UpdateRecipeBody,
 } from "@/modules/recipes/index.js";
@@ -16,7 +18,7 @@ import {
   buildRecipeFilter,
   withVisibilityFilter,
 } from "@/modules/recipes/index.js";
-import type { UserDocument } from "@/modules/users/index.js";
+import type { UserDocument, UserModelType } from "@/modules/users/index.js";
 
 export interface RecipeService {
   findAll(
@@ -30,10 +32,10 @@ export interface RecipeService {
 }
 
 export function createRecipeService(
-  recipeModel: Model<RecipeDocument>,
-  userModel: Model<UserDocument>,
-  favoriteModel: Model<FavoriteDocument>,
-  categoryModel: Model<CategoryDocument>,
+  recipeModel: RecipeModelType,
+  userModel: UserModelType,
+  favoriteModel: FavoriteModelType,
+  categoryModel: CategoryModelType,
 ): RecipeService {
   return {
     findAll: async (query, userId) => {
@@ -97,7 +99,7 @@ export function createRecipeService(
     },
 
     findById: async (id, userId) => {
-      if (!mongoose.isValidObjectId(id)) {
+      if (!isValidObjectId(id)) {
         throw new AppError("Invalid recipe ID", 400);
       }
 
@@ -134,10 +136,10 @@ export function createRecipeService(
     },
 
     create: async (data, authorId) => {
-      if (!mongoose.isValidObjectId(authorId)) {
+      if (!isValidObjectId(authorId)) {
         throw new AppError("Invalid author ID", 400);
       }
-      if (!mongoose.isValidObjectId(data.category)) {
+      if (!isValidObjectId(data.category)) {
         throw new AppError("Invalid category ID", 400);
       }
 
@@ -163,7 +165,7 @@ export function createRecipeService(
     },
 
     update: async (id, data, userId) => {
-      if (!mongoose.isValidObjectId(id)) {
+      if (!isValidObjectId(id)) {
         throw new AppError("Invalid recipe ID", 400);
       }
       const recipe = await recipeModel.findById(id);
@@ -200,7 +202,7 @@ export function createRecipeService(
     },
 
     delete: async (id, userId) => {
-      if (!mongoose.isValidObjectId(id)) {
+      if (!isValidObjectId(id)) {
         throw new AppError("Invalid recipe ID", 400);
       }
       const recipe = await recipeModel.findById(id);

--- a/apps/backend/src/modules/users/user.model.ts
+++ b/apps/backend/src/modules/users/user.model.ts
@@ -1,4 +1,5 @@
 import bcrypt from "bcryptjs";
+import type { Model } from "mongoose";
 import { model, Schema } from "mongoose";
 import type { BaseDocument } from "@/common/types/mongoose.js";
 import { env } from "@/config/env.js";
@@ -10,7 +11,9 @@ export interface UserDocument extends BaseDocument {
   comparePassword(candidate: string): Promise<boolean>;
 }
 
-const userSchema = new Schema<UserDocument>(
+export interface UserModelType extends Model<UserDocument> {}
+
+const userSchema = new Schema<UserDocument, UserModelType>(
   {
     email: {
       type: String,
@@ -39,4 +42,7 @@ userSchema.methods.comparePassword = async function (
 };
 
 export const USER_MODEL_NAME = "User";
-export const UserModel = model<UserDocument>(USER_MODEL_NAME, userSchema);
+export const UserModel = model<UserDocument, UserModelType>(
+  USER_MODEL_NAME,
+  userSchema,
+);

--- a/apps/backend/src/modules/users/user.service.ts
+++ b/apps/backend/src/modules/users/user.service.ts
@@ -1,11 +1,10 @@
 import type { Comment, Paginated, Recipe, User } from "@recipes/shared";
-import type { Model } from "mongoose";
 import { AppError } from "@/common/errors.js";
 import { toUser } from "@/common/utils/mongo.js";
 import type { CommentQuery, CommentService } from "@/modules/comments/index.js";
 import type { FavoriteQuery } from "@/modules/favorites/favorite.schema.js";
 import type { FavoriteService } from "@/modules/favorites/favorite.service.js";
-import type { UserDocument } from "@/modules/users/index.js";
+import type { UserModelType } from "@/modules/users/index.js";
 
 export interface UserService {
   getCurrentUser(userId: string): Promise<User>;
@@ -19,7 +18,7 @@ export interface UserService {
 export function createUserService(
   commentService: CommentService,
   favoriteService: FavoriteService,
-  userModel: Model<UserDocument>,
+  userModel: UserModelType,
 ): UserService {
   return {
     getCurrentUser: async (userId) => {


### PR DESCRIPTION
## What's Changed

- Added `XxxModelType extends Model<XxxDocument>` interface to all 5 models (User, Recipe, Category, Comment, Favorite)
- Updated all service factory functions to accept `XxxModelType` instead of `Model<XxxDocument>`
- Updated `model<T>()` calls to `model<T, XxxModelType>()` for static method support
- This prepares models for adding static methods in future PRs