### PR TITLE
refactor: move comment retrieval to aggregation pipeline with visibility filter

### DIFF
--- a/apps/backend/src/common/utils/mongo.ts
+++ b/apps/backend/src/common/utils/mongo.ts
@@ -88,11 +88,14 @@ export function toComment<T extends CommentDocument>(
 }
 
 export function toCommentForRecipe<T extends CommentDocument>(
-  doc: Replace<
-    T,
-    {
-      author: Pick<UserDocument, "_id" | "name" | "email">;
-    }
+  doc: Omit<
+    Replace<
+      T,
+      {
+        author: Pick<UserDocument, "_id" | "name" | "email">;
+      }
+    >,
+    "recipe"
   >,
 ): CommentForRecipe {
   return {

--- a/apps/backend/src/modules/comments/comment.aggregation.ts
+++ b/apps/backend/src/modules/comments/comment.aggregation.ts
@@ -1,7 +1,9 @@
 import type { PipelineStage } from "mongoose";
 import { byVisibility } from "@/modules/recipes/index.js";
 
-export function withRecipe(userId: string): PipelineStage.FacetPipelineStage[] {
+export function withRecipe(
+  userId: string | undefined,
+): PipelineStage.FacetPipelineStage[] {
   return [
     {
       $lookup: {
@@ -14,7 +16,6 @@ export function withRecipe(userId: string): PipelineStage.FacetPipelineStage[] {
               ...byVisibility(userId),
             },
           },
-          { $unset: "__v" },
           {
             $project: {
               _id: 1,

--- a/apps/backend/src/modules/comments/comment.model.ts
+++ b/apps/backend/src/modules/comments/comment.model.ts
@@ -35,6 +35,10 @@ export interface CommentModelType extends Model<CommentDocument> {
     userId: string,
     query: CommentQuery,
   ): Promise<[CommentDocumentPopulated[], number] | [null, 0]>;
+  findByRecipe(
+    params: { recipeId: string; userId?: string },
+    query: CommentQuery,
+  ): Promise<[CommentDocumentPopulated[], number] | [null, 0]>;
 }
 
 const commentSchema = new Schema<CommentDocument, CommentModelType>(
@@ -77,6 +81,33 @@ commentSchema.statics.findByUser = async function (
     { $unset: "__v" },
     ...withAuthor(),
     ...withRecipe(userId),
+    ...withTotalCount(
+      ...withSort("-createdAt"),
+      ...withPagination(query.page, query.limit),
+    ),
+  ]);
+  if (!comments.length || !comments[0]?.items.length) {
+    return [[], comments[0]?.total ?? 0];
+  }
+
+  return [comments[0].items, comments[0].total];
+};
+
+commentSchema.statics.findByRecipe = async function (
+  params: { recipeId: string; userId?: string },
+  query: CommentQuery,
+) {
+  const comments = await this.aggregate<
+    WithTotalCountResult<CommentDocumentPopulated>
+  >([
+    {
+      $match: {
+        recipe: Types.ObjectId.createFromHexString(params.recipeId),
+      },
+    },
+    { $unset: "__v" },
+    ...withAuthor(),
+    ...withRecipe(params.userId),
     ...withTotalCount(
       ...withSort("-createdAt"),
       ...withPagination(query.page, query.limit),

--- a/apps/backend/src/modules/comments/comment.service.ts
+++ b/apps/backend/src/modules/comments/comment.service.ts
@@ -1,25 +1,19 @@
 import type { Comment, CommentForRecipe, Paginated } from "@recipes/shared";
 import { withPagination } from "@recipes/shared";
-import type { QueryFilter } from "mongoose";
 import mongoose from "mongoose";
 import { AppError } from "@/common/errors.js";
 import { toComment, toCommentForRecipe } from "@/common/utils/mongo.js";
 import type {
-  CommentDocument,
   CommentModelType,
   CommentQuery,
   CreateCommentBody,
-  RecipeCommentsParams,
 } from "@/modules/comments/index.js";
-import type {
-  RecipeDocument,
-  RecipeModelType,
-} from "@/modules/recipes/index.js";
+import type { RecipeModelType } from "@/modules/recipes/index.js";
 import type { UserDocument, UserModelType } from "@/modules/users/index.js";
 
 export interface CommentService {
   findByRecipe(
-    params: RecipeCommentsParams,
+    params: { recipeId: string; userId?: string },
     query: CommentQuery,
   ): Promise<Paginated<CommentForRecipe>>;
   create(
@@ -39,34 +33,21 @@ export function createCommentService(
   return {
     findByRecipe: async (params, query) => {
       const { page, limit } = query;
-      const { recipeId } = params;
-
       if (!mongoose.isValidObjectId(params.recipeId)) {
         throw new AppError("Invalid recipe ID", 400);
       }
-      const recipeExists = await recipeModel.exists({ _id: recipeId });
+      const recipeExists = await recipeModel.exists({ _id: params.recipeId });
       if (!recipeExists) {
         throw new AppError("Recipe not found", 404);
       }
 
-      const filter: QueryFilter<CommentDocument> = { recipe: recipeId };
-
-      const [items, total] = await Promise.all([
-        commentModel
-          .find(filter)
-          .populate<{ author: Pick<UserDocument, "_id" | "name" | "email"> }>(
-            "author",
-            "name email",
-          )
-          .sort("-createdAt")
-          .skip((page - 1) * limit)
-          .limit(limit)
-          .lean(),
-        commentModel.countDocuments(filter),
-      ]);
+      const [comments, total] = await commentModel.findByRecipe(params, query);
+      if (!comments) {
+        return withPagination([], 0, page, limit);
+      }
 
       return withPagination(
-        items.map((item) => toCommentForRecipe(item)),
+        comments.map((item) => toCommentForRecipe(item)),
         total,
         page,
         limit,
@@ -109,12 +90,12 @@ export function createCommentService(
 
       const { page, limit } = query;
 
-      const [items, total] = await commentModel.findByUser(userId, query);
-      if (!items) {
+      const [comments, total] = await commentModel.findByUser(userId, query);
+      if (!comments) {
         return withPagination([], 0, page, limit);
       }
 
-      return withPagination(items.map(toComment), total, page, limit);
+      return withPagination(comments.map(toComment), total, page, limit);
     },
 
     delete: async (id, userId) => {

--- a/apps/backend/src/modules/recipes/recipe.routes.ts
+++ b/apps/backend/src/modules/recipes/recipe.routes.ts
@@ -196,10 +196,11 @@ export const recipeRoutes: FastifyPluginAsync<RecipeModuleOptions> = async (
           tags: ["Recipes"],
           summary: "Get comments for a recipe",
         },
+        onRequest: optionalAuth,
       },
       async (request, reply) => {
         const result = await commentService.findByRecipe(
-          { recipeId: request.params.id },
+          { recipeId: request.params.id, userId: request.user?.userId },
           request.query,
         );
         return reply.send(result);


### PR DESCRIPTION
## What's Changed

### Comment Aggregation
- Replaced `findByUser` and `findByRecipe` in `comment.service.ts` with static methods on `CommentModel`
- Reuses `withAuthor()` from recipes module for author population

### Visibility Filter
- `findByUser(userId)` — when viewing another user's comments, comments on their private recipes (that the viewer doesn't own) are hidden
- `findByRecipe(recipeId, userId?)` — comments on private recipes are only visible to the recipe author

### Service Simplification
- `comment.service.ts` — delegates to `CommentModel.findByUser` / `CommentModel.findByRecipe`, removed manual populate chains