### PR TITLE
feat: role-based authorization and admin user management

### DIFF
--- a/apps/backend/src/common/bootstrap/admin.ts
+++ b/apps/backend/src/common/bootstrap/admin.ts
@@ -1,0 +1,18 @@
+import { env } from "@/config/env.js";
+import { UserModel } from "@/modules/users/user.model.js";
+
+export async function ensureRootAdmin(): Promise<void> {
+  const existing = await UserModel.findOne({ role: "admin" });
+  if (existing) {
+    return;
+  }
+
+  await UserModel.create({
+    email: env.ROOT_ADMIN_EMAIL,
+    password: env.ROOT_ADMIN_PASSWORD,
+    name: "Root Admin",
+    role: "admin",
+  });
+
+  console.log(`✓ Root admin created: ${env.ROOT_ADMIN_EMAIL}`);
+}

--- a/apps/backend/src/common/middleware/role.guard.ts
+++ b/apps/backend/src/common/middleware/role.guard.ts
@@ -1,0 +1,13 @@
+import type { FastifyRequest } from "fastify";
+import { ForbiddenError } from "@/common/errors.js";
+import { assertAuthenticated } from "./auth.guard.js";
+
+export function rolesGuard(...roles: string[]) {
+  return async (request: FastifyRequest) => {
+    assertAuthenticated(request);
+
+    if (!roles.includes(request.user.role)) {
+      throw new ForbiddenError("Insufficient permissions");
+    }
+  };
+}

--- a/apps/backend/src/common/types/methods.ts
+++ b/apps/backend/src/common/types/methods.ts
@@ -1,8 +1,11 @@
 import type { Prettify } from "@recipes/shared";
 
 export type DefaultQuery = { page: number; limit: number };
-export type DefaultInitiator = { readonly id: string /* role:TODO */ };
-export type OptionalInitiator = { readonly id?: string };
+export type DefaultInitiator = { readonly id: string; readonly role: string };
+export type OptionalInitiator = {
+  readonly id?: string;
+  readonly role?: string;
+};
 
 export type InitiatedMethodParams<TInitiator = DefaultInitiator> = Prettify<
   Readonly<{

--- a/apps/backend/src/common/types/methods.ts
+++ b/apps/backend/src/common/types/methods.ts
@@ -1,10 +1,11 @@
 import type { Prettify } from "@recipes/shared";
+import type { UserRole } from "@/modules/users/user.model.js";
 
 export type DefaultQuery = { page: number; limit: number };
-export type DefaultInitiator = { readonly id: string; readonly role: string };
+export type DefaultInitiator = { readonly id: string; readonly role: UserRole };
 export type OptionalInitiator = {
   readonly id?: string;
-  readonly role?: string;
+  readonly role?: UserRole;
 };
 
 export type InitiatedMethodParams<TInitiator = DefaultInitiator> = Prettify<

--- a/apps/backend/src/common/utils/jwt.ts
+++ b/apps/backend/src/common/utils/jwt.ts
@@ -1,11 +1,12 @@
 import jwt from "jsonwebtoken";
 import type { StringValue } from "ms";
 import { env } from "@/config/env.js";
+import type { UserRole } from "@/modules/users/user.model.js";
 
 export interface JwtPayload {
   userId: string;
   email: string;
-  role: string;
+  role: UserRole;
 }
 
 export function signToken(payload: JwtPayload): string {

--- a/apps/backend/src/common/utils/jwt.ts
+++ b/apps/backend/src/common/utils/jwt.ts
@@ -5,6 +5,7 @@ import { env } from "@/config/env.js";
 export interface JwtPayload {
   userId: string;
   email: string;
+  role: string;
 }
 
 export function signToken(payload: JwtPayload): string {

--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -14,6 +14,14 @@ const envSchema = z.object({
   RATE_LIMIT_AUTH_WINDOW: z.string().default("3 minutes"),
   RATE_LIMIT_GLOBAL_MAX: z.coerce.number().default(100),
   RATE_LIMIT_GLOBAL_WINDOW: z.string().default("1 minute"),
+  ROOT_ADMIN_EMAIL: z.string().min(6),
+  ROOT_ADMIN_PASSWORD: z
+    .string()
+    .min(10)
+    .regex(/[A-Z]/, "Must contain at least one uppercase letter")
+    .regex(/[a-z]/, "Must contain at least one lowercase letter")
+    .regex(/[0-9]/, "Must contain at least one number")
+    .regex(/[^A-Za-z0-9]/, "Must contain at least one special character"),
 });
 
 const parsed = envSchema.safeParse(process.env);

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -1,9 +1,11 @@
 import { buildApp } from "./app.js";
+import { ensureRootAdmin } from "./common/bootstrap/admin.js";
 import { connectDatabase } from "./config/database.js";
 import { env } from "./config/env.js";
 
 async function start() {
   await connectDatabase();
+  await ensureRootAdmin();
 
   const app = buildApp();
 

--- a/apps/backend/src/modules/auth/auth.service.ts
+++ b/apps/backend/src/modules/auth/auth.service.ts
@@ -18,7 +18,11 @@ export function createAuthService(userModel: UserModelType): AuthService {
       }
 
       const user = await userModel.create(data);
-      const token = signToken({ userId: user.id, email: user.email });
+      const token = signToken({
+        userId: user.id,
+        email: user.email,
+        role: user.role,
+      });
 
       return {
         user: toUser(user.toObject()),
@@ -33,7 +37,11 @@ export function createAuthService(userModel: UserModelType): AuthService {
         throw new UnauthorizedError("Invalid email or password");
       }
 
-      const token = signToken({ userId: user.id, email: user.email });
+      const token = signToken({
+        userId: user.id,
+        email: user.email,
+        role: user.role,
+      });
 
       return {
         user: toUser(user.toObject()),

--- a/apps/backend/src/modules/categories/category.routes.ts
+++ b/apps/backend/src/modules/categories/category.routes.ts
@@ -4,6 +4,7 @@ import {
   assertAuthenticated,
   authGuard,
 } from "@/common/middleware/auth.guard.js";
+import { rolesGuard } from "@/common/middleware/role.guard.js";
 import {
   categoryParamsSchema,
   createCategorySchema,
@@ -42,7 +43,7 @@ export const categoryRoutes: FastifyPluginAsync<CategoryModuleOptions> = async (
           summary: "Create a category",
           security: [{ bearerAuth: [] }],
         },
-        onRequest: authGuard,
+        onRequest: [authGuard, rolesGuard("admin")],
       },
       async (request, reply) => {
         assertAuthenticated(request);
@@ -63,7 +64,7 @@ export const categoryRoutes: FastifyPluginAsync<CategoryModuleOptions> = async (
           summary: "Delete a category",
           security: [{ bearerAuth: [] }],
         },
-        onRequest: authGuard,
+        onRequest: [authGuard, rolesGuard("admin")],
       },
       async (request, reply) => {
         assertAuthenticated(request);

--- a/apps/backend/src/modules/categories/category.routes.ts
+++ b/apps/backend/src/modules/categories/category.routes.ts
@@ -49,7 +49,7 @@ export const categoryRoutes: FastifyPluginAsync<CategoryModuleOptions> = async (
 
         const category = await service.create({
           data: request.body,
-          initiator: { id: request.user.userId },
+          initiator: { id: request.user.userId, role: request.user.role },
         });
         return reply.status(201).send(category);
       },
@@ -69,7 +69,7 @@ export const categoryRoutes: FastifyPluginAsync<CategoryModuleOptions> = async (
         assertAuthenticated(request);
 
         await service.deleteById(request.params.id, {
-          initiator: { id: request.user.userId },
+          initiator: { id: request.user.userId, role: request.user.role },
         });
         return reply.status(204).send();
       },

--- a/apps/backend/src/modules/comments/comment.service.ts
+++ b/apps/backend/src/modules/comments/comment.service.ts
@@ -123,7 +123,7 @@ export function createCommentService(
         throw new NotFoundError("Comment not found");
       }
 
-      if (!comment.author.equals(initiator.id)) {
+      if (!comment.author.equals(initiator.id) && initiator.role !== "admin") {
         throw new ForbiddenError("Not authorized to delete this comment");
       }
 

--- a/apps/backend/src/modules/comments/comment.service.ts
+++ b/apps/backend/src/modules/comments/comment.service.ts
@@ -1,6 +1,6 @@
 import type { Comment, CommentForRecipe, Paginated } from "@recipes/shared";
 import { withPagination } from "@recipes/shared";
-import mongoose from "mongoose";
+import { isValidObjectId } from "mongoose";
 import {
   BadRequestError,
   ForbiddenError,
@@ -42,7 +42,7 @@ export function createCommentService(
 ): CommentService {
   return {
     findByRecipe: async (recipeId, { query, initiator }) => {
-      if (!mongoose.isValidObjectId(recipeId)) {
+      if (!isValidObjectId(recipeId)) {
         throw new BadRequestError("Invalid recipe ID");
       }
       const recipeExists = await recipeModel.exists({ _id: recipeId });
@@ -68,7 +68,7 @@ export function createCommentService(
     },
 
     findByAuthor: async (authorId, { query, initiator }) => {
-      if (!mongoose.isValidObjectId(authorId)) {
+      if (!isValidObjectId(authorId)) {
         throw new BadRequestError("Invalid author ID");
       }
       const { page, limit } = query;
@@ -85,10 +85,10 @@ export function createCommentService(
     },
 
     create: async (recipeId, { data, initiator }) => {
-      if (!mongoose.isValidObjectId(recipeId)) {
+      if (!isValidObjectId(recipeId)) {
         throw new BadRequestError("Invalid recipe ID");
       }
-      if (!mongoose.isValidObjectId(initiator.id)) {
+      if (!isValidObjectId(initiator.id)) {
         throw new BadRequestError("Invalid author ID");
       }
 
@@ -114,7 +114,7 @@ export function createCommentService(
     },
 
     delete: async (commentId, { initiator }) => {
-      if (!mongoose.isValidObjectId(commentId)) {
+      if (!isValidObjectId(commentId)) {
         throw new BadRequestError("Invalid comment ID");
       }
 

--- a/apps/backend/src/modules/favorites/favorite.model.ts
+++ b/apps/backend/src/modules/favorites/favorite.model.ts
@@ -1,8 +1,9 @@
 import type { Replace } from "@recipes/shared";
-import type { Model } from "mongoose";
-import { model, Schema, Types } from "mongoose";
+import type { Model, Types } from "mongoose";
+import { model, Schema } from "mongoose";
 import type { QueryMethodParams } from "@/common/types/methods.js";
 import type { BaseDocumentWithoutUpdate } from "@/common/types/mongoose.js";
+import { toObjectId } from "@/common/utils/mongo.js";
 import type { WithTotalCountResult } from "@/common/utils/mongoose.aggregation.js";
 import {
   withPagination,
@@ -57,7 +58,7 @@ favoriteSchema.statics.findByUser = async function (
   >([
     {
       $match: {
-        user: Types.ObjectId.createFromHexString(userId),
+        user: toObjectId(userId),
       },
     },
     { $unset: ["__v", "user"] },

--- a/apps/backend/src/modules/recipes/recipe.aggregation.ts
+++ b/apps/backend/src/modules/recipes/recipe.aggregation.ts
@@ -1,6 +1,6 @@
 import type { PipelineStage } from "mongoose";
-import { Types } from "mongoose";
 import type { OptionalInitiator } from "@/common/types/methods.js";
+import { toObjectId } from "@/common/utils/mongo.js";
 
 export function byVisibility({ id, role }: OptionalInitiator) {
   if (role === "admin") {
@@ -9,10 +9,7 @@ export function byVisibility({ id, role }: OptionalInitiator) {
 
   if (id) {
     return {
-      $or: [
-        { isPublic: true },
-        { author: Types.ObjectId.createFromHexString(id) },
-      ],
+      $or: [{ isPublic: true }, { author: toObjectId(id) }],
     };
   }
 
@@ -75,7 +72,7 @@ export function withFavorited(userId?: string) {
       },
     ] satisfies PipelineStage[];
   }
-  const userOid = Types.ObjectId.createFromHexString(userId);
+  const userOid = toObjectId(userId);
 
   return [
     {

--- a/apps/backend/src/modules/recipes/recipe.aggregation.ts
+++ b/apps/backend/src/modules/recipes/recipe.aggregation.ts
@@ -2,7 +2,11 @@ import type { PipelineStage } from "mongoose";
 import { Types } from "mongoose";
 import type { OptionalInitiator } from "@/common/types/methods.js";
 
-export function byVisibility({ id }: OptionalInitiator) {
+export function byVisibility({ id, role }: OptionalInitiator) {
+  if (role === "admin") {
+    return {};
+  }
+
   if (id) {
     return {
       $or: [

--- a/apps/backend/src/modules/recipes/recipe.model.ts
+++ b/apps/backend/src/modules/recipes/recipe.model.ts
@@ -1,12 +1,13 @@
 import type { Difficulty, Minutes, Replace } from "@recipes/shared";
-import type { Model } from "mongoose";
-import { model, Schema, Types } from "mongoose";
+import type { Model, Types } from "mongoose";
+import { model, Schema } from "mongoose";
 import type {
   InitiatedMethodParams,
   OptionalInitiator,
   QueryMethodParams,
 } from "@/common/types/methods.js";
 import type { BaseDocument } from "@/common/types/mongoose.js";
+import { toObjectId } from "@/common/utils/mongo.js";
 import type { WithTotalCountResult } from "@/common/utils/mongoose.aggregation.js";
 import {
   withPagination,
@@ -167,7 +168,7 @@ recipeSchema.statics.findByIdFull = async function (
   const recipes = await this.aggregate<RecipeDocumentPopulated>([
     {
       $match: {
-        _id: Types.ObjectId.createFromHexString(id),
+        _id: toObjectId(id),
         ...byVisibility(initiator),
       },
     },

--- a/apps/backend/src/modules/recipes/recipe.routes.ts
+++ b/apps/backend/src/modules/recipes/recipe.routes.ts
@@ -45,7 +45,7 @@ export const recipeRoutes: FastifyPluginAsync<RecipeModuleOptions> = async (
       async (request, reply) => {
         const result = await service.findAll({
           query: request.query,
-          initiator: { id: request.user?.userId },
+          initiator: { id: request.user?.userId, role: request.user?.role },
         });
         return reply.send(result);
       },
@@ -62,7 +62,7 @@ export const recipeRoutes: FastifyPluginAsync<RecipeModuleOptions> = async (
       },
       async (request, reply) => {
         const recipe = await service.findById(request.params.id, {
-          initiator: { id: request.user?.userId },
+          initiator: { id: request.user?.userId, role: request.user?.role },
         });
         return reply.send(recipe);
       },
@@ -83,7 +83,7 @@ export const recipeRoutes: FastifyPluginAsync<RecipeModuleOptions> = async (
 
         const recipe = await service.create({
           data: request.body,
-          initiator: { id: request.user.userId },
+          initiator: { id: request.user.userId, role: request.user.role },
         });
         return reply.status(201).send(recipe);
       },
@@ -105,7 +105,7 @@ export const recipeRoutes: FastifyPluginAsync<RecipeModuleOptions> = async (
 
         const recipe = await service.update(request.params.id, {
           data: request.body,
-          initiator: { id: request.user.userId },
+          initiator: { id: request.user.userId, role: request.user.role },
         });
         return reply.send(recipe);
       },
@@ -125,7 +125,7 @@ export const recipeRoutes: FastifyPluginAsync<RecipeModuleOptions> = async (
         assertAuthenticated(request);
 
         await service.delete(request.params.id, {
-          initiator: { id: request.user.userId },
+          initiator: { id: request.user.userId, role: request.user.role },
         });
         return reply.status(204).send();
       },
@@ -145,7 +145,7 @@ export const recipeRoutes: FastifyPluginAsync<RecipeModuleOptions> = async (
         assertAuthenticated(request);
 
         const result = await favoriteService.add(request.params.id, {
-          initiator: { id: request.user.userId },
+          initiator: { id: request.user.userId, role: request.user.role },
         });
         return reply.send(result);
       },
@@ -165,7 +165,7 @@ export const recipeRoutes: FastifyPluginAsync<RecipeModuleOptions> = async (
         assertAuthenticated(request);
 
         const result = await favoriteService.remove(request.params.id, {
-          initiator: { id: request.user.userId },
+          initiator: { id: request.user.userId, role: request.user.role },
         });
         return reply.send(result);
       },
@@ -178,16 +178,13 @@ export const recipeRoutes: FastifyPluginAsync<RecipeModuleOptions> = async (
           tags: ["Recipes"],
           summary: "Check if recipe is favorited",
         },
-        onRequest: optionalAuth,
+        onRequest: authGuard,
       },
       async (request, reply) => {
-        const userId = request.user?.userId;
-        if (!userId) {
-          return reply.send({ favorited: false });
-        }
+        assertAuthenticated(request);
 
         const favorited = await favoriteService.isFavorited(request.params.id, {
-          initiator: { id: userId },
+          initiator: { id: request.user.userId, role: request.user.role },
         });
         return reply.send({ favorited });
       },
@@ -206,7 +203,7 @@ export const recipeRoutes: FastifyPluginAsync<RecipeModuleOptions> = async (
       async (request, reply) => {
         const result = await commentService.findByRecipe(request.params.id, {
           query: request.query,
-          initiator: { id: request.user?.userId },
+          initiator: { id: request.user?.userId, role: request.user?.role },
         });
         return reply.send(result);
       },
@@ -228,7 +225,7 @@ export const recipeRoutes: FastifyPluginAsync<RecipeModuleOptions> = async (
 
         const comment = await commentService.create(request.params.id, {
           data: request.body,
-          initiator: { id: request.user.userId },
+          initiator: { id: request.user.userId, role: request.user.role },
         });
         return reply.status(201).send(comment);
       },
@@ -248,7 +245,7 @@ export const recipeRoutes: FastifyPluginAsync<RecipeModuleOptions> = async (
         assertAuthenticated(request);
 
         await commentService.delete(request.params.id, {
-          initiator: { id: request.user.userId },
+          initiator: { id: request.user.userId, role: request.user.role },
         });
         return reply.status(204).send();
       },

--- a/apps/backend/src/modules/recipes/recipe.service.ts
+++ b/apps/backend/src/modules/recipes/recipe.service.ts
@@ -128,7 +128,7 @@ export function createRecipeService(
         throw new NotFoundError("Recipe not found");
       }
 
-      if (!recipe.author.equals(initiator.id)) {
+      if (!recipe.author.equals(initiator.id) && initiator.role !== "admin") {
         throw new ForbiddenError("Not authorized to update this recipe");
       }
 
@@ -142,16 +142,12 @@ export function createRecipeService(
         { path: "category", select: "name slug" },
       ]);
 
-      let isFavorited = false;
-      if (initiator) {
-        const favorite = await favoriteModel
-          .findOne({
-            user: initiator.id,
-            recipe: id,
-          })
-          .lean();
-        isFavorited = !!favorite;
-      }
+      const isFavorited = !!(await favoriteModel
+        .findOne({
+          user: initiator.id,
+          recipe: id,
+        })
+        .lean());
 
       return toRecipe(populated.toObject<typeof populated>(), isFavorited);
     },
@@ -165,7 +161,7 @@ export function createRecipeService(
         throw new NotFoundError("Recipe not found");
       }
 
-      if (!recipe.author.equals(initiator.id)) {
+      if (!recipe.author.equals(initiator.id) && initiator.role !== "admin") {
         throw new ForbiddenError("Not authorized to delete this recipe");
       }
 

--- a/apps/backend/src/modules/users/user.model.ts
+++ b/apps/backend/src/modules/users/user.model.ts
@@ -4,10 +4,13 @@ import { model, Schema } from "mongoose";
 import type { BaseDocument } from "@/common/types/mongoose.js";
 import { env } from "@/config/env.js";
 
+export type UserRole = "user" | "admin";
+
 export interface UserDocument extends BaseDocument {
   email: string;
   password: string;
   name: string;
+  role: UserRole;
   comparePassword(candidate: string): Promise<boolean>;
 }
 
@@ -24,6 +27,11 @@ const userSchema = new Schema<UserDocument, UserModelType>(
     },
     password: { type: String, required: true, minlength: 6, select: false },
     name: { type: String, required: true, trim: true },
+    role: {
+      type: String,
+      enum: ["user", "admin"],
+      default: "user",
+    },
   },
   {
     timestamps: true,

--- a/apps/backend/src/modules/users/user.routes.ts
+++ b/apps/backend/src/modules/users/user.routes.ts
@@ -30,6 +30,7 @@ export const userRoutes: FastifyPluginAsync<UserPluginOptions> = async (
       },
       async (request, reply) => {
         assertAuthenticated(request);
+
         const user = await service.getCurrentUser(request.user.userId);
         return reply.send(user);
       },
@@ -47,9 +48,10 @@ export const userRoutes: FastifyPluginAsync<UserPluginOptions> = async (
       },
       async (request, reply) => {
         assertAuthenticated(request);
+
         const result = await service.getFavorites(request.user.userId, {
           query: request.query,
-          initiator: { id: request.user.userId },
+          initiator: { id: request.user.userId, role: request.user.role },
         });
         return reply.send(result);
       },
@@ -67,9 +69,10 @@ export const userRoutes: FastifyPluginAsync<UserPluginOptions> = async (
       },
       async (request, reply) => {
         assertAuthenticated(request);
+
         const result = await service.getComments(request.user.userId, {
           query: request.query,
-          initiator: { id: request.user.userId },
+          initiator: { id: request.user.userId, role: request.user.role },
         });
         return reply.send(result);
       },


### PR DESCRIPTION
## Related Issues

Closes #35 

## PR Type

- [ ] Bugfix
- [x] Feature
- [x] Refactoring
- [ ] Tests
- [ ] Other

## Description

### User & Auth
- Added `role` field to `UserDocument` with enum values (`user` | `admin`)
- Extended `JwtPayload` to include user role
- Updated `DefaultInitiator` and `OptionalInitiator` types

### Authorization
- Created `requireRoles()` middleware for route protection
- Protected category creation/deletion with admin-only access
- Admin can delete/update any recipe or comment
- Updated `byVisibility()` to show all recipes to admin (including private ones)

### Bootstrap
- Added `ensureRootAdmin()` to create admin from env vars at server startup
- Required env vars: `ADMIN_EMAIL`, `ADMIN_PASSWORD`

## Screenshots

N/A

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [ ] Added/updated tests for new functionality
- [ ] Updated documentation (if needed)