### PR TITLE
test: unit tests for common layer (utils, middleware, bootstrap)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+coverage/
 .env
 !.env.example
 *.log

--- a/apps/backend/src/__tests__/helpers.ts
+++ b/apps/backend/src/__tests__/helpers.ts
@@ -21,21 +21,13 @@ export function createMockRequest(
   } as unknown as FastifyRequest;
 }
 
-export function createMockReply(): FastifyReply & {
-  __mocks: { status: ReturnType<typeof vi.fn>; send: ReturnType<typeof vi.fn> };
-} {
+export function createMockReply(): FastifyReply {
   const send = vi.fn();
   const status = vi.fn(() => ({ send }));
   return {
     status,
     send,
-    __mocks: { status, send },
-  } as unknown as FastifyReply & {
-    __mocks: {
-      status: ReturnType<typeof vi.fn>;
-      send: ReturnType<typeof vi.fn>;
-    };
-  };
+  } as unknown as FastifyReply;
 }
 
 // ── Document factories ──

--- a/apps/backend/src/__tests__/helpers.ts
+++ b/apps/backend/src/__tests__/helpers.ts
@@ -1,0 +1,209 @@
+import type { Minutes } from "@recipes/shared";
+import type { FastifyReply, FastifyRequest } from "fastify";
+import { Types } from "mongoose";
+import { vi } from "vitest";
+import type { CategoryDocument } from "@/modules/categories/category.model.js";
+import type { CommentDocument } from "@/modules/comments/comment.model.js";
+import type { RecipeDocument } from "@/modules/recipes/recipe.model.js";
+import type { UserDocument, UserRole } from "@/modules/users/user.model.js";
+
+// ── Fastify mocks ──
+
+export function createMockRequest(
+  overrides: Partial<FastifyRequest> = {},
+): FastifyRequest {
+  return {
+    log: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+    method: "GET",
+    url: "/test",
+    headers: {},
+    ...overrides,
+  } as unknown as FastifyRequest;
+}
+
+export function createMockReply(): FastifyReply & {
+  __mocks: { status: ReturnType<typeof vi.fn>; send: ReturnType<typeof vi.fn> };
+} {
+  const send = vi.fn();
+  const status = vi.fn(() => ({ send }));
+  return {
+    status,
+    send,
+    __mocks: { status, send },
+  } as unknown as FastifyReply & {
+    __mocks: {
+      status: ReturnType<typeof vi.fn>;
+      send: ReturnType<typeof vi.fn>;
+    };
+  };
+}
+
+// ── Document factories ──
+
+export function createObjectId(): Types.ObjectId {
+  return new Types.ObjectId();
+}
+
+export function createCategoryDoc(
+  overrides: Partial<CategoryDocument> = {},
+): CategoryDocument {
+  const _id = createObjectId();
+  return {
+    _id,
+    name: "Test Category",
+    slug: "test-category",
+    description: "A test category",
+    createdAt: new Date("2024-01-01"),
+    updatedAt: new Date("2024-01-01"),
+    ...overrides,
+  } as CategoryDocument;
+}
+
+export function createUserDoc(
+  overrides: Partial<UserDocument> = {},
+): UserDocument {
+  const _id = createObjectId();
+  return {
+    _id,
+    email: "test@example.com",
+    password: "hashedPassword",
+    name: "Test User",
+    role: "user",
+    createdAt: new Date("2024-01-01"),
+    updatedAt: new Date("2024-01-01"),
+    comparePassword: vi.fn().mockResolvedValue(true),
+    ...overrides,
+  };
+}
+
+export function createRecipeDoc(
+  overrides: Partial<RecipeDocument> = {},
+): RecipeDocument {
+  const _id = createObjectId();
+  return {
+    _id,
+    title: "Test Recipe",
+    description: "A test recipe",
+    ingredients: [{ name: "Flour", quantity: 200, unit: "g" }],
+    instructions: ["Mix ingredients"],
+    category: createObjectId(),
+    author: createObjectId(),
+    difficulty: "easy",
+    cookingTime: 30 as Minutes,
+    servings: 4,
+    isPublic: true,
+    createdAt: new Date("2024-01-01"),
+    updatedAt: new Date("2024-01-01"),
+    ...overrides,
+  };
+}
+
+export function createCommentDoc(
+  overrides: Partial<CommentDocument> = {},
+): CommentDocument {
+  const _id = createObjectId();
+  return {
+    _id,
+    text: "Great recipe!",
+    recipe: createObjectId(),
+    author: createObjectId(),
+    createdAt: new Date("2024-01-01"),
+    updatedAt: new Date("2024-01-01"),
+    ...overrides,
+  };
+}
+
+// ── Mongoose model mock factories ──
+
+export function createMockCategoryModel(
+  overrides: Record<string, ReturnType<typeof vi.fn>> = {},
+) {
+  const chainable = {
+    sort: vi.fn().mockReturnThis(),
+    lean: vi.fn().mockResolvedValue([]),
+  };
+
+  return {
+    find: vi.fn().mockReturnValue(chainable),
+    create: vi.fn(),
+    findByIdAndDelete: vi.fn(),
+    countDocuments: vi.fn().mockResolvedValue(0),
+    exists: vi.fn(),
+    ...overrides,
+  };
+}
+
+export function createMockUserModel(
+  overrides: Record<string, ReturnType<typeof vi.fn>> = {},
+) {
+  const queryChain = {
+    select: vi.fn().mockReturnThis(),
+    lean: vi.fn().mockResolvedValue(null),
+  };
+
+  return {
+    findById: vi.fn().mockReturnValue(queryChain),
+    findOne: vi.fn().mockReturnValue(queryChain),
+    exists: vi.fn(),
+    create: vi.fn(),
+    ...overrides,
+  };
+}
+
+export function createMockRecipeModel(
+  overrides: Record<string, ReturnType<typeof vi.fn>> = {},
+) {
+  return {
+    findById: vi.fn(),
+    searchFull: vi.fn(),
+    findByIdFull: vi.fn(),
+    create: vi.fn(),
+    countDocuments: vi.fn().mockResolvedValue(0),
+    exists: vi.fn(),
+    ...overrides,
+  };
+}
+
+export function createMockCommentModel(
+  overrides: Record<string, ReturnType<typeof vi.fn>> = {},
+) {
+  return {
+    findFull: vi.fn(),
+    findById: vi.fn(),
+    create: vi.fn(),
+    ...overrides,
+  };
+}
+
+export function createMockFavoriteModel(
+  overrides: Record<string, ReturnType<typeof vi.fn>> = {},
+) {
+  return {
+    findByUser: vi.fn(),
+    create: vi.fn(),
+    findOneAndDelete: vi.fn(),
+    exists: vi.fn(),
+    findOne: vi.fn(),
+    ...overrides,
+  };
+}
+
+// ── Service param builders ──
+
+export function initiator(id?: string, role: UserRole = "user") {
+  return {
+    id: id ?? createObjectId().toString(),
+    role,
+  };
+}
+
+export function queryParams(
+  page = 1,
+  limit = 10,
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    query: { page, limit, ...overrides },
+    initiator: initiator(),
+  };
+}

--- a/apps/backend/src/__tests__/helpers.ts
+++ b/apps/backend/src/__tests__/helpers.ts
@@ -9,6 +9,12 @@ import type { UserDocument, UserRole } from "@/modules/users/user.model.js";
 
 // ── Fastify mocks ──
 
+/**
+ * Creates a mock Fastify request.
+ *
+ * @param overrides - Overrides for the request.
+ * @returns A mock Fastify request.
+ */
 export function createMockRequest(
   overrides: Partial<FastifyRequest> = {},
 ): FastifyRequest {
@@ -21,6 +27,11 @@ export function createMockRequest(
   } as unknown as FastifyRequest;
 }
 
+/**
+ * Creates a mock Fastify reply.
+ *
+ * @returns A mock Fastify reply.
+ */
 export function createMockReply(): FastifyReply {
   const send = vi.fn();
   const status = vi.fn(() => ({ send }));
@@ -32,6 +43,11 @@ export function createMockReply(): FastifyReply {
 
 // ── Document factories ──
 
+/**
+ * Creates new ObjectId.
+ *
+ * @returns A new ObjectId.
+ */
 export function createObjectId(): Types.ObjectId {
   return new Types.ObjectId();
 }
@@ -182,6 +198,13 @@ export function createMockFavoriteModel(
 
 // ── Service param builders ──
 
+/**
+ * Creates a new initiator.
+ *
+ * @param id - The initiator's ID.
+ * @param role - The initiator's role.
+ * @returns A new initiator.
+ */
 export function initiator(id?: string, role: UserRole = "user") {
   return {
     id: id ?? createObjectId().toString(),
@@ -189,6 +212,14 @@ export function initiator(id?: string, role: UserRole = "user") {
   };
 }
 
+/**
+ * Creates a new query params with initiator.
+ *
+ * @param page - The page number.
+ * @param limit - The number of items per page.
+ * @param overrides - Overrides for the query params.
+ * @returns A new query params.
+ */
 export function queryParams(
   page = 1,
   limit = 10,

--- a/apps/backend/src/__tests__/helpers.ts
+++ b/apps/backend/src/__tests__/helpers.ts
@@ -1,11 +1,17 @@
 import type { Minutes } from "@recipes/shared";
 import type { FastifyReply, FastifyRequest } from "fastify";
 import { Types } from "mongoose";
+import type { Mock } from "vitest";
 import { vi } from "vitest";
 import type { CategoryDocument } from "@/modules/categories/category.model.js";
 import type { CommentDocument } from "@/modules/comments/comment.model.js";
 import type { RecipeDocument } from "@/modules/recipes/recipe.model.js";
 import type { UserDocument, UserRole } from "@/modules/users/user.model.js";
+
+type LocalProcedure = (...args: unknown[]) => unknown;
+function viFn<T extends LocalProcedure>(fn?: T): Mock<T> {
+  return vi.fn(fn);
+}
 
 // ── Fastify mocks ──
 
@@ -123,75 +129,61 @@ export function createCommentDoc(
 
 // ── Mongoose model mock factories ──
 
-export function createMockCategoryModel(
-  overrides: Record<string, ReturnType<typeof vi.fn>> = {},
-) {
-  const chainable = {
-    sort: vi.fn().mockReturnThis(),
-    lean: vi.fn().mockResolvedValue([]),
-  };
+const chainable = {
+  select: viFn().mockReturnThis(),
+  sort: viFn().mockReturnThis(),
+  lean: viFn().mockResolvedValue(null),
+};
 
+export function createMockCategoryModel(overrides: Record<string, Mock> = {}) {
   return {
-    find: vi.fn().mockReturnValue(chainable),
-    create: vi.fn(),
-    findByIdAndDelete: vi.fn(),
-    countDocuments: vi.fn().mockResolvedValue(0),
-    exists: vi.fn(),
+    find: viFn().mockReturnValue(chainable),
+    create: viFn(),
+    findByIdAndDelete: viFn(),
+    countDocuments: viFn().mockResolvedValue(0),
+    exists: viFn(),
     ...overrides,
   };
 }
 
-export function createMockUserModel(
-  overrides: Record<string, ReturnType<typeof vi.fn>> = {},
-) {
-  const queryChain = {
-    select: vi.fn().mockReturnThis(),
-    lean: vi.fn().mockResolvedValue(null),
-  };
-
+export function createMockUserModel(overrides: Record<string, Mock> = {}) {
   return {
-    findById: vi.fn().mockReturnValue(queryChain),
-    findOne: vi.fn().mockReturnValue(queryChain),
-    exists: vi.fn(),
-    create: vi.fn(),
+    findById: viFn().mockReturnValue(chainable),
+    findOne: viFn().mockReturnValue(chainable),
+    exists: viFn(),
+    create: viFn(),
     ...overrides,
   };
 }
 
-export function createMockRecipeModel(
-  overrides: Record<string, ReturnType<typeof vi.fn>> = {},
-) {
+export function createMockRecipeModel(overrides: Record<string, Mock> = {}) {
   return {
-    findById: vi.fn(),
-    searchFull: vi.fn(),
-    findByIdFull: vi.fn(),
-    create: vi.fn(),
-    countDocuments: vi.fn().mockResolvedValue(0),
-    exists: vi.fn(),
+    findById: viFn(),
+    searchFull: viFn(),
+    findByIdFull: viFn(),
+    create: viFn(),
+    countDocuments: viFn().mockResolvedValue(0),
+    exists: viFn(),
     ...overrides,
   };
 }
 
-export function createMockCommentModel(
-  overrides: Record<string, ReturnType<typeof vi.fn>> = {},
-) {
+export function createMockCommentModel(overrides: Record<string, Mock> = {}) {
   return {
-    findFull: vi.fn(),
-    findById: vi.fn(),
-    create: vi.fn(),
+    findFull: viFn(),
+    findById: viFn(),
+    create: viFn(),
     ...overrides,
   };
 }
 
-export function createMockFavoriteModel(
-  overrides: Record<string, ReturnType<typeof vi.fn>> = {},
-) {
+export function createMockFavoriteModel(overrides: Record<string, Mock> = {}) {
   return {
-    findByUser: vi.fn(),
-    create: vi.fn(),
-    findOneAndDelete: vi.fn(),
-    exists: vi.fn(),
-    findOne: vi.fn(),
+    findByUser: viFn(),
+    create: viFn(),
+    findOneAndDelete: viFn(),
+    exists: viFn(),
+    findOne: viFn(),
     ...overrides,
   };
 }

--- a/apps/backend/src/common/bootstrap/admin.test.ts
+++ b/apps/backend/src/common/bootstrap/admin.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ensureRootAdmin } from "@/common/bootstrap/admin.js";
+
+const { UserModel } = await vi.hoisted(async () => ({
+  UserModel: (await import("@/__tests__/helpers.js")).createMockUserModel(),
+}));
+
+vi.mock("@/config/env.js", () => ({
+  env: {
+    ROOT_ADMIN_EMAIL: "admin@test.com",
+    ROOT_ADMIN_PASSWORD: "SecureP@ss123",
+  },
+}));
+vi.mock("@/modules/users/user.model.js", () => ({
+  UserModel,
+}));
+
+describe("ensureRootAdmin", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should create root admin when no admin exists", async () => {
+    UserModel.findOne.mockResolvedValue(null);
+    UserModel.create.mockResolvedValue({});
+
+    await ensureRootAdmin();
+
+    expect(UserModel.findOne).toHaveBeenCalledWith({ role: "admin" });
+    expect(UserModel.create).toHaveBeenCalledWith({
+      email: "admin@test.com",
+      password: "SecureP@ss123",
+      name: "Root Admin",
+      role: "admin",
+    });
+  });
+
+  it("should not create admin when one already exists", async () => {
+    UserModel.findOne.mockResolvedValue({ email: "existing@admin.com" });
+
+    await ensureRootAdmin();
+
+    expect(UserModel.findOne).toHaveBeenCalledWith({ role: "admin" });
+    expect(UserModel.create).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/common/middleware/auth.guard.test.ts
+++ b/apps/backend/src/common/middleware/auth.guard.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createMockReply, createMockRequest } from "@/__tests__/helpers.js";
+import { UnauthorizedError } from "@/common/errors.js";
+import {
+  assertAuthenticated,
+  authGuard,
+  extractToken,
+  optionalAuth,
+} from "@/common/middleware/auth.guard.js";
+import type { JwtPayload } from "@/common/utils/jwt.js";
+
+const { verifyToken } = vi.hoisted(() => ({
+  verifyToken: vi.fn(),
+}));
+
+vi.mock("@/common/utils/jwt.js", () => ({ verifyToken }));
+
+describe("auth.guard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("extractToken", () => {
+    it("should extract token from valid Bearer header", () => {
+      const request = createMockRequest({
+        headers: { authorization: "Bearer my-jwt-token" },
+      });
+
+      const token = extractToken(request);
+
+      expect(token).toBe("my-jwt-token");
+    });
+
+    it("should throw UnauthorizedError when header is missing", () => {
+      const request = createMockRequest({ headers: {} });
+
+      expect(() => extractToken(request)).toThrow(UnauthorizedError);
+    });
+
+    it("should throw UnauthorizedError when scheme is not Bearer", () => {
+      const request = createMockRequest({
+        headers: { authorization: "Basic abc123" },
+      });
+
+      expect(() => extractToken(request)).toThrow(UnauthorizedError);
+    });
+
+    it("should throw UnauthorizedError when token part is missing", () => {
+      const request = createMockRequest({
+        headers: { authorization: "Bearer " },
+      });
+
+      expect(() => extractToken(request)).toThrow(UnauthorizedError);
+    });
+
+    it("should throw UnauthorizedError on empty string header", () => {
+      const request = createMockRequest({
+        headers: { authorization: "" },
+      });
+
+      expect(() => extractToken(request)).toThrow(UnauthorizedError);
+    });
+  });
+
+  describe("assertAuthenticated", () => {
+    it("should not throw when user is present", () => {
+      const request = createMockRequest({
+        user: { userId: "123", email: "test@test.com", role: "user" },
+      });
+
+      expect(() => assertAuthenticated(request)).not.toThrow();
+    });
+
+    it("should throw UnauthorizedError when user is not set", () => {
+      const request = createMockRequest();
+
+      expect(() => assertAuthenticated(request)).toThrow(UnauthorizedError);
+    });
+  });
+
+  describe("authGuard", () => {
+    it("should set request.user on valid token", async () => {
+      const payload = {
+        userId: "123",
+        email: "test@test.com",
+        role: "user",
+      } satisfies JwtPayload;
+      verifyToken.mockReturnValue(payload);
+
+      const request = createMockRequest({
+        headers: { authorization: "Bearer valid-token" },
+      });
+      const reply = createMockReply();
+
+      await authGuard(request, reply);
+
+      expect(verifyToken).toHaveBeenCalledWith("valid-token");
+      expect(request.user).toEqual(payload);
+    });
+
+    it("should return 401 on invalid token", async () => {
+      verifyToken.mockImplementation(() => {
+        throw new Error("jwt malformed");
+      });
+
+      const request = createMockRequest({
+        headers: { authorization: "Bearer bad-token" },
+      });
+      const reply = createMockReply();
+
+      await authGuard(request, reply);
+
+      expect(reply.status).toHaveBeenCalledWith(401);
+      expect(reply.send).toHaveBeenCalledWith({
+        error: "Invalid or expired token",
+      });
+    });
+  });
+
+  describe("optionalAuth", () => {
+    it("should skip when no authorization header", async () => {
+      const request = createMockRequest({ headers: {} });
+      const reply = createMockReply();
+
+      await optionalAuth(request, reply);
+
+      expect(verifyToken).not.toHaveBeenCalled();
+    });
+
+    it("should call authGuard when authorization header is present", async () => {
+      const payload = {
+        userId: "123",
+        email: "test@test.com",
+        role: "user",
+      } satisfies JwtPayload;
+      verifyToken.mockReturnValue(payload);
+
+      const request = createMockRequest({
+        headers: { authorization: "Bearer valid-token" },
+      });
+      const reply = createMockReply();
+
+      await optionalAuth(request, reply);
+
+      expect(request.user).toEqual(payload);
+    });
+  });
+});

--- a/apps/backend/src/common/middleware/errorHandler.test.ts
+++ b/apps/backend/src/common/middleware/errorHandler.test.ts
@@ -17,7 +17,7 @@ const {
 
 function createMockReply() {
   const send = vi.fn();
-  const status = vi.fn().mockReturnValue({ send });
+  const status = vi.fn(() => ({ send }));
   return {
     reply: { status } as unknown as Parameters<typeof errorHandler>[2],
     send,

--- a/apps/backend/src/common/middleware/errorHandler.test.ts
+++ b/apps/backend/src/common/middleware/errorHandler.test.ts
@@ -1,197 +1,177 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ZodError } from "zod";
-
-vi.mock("@/config/env.js", () => ({
-  env: { NODE_ENV: "development" },
-}));
-
-const { errorHandler } = await import("@/common/middleware/errorHandler.js");
-const {
+import { createMockReply, createMockRequest } from "@/__tests__/helpers.js";
+import {
   AppError,
   BadRequestError,
-  UnauthorizedError,
+  ConflictError,
   ForbiddenError,
   NotFoundError,
-  ConflictError,
-} = await import("@/common/errors.js");
+  UnauthorizedError,
+} from "@/common/errors.js";
+import { errorHandler } from "@/common/middleware/errorHandler.js";
 
-function createMockReply() {
-  const send = vi.fn();
-  const status = vi.fn(() => ({ send }));
-  return {
-    reply: { status } as unknown as Parameters<typeof errorHandler>[2],
-    send,
-    status,
-  };
-}
-
-function createMockRequest() {
-  return {
-    log: { error: vi.fn() },
-    method: "GET",
-    url: "/test",
-  } as unknown as Parameters<typeof errorHandler>[1];
-}
+vi.mock("@/config/env.js", () => ({
+  env: { NODE_ENV: "development" as const },
+}));
 
 describe("errorHandler", () => {
   let request: ReturnType<typeof createMockRequest>;
-  let reply: Parameters<typeof errorHandler>[2];
-  let send: ReturnType<typeof createMockReply>["send"];
-  let status: ReturnType<typeof createMockReply>["status"];
+  let reply: ReturnType<typeof createMockReply>;
 
   beforeEach(() => {
     vi.clearAllMocks();
     request = createMockRequest();
-    const mock = createMockReply();
-    reply = mock.reply;
-    send = mock.send;
-    status = mock.status;
+    reply = createMockReply();
   });
 
-  it("should handle AppError with custom statusCode", () => {
-    const error = new AppError("Not found", 404);
+  describe("AppError subclasses", () => {
+    it("should handle AppError with custom statusCode", () => {
+      errorHandler(new AppError("Not found", 404), request, reply);
 
-    errorHandler(error, request, reply);
+      expect(reply.status).toHaveBeenCalledWith(404);
+      expect(reply.send).toHaveBeenCalledWith({ error: "Not found" });
+    });
 
-    expect(status).toHaveBeenCalledWith(404);
-    expect(send).toHaveBeenCalledWith({ error: "Not found" });
-  });
+    it("should handle AppError with 403", () => {
+      errorHandler(new AppError("Forbidden", 403), request, reply);
 
-  it("should handle AppError with 403", () => {
-    const error = new AppError("Forbidden", 403);
+      expect(reply.status).toHaveBeenCalledWith(403);
+      expect(reply.send).toHaveBeenCalledWith({ error: "Forbidden" });
+    });
 
-    errorHandler(error, request, reply);
+    it("should handle BadRequestError", () => {
+      errorHandler(new BadRequestError("Invalid recipe ID"), request, reply);
 
-    expect(status).toHaveBeenCalledWith(403);
-    expect(send).toHaveBeenCalledWith({ error: "Forbidden" });
-  });
+      expect(reply.status).toHaveBeenCalledWith(400);
+      expect(reply.send).toHaveBeenCalledWith({ error: "Invalid recipe ID" });
+    });
 
-  it("should handle BadRequestError", () => {
-    const error = new BadRequestError("Invalid recipe ID");
+    it("should handle UnauthorizedError", () => {
+      errorHandler(new UnauthorizedError("Not authorized"), request, reply);
 
-    errorHandler(error, request, reply);
+      expect(reply.status).toHaveBeenCalledWith(401);
+      expect(reply.send).toHaveBeenCalledWith({ error: "Not authorized" });
+    });
 
-    expect(status).toHaveBeenCalledWith(400);
-    expect(send).toHaveBeenCalledWith({ error: "Invalid recipe ID" });
-  });
+    it("should handle ForbiddenError", () => {
+      errorHandler(
+        new ForbiddenError("Not authorized to delete this recipe"),
+        request,
+        reply,
+      );
 
-  it("should handle UnauthorizedError", () => {
-    const error = new UnauthorizedError("Not authorized");
+      expect(reply.status).toHaveBeenCalledWith(403);
+      expect(reply.send).toHaveBeenCalledWith({
+        error: "Not authorized to delete this recipe",
+      });
+    });
 
-    errorHandler(error, request, reply);
+    it("should handle NotFoundError", () => {
+      errorHandler(new NotFoundError("Recipe not found"), request, reply);
 
-    expect(status).toHaveBeenCalledWith(401);
-    expect(send).toHaveBeenCalledWith({ error: "Not authorized" });
-  });
+      expect(reply.status).toHaveBeenCalledWith(404);
+      expect(reply.send).toHaveBeenCalledWith({ error: "Recipe not found" });
+    });
 
-  it("should handle ForbiddenError", () => {
-    const error = new ForbiddenError("Not authorized to delete this recipe");
+    it("should handle ConflictError", () => {
+      errorHandler(new ConflictError("Email already in use"), request, reply);
 
-    errorHandler(error, request, reply);
-
-    expect(status).toHaveBeenCalledWith(403);
-    expect(send).toHaveBeenCalledWith({
-      error: "Not authorized to delete this recipe",
+      expect(reply.status).toHaveBeenCalledWith(409);
+      expect(reply.send).toHaveBeenCalledWith({
+        error: "Email already in use",
+      });
     });
   });
 
-  it("should handle NotFoundError", () => {
-    const error = new NotFoundError("Recipe not found");
+  describe("Zod and Mongoose errors", () => {
+    it("should handle ZodError with validation details", () => {
+      const error = new ZodError([
+        {
+          code: "too_small",
+          origin: "string",
+          minimum: 1,
+          inclusive: true,
+          path: ["text"],
+          message: "Required",
+        },
+      ]);
 
-    errorHandler(error, request, reply);
+      errorHandler(error, request, reply);
 
-    expect(status).toHaveBeenCalledWith(404);
-    expect(send).toHaveBeenCalledWith({ error: "Recipe not found" });
-  });
+      expect(reply.status).toHaveBeenCalledWith(400);
+      expect(reply.send).toHaveBeenCalledWith({
+        error: "Validation error",
+        details: error.issues,
+      });
+    });
 
-  it("should handle ConflictError", () => {
-    const error = new ConflictError("Email already in use");
+    it("should handle Mongoose CastError", () => {
+      const error = Object.assign(new Error("Cast to ObjectId failed"), {
+        name: "CastError",
+        path: "_id",
+        value: "invalid-id",
+      });
 
-    errorHandler(error, request, reply);
+      errorHandler(error, request, reply);
 
-    expect(status).toHaveBeenCalledWith(409);
-    expect(send).toHaveBeenCalledWith({ error: "Email already in use" });
-  });
+      expect(reply.status).toHaveBeenCalledWith(400);
+      expect(reply.send).toHaveBeenCalledWith({
+        error: "Invalid _id: invalid-id",
+      });
+    });
 
-  it("should handle ZodError with validation details", () => {
-    const error = new ZodError([
-      {
-        code: "too_small",
-        minimum: 1,
-        type: "string",
-        inclusive: true,
-        path: ["text"],
-        message: "Required",
-      } as never,
-    ]);
+    it("should handle MongoDB duplicate key error", () => {
+      const error = Object.assign(new Error("Duplicate key"), {
+        code: 11000,
+      });
 
-    errorHandler(error, request, reply);
+      errorHandler(error, request, reply);
 
-    expect(status).toHaveBeenCalledWith(400);
-    expect(send).toHaveBeenCalledWith({
-      error: "Validation error",
-      details: error.issues,
+      expect(reply.status).toHaveBeenCalledWith(409);
+      expect(reply.send).toHaveBeenCalledWith({ error: "Duplicate entry" });
     });
   });
 
-  it("should handle Mongoose CastError", () => {
-    const error = Object.assign(new Error("Cast to ObjectId failed"), {
-      name: "CastError",
-      path: "_id",
-      value: "invalid-id",
+  describe("generic errors", () => {
+    it("should pass through statusCode when not 500", () => {
+      const error = Object.assign(new Error("Bad request"), {
+        statusCode: 400,
+      });
+
+      errorHandler(error, request, reply);
+
+      expect(reply.status).toHaveBeenCalledWith(400);
+      expect(reply.send).toHaveBeenCalledWith({ error: "Bad request" });
     });
 
-    errorHandler(error, request, reply);
+    it("should show message and stack in development for 500", () => {
+      const error = new Error("Something broke");
+      error.stack = "Error: Something broke\n    at test";
 
-    expect(status).toHaveBeenCalledWith(400);
-    expect(send).toHaveBeenCalledWith({
-      error: "Invalid _id: invalid-id",
-    });
-  });
+      errorHandler(error, request, reply);
 
-  it("should handle MongoDB duplicate key error", () => {
-    const error = Object.assign(new Error("Duplicate key"), {
-      code: 11000,
-    });
-
-    errorHandler(error, request, reply);
-
-    expect(status).toHaveBeenCalledWith(409);
-    expect(send).toHaveBeenCalledWith({
-      error: "Duplicate entry",
+      expect(reply.status).toHaveBeenCalledWith(500);
+      expect(reply.send).toHaveBeenCalledWith({
+        error: "Something broke",
+        stack: error.stack,
+      });
     });
   });
 
-  it("should handle error with statusCode (not 500)", () => {
-    const error = Object.assign(new Error("Bad request"), { statusCode: 400 });
+  describe("logging", () => {
+    it("should log error code for typed errors", () => {
+      errorHandler(new NotFoundError("Recipe not found"), request, reply);
 
-    errorHandler(error, request, reply);
-
-    expect(status).toHaveBeenCalledWith(400);
-    expect(send).toHaveBeenCalledWith({ error: "Bad request" });
-  });
-
-  it("should show error message and stack in development for 500", () => {
-    const error = new Error("Something broke");
-    error.stack = "Error: Something broke\n    at test";
-
-    errorHandler(error, request, reply);
-
-    expect(status).toHaveBeenCalledWith(500);
-    expect(send).toHaveBeenCalledWith({
-      error: "Something broke",
-      stack: error.stack,
+      expect(request.log.error).toHaveBeenCalledWith(
+        {
+          err: expect.any(NotFoundError),
+          method: "GET",
+          url: "/test",
+          errorCode: "NOT_FOUND",
+        },
+        "Request error",
+      );
     });
-  });
-
-  it("should log error code for typed errors", () => {
-    const error = new NotFoundError("Recipe not found");
-
-    errorHandler(error, request, reply);
-
-    expect(request.log.error).toHaveBeenCalledWith(
-      { err: error, method: "GET", url: "/test", errorCode: "NOT_FOUND" },
-      "Request error",
-    );
   });
 });

--- a/apps/backend/src/common/middleware/role.guard.test.ts
+++ b/apps/backend/src/common/middleware/role.guard.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createMockRequest } from "@/__tests__/helpers.js";
+import { assertAuthenticated } from "@/common/middleware/auth.guard.js";
+import { ForbiddenError } from "../errors.js";
+import { rolesGuard } from "./role.guard.js";
+
+vi.mock("@/config/env.js", () => ({
+  env: { JWT_SECRET: "test", JWT_EXPIRES_IN: "1h" },
+}));
+
+vi.mock(import("@/common/middleware/auth.guard.js"), { spy: true });
+
+describe("rolesGuard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should pass when user has the required role", async () => {
+    const request = createMockRequest();
+    request.user = {
+      userId: "123",
+      email: "admin@test.com",
+      role: "admin",
+    };
+
+    const guard = rolesGuard("admin");
+
+    await expect(guard(request)).resolves.toBeUndefined();
+    expect(assertAuthenticated).toHaveBeenCalledWith(request);
+  });
+
+  it("should throw ForbiddenError when user lacks the required role", async () => {
+    const request = createMockRequest({
+      user: {
+        userId: "123",
+        email: "user@test.com",
+        role: "user",
+      },
+    });
+
+    const guard = rolesGuard("admin");
+
+    await expect(guard(request)).rejects.toThrow(ForbiddenError);
+    await expect(guard(request)).rejects.toThrow("Insufficient permissions");
+    expect(assertAuthenticated).toHaveBeenCalledWith(request);
+  });
+
+  it("should pass when user has any of multiple allowed roles", async () => {
+    const request = createMockRequest({
+      user: {
+        userId: "123",
+        email: "user@test.com",
+        role: "user",
+      },
+    });
+    const guard = rolesGuard("admin", "user");
+
+    await expect(guard(request)).resolves.toBeUndefined();
+    expect(assertAuthenticated).toHaveBeenCalledWith(request);
+  });
+});

--- a/apps/backend/src/common/utils/jwt.test.ts
+++ b/apps/backend/src/common/utils/jwt.test.ts
@@ -1,0 +1,56 @@
+import jwt from "jsonwebtoken";
+import { describe, expect, it, vi } from "vitest";
+import type { JwtPayload } from "./jwt.js";
+import { signToken, verifyToken } from "./jwt.js";
+
+vi.mock("@/config/env.js", () => ({
+  env: {
+    JWT_SECRET: "test-secret-key-for-unit-tests",
+    JWT_EXPIRES_IN: "1h",
+  },
+}));
+
+describe("jwt utils", () => {
+  const payload = {
+    userId: "507f1f77bcf86cd799439011",
+    email: "test@example.com",
+    role: "user",
+  } satisfies JwtPayload;
+
+  describe("signToken", () => {
+    it("should return a JWT string", () => {
+      const token = signToken(payload);
+
+      expect(typeof token).toBe("string");
+      expect(token.split(".")).toHaveLength(3);
+    });
+
+    it("should produce different tokens for different payloads", () => {
+      const token1 = signToken(payload);
+      const token2 = signToken({ ...payload, email: "other@test.com" });
+
+      expect(token1).not.toBe(token2);
+    });
+  });
+
+  describe("verifyToken", () => {
+    it("should decode a valid token", () => {
+      const token = signToken(payload);
+      const decoded = verifyToken(token);
+
+      expect(decoded.userId).toBe(payload.userId);
+      expect(decoded.email).toBe(payload.email);
+      expect(decoded.role).toBe(payload.role);
+    });
+
+    it("should throw on invalid token", () => {
+      expect(() => verifyToken("not.a.token")).toThrow();
+    });
+
+    it("should throw on token signed with different secret", () => {
+      const token = jwt.sign(payload, "other-secret");
+
+      expect(() => verifyToken(token)).toThrow();
+    });
+  });
+});

--- a/apps/backend/src/common/utils/mongo.test.ts
+++ b/apps/backend/src/common/utils/mongo.test.ts
@@ -1,0 +1,187 @@
+import type { Minutes } from "@recipes/shared";
+import { Types } from "mongoose";
+import { describe, expect, it } from "vitest";
+import {
+  createCategoryDoc,
+  createCommentDoc,
+  createObjectId,
+  createRecipeDoc,
+  createUserDoc,
+} from "@/__tests__/helpers.js";
+import {
+  toCategory,
+  toComment,
+  toCommentForRecipe,
+  toObjectId,
+  toRecipe,
+  toUser,
+} from "@/common/utils/mongo.js";
+import type { RecipeDocumentPopulated } from "@/modules/recipes/recipe.model.js";
+
+describe("toObjectId", () => {
+  it("should convert a valid hex string to ObjectId", () => {
+    const hex = "507f1f77bcf86cd799439011";
+    const result = toObjectId(hex);
+
+    expect(result).toBeInstanceOf(Types.ObjectId);
+    expect(result.toHexString()).toBe(hex);
+  });
+
+  it("should throw on invalid hex string", () => {
+    expect(() => toObjectId("invalid")).toThrow();
+  });
+});
+
+describe("toCategory", () => {
+  it("should map CategoryDocument to Category DTO", () => {
+    const doc = createCategoryDoc({
+      name: "Desserts",
+      slug: "desserts",
+      description: "Sweet dishes",
+    });
+
+    const result = toCategory(doc);
+
+    expect(result).toEqual({
+      id: doc._id.toString(),
+      name: "Desserts",
+      slug: "desserts",
+      description: "Sweet dishes",
+      createdAt: doc.createdAt.toISOString(),
+      updatedAt: doc.updatedAt.toISOString(),
+    });
+  });
+
+  it("should handle optional description", () => {
+    const doc = createCategoryDoc({ description: undefined });
+
+    const result = toCategory(doc);
+
+    expect(result.description).toBeUndefined();
+  });
+});
+
+describe("toUser", () => {
+  it("should map UserDocument to User DTO", () => {
+    const doc = createUserDoc({
+      email: "john@test.com",
+      name: "John",
+    });
+
+    const result = toUser(doc);
+
+    expect(result).toEqual({
+      id: doc._id.toString(),
+      email: "john@test.com",
+      name: "John",
+      createdAt: doc.createdAt.toISOString(),
+      updatedAt: doc.updatedAt.toISOString(),
+    });
+  });
+
+  it("should not expose password field", () => {
+    const doc = createUserDoc();
+
+    const result = toUser(doc);
+
+    expect(result).not.toHaveProperty("password");
+    expect(result).not.toHaveProperty("role");
+  });
+});
+
+describe("toRecipe", () => {
+  it("should map recipe document to Recipe DTO", () => {
+    const categoryId = createObjectId();
+    const authorId = createObjectId();
+    const doc = {
+      ...createRecipeDoc({
+        title: "Pasta",
+        description: "Delicious pasta",
+        difficulty: "easy",
+        cookingTime: 30 as Minutes,
+        servings: 4,
+        isPublic: true,
+      }),
+      category: {
+        _id: categoryId,
+        name: "Italian",
+        slug: "italian",
+      },
+      author: {
+        _id: authorId,
+        name: "Chef",
+        email: "chef@test.com",
+      },
+      isFavorited: true,
+    } satisfies RecipeDocumentPopulated;
+
+    const result = toRecipe(doc, doc.isFavorited);
+
+    expect(result.id).toBe(doc._id.toString());
+    expect(result.title).toBe("Pasta");
+    expect(result.isFavorited).toBe(doc.isFavorited);
+    expect(result.category).toEqual({
+      id: categoryId.toString(),
+      name: "Italian",
+      slug: "italian",
+    });
+    expect(result.author).toEqual({
+      id: authorId.toString(),
+      email: "chef@test.com",
+      name: "Chef",
+    });
+  });
+
+  it("should map isFavorited=false", () => {
+    const doc = {
+      ...createRecipeDoc(),
+      category: { _id: createObjectId(), name: "Cat", slug: "cat" },
+      author: { _id: createObjectId(), name: "Auth", email: "a@b.c" },
+    };
+
+    const result = toRecipe(doc, false);
+
+    expect(result.isFavorited).toBe(false);
+  });
+});
+
+describe("toComment", () => {
+  it("should map comment document to Comment DTO with recipe", () => {
+    const authorId = createObjectId();
+    const recipeId = createObjectId();
+    const doc = {
+      ...createCommentDoc({ text: "Nice!" }),
+      author: { _id: authorId, name: "User", email: "user@test.com" },
+      recipe: { _id: recipeId, title: "Pasta" },
+    };
+
+    const result = toComment(doc);
+
+    expect(result.text).toBe("Nice!");
+    expect(result.author).toEqual({
+      id: authorId.toString(),
+      email: "user@test.com",
+      name: "User",
+    });
+    expect(result.recipe).toEqual({
+      id: recipeId.toString(),
+      title: "Pasta",
+    });
+  });
+});
+
+describe("toCommentForRecipe", () => {
+  it("should map comment document to CommentForRecipe DTO (no recipe field)", () => {
+    const authorId = createObjectId();
+    const doc = {
+      ...createCommentDoc({ text: "Great!" }),
+      author: { _id: authorId, name: "User", email: "user@test.com" },
+    };
+
+    const result = toCommentForRecipe(doc);
+
+    expect(result.text).toBe("Great!");
+    expect(result).not.toHaveProperty("recipe");
+    expect(result.author.id).toBe(authorId.toString());
+  });
+});

--- a/apps/backend/src/common/utils/mongoose.aggregation.test.ts
+++ b/apps/backend/src/common/utils/mongoose.aggregation.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+const { withSort, withPagination, withTotalCount } = await import(
+  "@/common/utils/mongoose.aggregation.js"
+);
+
+describe("withSort", () => {
+  it("should return createdAt descending sort by default", () => {
+    const result = withSort();
+
+    expect(result).toEqual([{ $sort: { createdAt: -1 } }]);
+  });
+
+  it("should return ascending sort when no minus prefix", () => {
+    const result = withSort("name");
+
+    expect(result).toEqual([{ $sort: { name: 1 } }]);
+  });
+
+  it("should handle descending sort with prefix", () => {
+    const result = withSort("-updatedAt");
+
+    expect(result).toHaveLength(1);
+    expect(result).toEqual([{ $sort: { updatedAt: -1 } }]);
+  });
+});
+
+describe("withPagination", () => {
+  it("should return $skip and $limit stages", () => {
+    const result = withPagination(1, 10);
+
+    expect(result).toHaveLength(2);
+    expect(result).toEqual([{ $skip: 0 }, { $limit: 10 }]);
+  });
+
+  it("should calculate correct skip for page 3 with limit 20", () => {
+    const result = withPagination(3, 20);
+
+    expect(result).toHaveLength(2);
+    expect(result).toEqual([{ $skip: 40 }, { $limit: 20 }]);
+  });
+
+  it("should skip 0 for page 1", () => {
+    const result = withPagination(1, 5);
+
+    expect(result).toHaveLength(2);
+    expect(result).toEqual([{ $skip: 0 }, { $limit: 5 }]);
+  });
+});
+
+describe("withTotalCount", () => {
+  it("should wrap pipelines in $facet with total count", () => {
+    const pipeline = { $sort: { createdAt: -1 } } as const;
+    const result = withTotalCount(pipeline);
+
+    expect(result[0]?.$facet?.items).toHaveLength(1);
+    expect(result[0]?.$facet?.items[0]).toEqual(pipeline);
+  });
+
+  it("should handle multiple pipeline stages", () => {
+    const result = withTotalCount(
+      { $sort: { name: 1 } },
+      { $skip: 0 },
+      { $limit: 10 },
+    );
+
+    expect(result[0]?.$facet?.items).toHaveLength(3);
+  });
+});

--- a/apps/backend/vitest.config.ts
+++ b/apps/backend/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    globals: true,
+    globals: false,
     environment: "node",
     include: ["src/**/*.test.ts"],
     coverage: {


### PR DESCRIPTION
## Related Issues

<!-- Link related issues: Closes #123, Refs #456 -->

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [x] Tests
- [ ] Other

## Description

Added unit tests for the backend common layer:

**Test infrastructure:**
- `src/__tests__/helpers.ts` — shared test utilities: Fastify mock factories (`createMockRequest`, `createMockReply`), document factories (`createCategoryDoc`, `createUserDoc`, `createRecipeDoc`, `createCommentDoc`), Mongoose model mock factories, and service param builders (`initiator`, `queryParams`)

**Tests (52 tests total):**
- `utils/mongo.test.ts` — `toObjectId`, `toCategory`, `toUser`, `toRecipe`, `toComment`, `toCommentForRecipe`
- `utils/jwt.test.ts` — `signToken`, `verifyToken`
- `utils/mongoose.aggregation.test.ts` — `withSort`, `withPagination`, `withTotalCount`
- `middleware/auth.guard.test.ts` — `extractToken`, `assertAuthenticated`, `authGuard`, `optionalAuth`
- `middleware/role.guard.test.ts` — `rolesGuard`
- `bootstrap/admin.test.ts` — `ensureRootAdmin`
- `middleware/errorHandler.test.ts` — refactored to use `vi.hoisted()`, shared helpers, nested `describe` blocks

**Patterns established:**
- `vi.hoisted()` + regular `import` (instead of `await import()`)
- Type-safe mock factories with `viFn()` wrapper to avoid non-portable `Procedure` type
- Shared test helpers in `__tests__/helpers.ts`

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Added/updated tests for new functionality
- [ ] Updated documentation (if needed)