### PR TITLE
test: unit tests for service layer (6 services)

### DIFF
--- a/apps/backend/src/__tests__/helpers.ts
+++ b/apps/backend/src/__tests__/helpers.ts
@@ -5,7 +5,10 @@ import type { Mock } from "vitest";
 import { vi } from "vitest";
 import type { CategoryDocument } from "@/modules/categories/category.model.js";
 import type { CommentDocument } from "@/modules/comments/comment.model.js";
-import type { RecipeDocument } from "@/modules/recipes/recipe.model.js";
+import type {
+  RecipeDocument,
+  RecipeDocumentPopulated,
+} from "@/modules/recipes/recipe.model.js";
 import type { UserDocument, UserRole } from "@/modules/users/user.model.js";
 
 type LocalProcedure = (...args: unknown[]) => unknown;
@@ -112,6 +115,19 @@ export function createRecipeDoc(
   };
 }
 
+export function populateRecipeDoc(
+  recipe: RecipeDocument,
+  overrides: Partial<RecipeDocumentPopulated> = {},
+): RecipeDocumentPopulated {
+  return {
+    ...recipe,
+    category: { _id: createObjectId(), name: "Italian", slug: "italian" },
+    author: { _id: createObjectId(), name: "Chef", email: "chef@test.com" },
+    isFavorited: false,
+    ...overrides,
+  };
+}
+
 export function createCommentDoc(
   overrides: Partial<CommentDocument> = {},
 ): CommentDocument {
@@ -193,8 +209,8 @@ export function createMockFavoriteModel(overrides: Record<string, Mock> = {}) {
 /**
  * Creates a new initiator.
  *
- * @param id - The initiator's ID.
- * @param role - The initiator's role.
+ * @param id - The initiator's ID. If not provided, a new ID will be generated.
+ * @param role - The initiator's role. Defaults to "user".
  * @returns A new initiator.
  */
 export function initiator(id?: string, role: UserRole = "user") {
@@ -202,6 +218,15 @@ export function initiator(id?: string, role: UserRole = "user") {
     id: id ?? createObjectId().toString(),
     role,
   };
+}
+
+/**
+ * Creates a new initiator without an ID or role.
+ *
+ * @returns A new initiator.
+ */
+export function noInitiator() {
+  return { id: undefined, role: undefined };
 }
 
 /**

--- a/apps/backend/src/modules/auth/auth.service.test.ts
+++ b/apps/backend/src/modules/auth/auth.service.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createMockUserModel, createUserDoc } from "@/__tests__/helpers.js";
+import { ConflictError, UnauthorizedError } from "@/common/errors.js";
+import type { UserModelType } from "@/modules/users/user.model.js";
+import { createAuthService } from "./auth.service.js";
+
+const { signToken } = vi.hoisted(() => ({
+  signToken: vi.fn().mockReturnValue("mock-jwt-token"),
+}));
+
+vi.mock("@/common/utils/jwt.js", () => ({ signToken }));
+
+describe("authService", () => {
+  const userModel = createMockUserModel();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("register", () => {
+    it("should register user and return auth response", async () => {
+      userModel.exists.mockResolvedValue(null);
+      const doc = createUserDoc({ email: "new@test.com", name: "New User" });
+      userModel.create.mockResolvedValue({ ...doc, toObject: () => doc });
+
+      const service = createAuthService(userModel as unknown as UserModelType);
+      const result = await service.register({
+        email: "new@test.com",
+        password: "Password123!",
+        name: "New User",
+      });
+
+      expect(userModel.exists).toHaveBeenCalledWith({ email: "new@test.com" });
+      expect(userModel.create).toHaveBeenCalled();
+      expect(signToken).toHaveBeenCalled();
+      expect(result.user.email).toBe("new@test.com");
+      expect(result.token).toBe("mock-jwt-token");
+    });
+
+    it("should throw ConflictError when email already in use", async () => {
+      userModel.exists.mockResolvedValue({ _id: "existing-id" });
+
+      const service = createAuthService(userModel as unknown as UserModelType);
+
+      await expect(
+        service.register({
+          email: "existing@test.com",
+          password: "Password123!",
+          name: "Existing",
+        }),
+      ).rejects.toThrow(ConflictError);
+      await expect(
+        service.register({
+          email: "existing@test.com",
+          password: "Password123!",
+          name: "Existing",
+        }),
+      ).rejects.toThrow("Email already in use");
+    });
+  });
+
+  describe("login", () => {
+    it("should login and return auth response", async () => {
+      const doc = createUserDoc({ email: "user@test.com" });
+      userModel.findOne.mockReturnValue({
+        select: vi.fn().mockResolvedValue({
+          ...doc,
+          toObject: () => doc,
+        }),
+      });
+
+      const service = createAuthService(userModel as unknown as UserModelType);
+      const result = await service.login({
+        email: "user@test.com",
+        password: "correct-password",
+      });
+
+      expect(userModel.findOne).toHaveBeenCalledWith({
+        email: "user@test.com",
+      });
+      expect(result.user.email).toBe("user@test.com");
+      expect(result.token).toBe("mock-jwt-token");
+    });
+
+    it("should throw UnauthorizedError when user not found", async () => {
+      userModel.findOne.mockReturnValue({
+        select: vi.fn().mockResolvedValue(null),
+      });
+
+      const service = createAuthService(userModel as unknown as UserModelType);
+
+      await expect(
+        service.login({ email: "nobody@test.com", password: "pass" }),
+      ).rejects.toThrow(UnauthorizedError);
+      await expect(
+        service.login({ email: "nobody@test.com", password: "pass" }),
+      ).rejects.toThrow("Invalid email or password");
+    });
+
+    it("should throw UnauthorizedError when password is wrong", async () => {
+      const doc = createUserDoc({
+        email: "user@test.com",
+        comparePassword: vi.fn().mockResolvedValue(false),
+      });
+      userModel.findOne.mockReturnValue({
+        select: vi.fn().mockResolvedValue({
+          ...doc,
+          toObject: () => doc,
+        }),
+      });
+
+      const service = createAuthService(userModel as unknown as UserModelType);
+
+      await expect(
+        service.login({ email: "user@test.com", password: "wrong" }),
+      ).rejects.toThrow(UnauthorizedError);
+    });
+  });
+});

--- a/apps/backend/src/modules/auth/auth.service.test.ts
+++ b/apps/backend/src/modules/auth/auth.service.test.ts
@@ -12,6 +12,7 @@ vi.mock("@/common/utils/jwt.js", () => ({ signToken }));
 
 describe("authService", () => {
   const userModel = createMockUserModel();
+  const service = createAuthService(userModel as unknown as UserModelType);
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -23,7 +24,6 @@ describe("authService", () => {
       const doc = createUserDoc({ email: "new@test.com", name: "New User" });
       userModel.create.mockResolvedValue({ ...doc, toObject: () => doc });
 
-      const service = createAuthService(userModel as unknown as UserModelType);
       const result = await service.register({
         email: "new@test.com",
         password: "Password123!",
@@ -39,8 +39,6 @@ describe("authService", () => {
 
     it("should throw ConflictError when email already in use", async () => {
       userModel.exists.mockResolvedValue({ _id: "existing-id" });
-
-      const service = createAuthService(userModel as unknown as UserModelType);
 
       await expect(
         service.register({
@@ -69,7 +67,6 @@ describe("authService", () => {
         }),
       });
 
-      const service = createAuthService(userModel as unknown as UserModelType);
       const result = await service.login({
         email: "user@test.com",
         password: "correct-password",
@@ -86,8 +83,6 @@ describe("authService", () => {
       userModel.findOne.mockReturnValue({
         select: vi.fn().mockResolvedValue(null),
       });
-
-      const service = createAuthService(userModel as unknown as UserModelType);
 
       await expect(
         service.login({ email: "nobody@test.com", password: "pass" }),
@@ -108,8 +103,6 @@ describe("authService", () => {
           toObject: () => doc,
         }),
       });
-
-      const service = createAuthService(userModel as unknown as UserModelType);
 
       await expect(
         service.login({ email: "user@test.com", password: "wrong" }),

--- a/apps/backend/src/modules/categories/category.service.test.ts
+++ b/apps/backend/src/modules/categories/category.service.test.ts
@@ -14,6 +14,10 @@ import type { RecipeModelType } from "@/modules/recipes/index.js";
 describe("categoryService", () => {
   const categoryModel = createMockCategoryModel();
   const recipeModel = createMockRecipeModel();
+  const service = createCategoryService(
+    categoryModel as unknown as CategoryModelType,
+    recipeModel as unknown as RecipeModelType,
+  );
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -31,10 +35,6 @@ describe("categoryService", () => {
         }),
       });
 
-      const service = createCategoryService(
-        categoryModel as unknown as CategoryModelType,
-        recipeModel as unknown as RecipeModelType,
-      );
       const result = await service.findAll();
 
       expect(categoryModel.find).toHaveBeenCalled();
@@ -49,10 +49,6 @@ describe("categoryService", () => {
         }),
       });
 
-      const service = createCategoryService(
-        categoryModel as unknown as CategoryModelType,
-        recipeModel as unknown as RecipeModelType,
-      );
       const result = await service.findAll();
 
       expect(result).toEqual([]);
@@ -67,10 +63,6 @@ describe("categoryService", () => {
       });
       categoryModel.create.mockResolvedValue({ toObject: () => doc });
 
-      const service = createCategoryService(
-        categoryModel as unknown as CategoryModelType,
-        recipeModel as unknown as RecipeModelType,
-      );
       const result = await service.create({
         data: { name: "New Category" },
         initiator: initiator(),
@@ -90,10 +82,6 @@ describe("categoryService", () => {
       categoryModel.findByIdAndDelete.mockResolvedValue(createCategoryDoc());
 
       const id = createObjectId().toString();
-      const service = createCategoryService(
-        categoryModel as unknown as CategoryModelType,
-        recipeModel as unknown as RecipeModelType,
-      );
       await service.deleteById(id, { initiator: initiator() });
 
       expect(recipeModel.countDocuments).toHaveBeenCalledWith({ category: id });
@@ -102,11 +90,6 @@ describe("categoryService", () => {
 
     it("should throw ConflictError when recipes exist", async () => {
       recipeModel.countDocuments.mockResolvedValue(3);
-
-      const service = createCategoryService(
-        categoryModel as unknown as CategoryModelType,
-        recipeModel as unknown as RecipeModelType,
-      );
 
       await expect(
         service.deleteById(createObjectId().toString(), {
@@ -118,11 +101,6 @@ describe("categoryService", () => {
     it("should throw NotFoundError when category not found", async () => {
       recipeModel.countDocuments.mockResolvedValue(0);
       categoryModel.findByIdAndDelete.mockResolvedValue(null);
-
-      const service = createCategoryService(
-        categoryModel as unknown as CategoryModelType,
-        recipeModel as unknown as RecipeModelType,
-      );
 
       await expect(
         service.deleteById(createObjectId().toString(), {

--- a/apps/backend/src/modules/categories/category.service.test.ts
+++ b/apps/backend/src/modules/categories/category.service.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createCategoryDoc,
+  createMockCategoryModel,
+  createMockRecipeModel,
+  createObjectId,
+  initiator,
+} from "@/__tests__/helpers.js";
+import { ConflictError, NotFoundError } from "@/common/errors.js";
+import type { CategoryModelType } from "@/modules/categories/category.model.js";
+import { createCategoryService } from "@/modules/categories/category.service.js";
+import type { RecipeModelType } from "@/modules/recipes/index.js";
+
+describe("categoryService", () => {
+  const categoryModel = createMockCategoryModel();
+  const recipeModel = createMockRecipeModel();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("findAll", () => {
+    it("should return all categories sorted by name", async () => {
+      const docs = [
+        createCategoryDoc({ name: "Desserts", slug: "desserts" }),
+        createCategoryDoc({ name: "Soups", slug: "soups" }),
+      ];
+      categoryModel.find.mockReturnValue({
+        sort: vi.fn().mockReturnValue({
+          lean: vi.fn().mockResolvedValue(docs),
+        }),
+      });
+
+      const service = createCategoryService(
+        categoryModel as unknown as CategoryModelType,
+        recipeModel as unknown as RecipeModelType,
+      );
+      const result = await service.findAll();
+
+      expect(categoryModel.find).toHaveBeenCalled();
+      expect(result).toHaveLength(2);
+      expect(result[0]?.name).toBe("Desserts");
+    });
+
+    it("should return empty array when no categories exist", async () => {
+      categoryModel.find.mockReturnValue({
+        sort: vi.fn().mockReturnValue({
+          lean: vi.fn().mockResolvedValue([]),
+        }),
+      });
+
+      const service = createCategoryService(
+        categoryModel as unknown as CategoryModelType,
+        recipeModel as unknown as RecipeModelType,
+      );
+      const result = await service.findAll();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("create", () => {
+    it("should create and return a category", async () => {
+      const doc = createCategoryDoc({
+        name: "New Category",
+        slug: "new-category",
+      });
+      categoryModel.create.mockResolvedValue({ toObject: () => doc });
+
+      const service = createCategoryService(
+        categoryModel as unknown as CategoryModelType,
+        recipeModel as unknown as RecipeModelType,
+      );
+      const result = await service.create({
+        data: { name: "New Category" },
+        initiator: initiator(),
+      });
+
+      expect(categoryModel.create).toHaveBeenCalledWith({
+        name: "New Category",
+      });
+      expect(result.name).toBe("New Category");
+      expect(result.slug).toBe("new-category");
+    });
+  });
+
+  describe("deleteById", () => {
+    it("should delete category when no recipes exist", async () => {
+      recipeModel.countDocuments.mockResolvedValue(0);
+      categoryModel.findByIdAndDelete.mockResolvedValue(createCategoryDoc());
+
+      const id = createObjectId().toString();
+      const service = createCategoryService(
+        categoryModel as unknown as CategoryModelType,
+        recipeModel as unknown as RecipeModelType,
+      );
+      await service.deleteById(id, { initiator: initiator() });
+
+      expect(recipeModel.countDocuments).toHaveBeenCalledWith({ category: id });
+      expect(categoryModel.findByIdAndDelete).toHaveBeenCalledWith(id);
+    });
+
+    it("should throw ConflictError when recipes exist", async () => {
+      recipeModel.countDocuments.mockResolvedValue(3);
+
+      const service = createCategoryService(
+        categoryModel as unknown as CategoryModelType,
+        recipeModel as unknown as RecipeModelType,
+      );
+
+      await expect(
+        service.deleteById(createObjectId().toString(), {
+          initiator: initiator(),
+        }),
+      ).rejects.toThrow(ConflictError);
+    });
+
+    it("should throw NotFoundError when category not found", async () => {
+      recipeModel.countDocuments.mockResolvedValue(0);
+      categoryModel.findByIdAndDelete.mockResolvedValue(null);
+
+      const service = createCategoryService(
+        categoryModel as unknown as CategoryModelType,
+        recipeModel as unknown as RecipeModelType,
+      );
+
+      await expect(
+        service.deleteById(createObjectId().toString(), {
+          initiator: initiator(),
+        }),
+      ).rejects.toThrow(NotFoundError);
+    });
+  });
+});

--- a/apps/backend/src/modules/comments/comment.service.test.ts
+++ b/apps/backend/src/modules/comments/comment.service.test.ts
@@ -1,0 +1,252 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createCommentDoc,
+  createMockCommentModel,
+  createMockRecipeModel,
+  createMockUserModel,
+  createObjectId,
+  initiator,
+  queryParams,
+} from "@/__tests__/helpers.js";
+import {
+  BadRequestError,
+  ForbiddenError,
+  NotFoundError,
+} from "@/common/errors.js";
+import type { CommentModelType } from "@/modules/comments/comment.model.js";
+import { createCommentService } from "@/modules/comments/comment.service.js";
+import type { RecipeModelType } from "@/modules/recipes/index.js";
+import type { UserModelType } from "@/modules/users/index.js";
+
+describe("commentService", () => {
+  const commentModel = createMockCommentModel();
+  const recipeModel = createMockRecipeModel();
+  const userModel = createMockUserModel();
+  const service = createCommentService(
+    commentModel as unknown as CommentModelType,
+    recipeModel as unknown as RecipeModelType,
+    userModel as unknown as UserModelType,
+  );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("findByRecipe", () => {
+    it("should return paginated comments for recipe", async () => {
+      recipeModel.exists.mockResolvedValue(true);
+      const authorId = createObjectId();
+      const recipeId = createObjectId();
+      const populatedComment = {
+        _id: createObjectId(),
+        text: "Nice!",
+        author: { _id: authorId, name: "User", email: "user@test.com" },
+        recipe: { _id: recipeId, title: "Pasta" },
+        createdAt: new Date("2024-01-01"),
+        updatedAt: new Date("2024-01-01"),
+      };
+      commentModel.findFull.mockResolvedValue([[populatedComment], 1]);
+
+      const result = await service.findByRecipe(
+        recipeId.toString(),
+        queryParams(),
+      );
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]?.text).toBe("Nice!");
+      expect(result.pagination.total).toBe(1);
+    });
+
+    it("should throw BadRequestError for invalid recipe ID", async () => {
+      await expect(
+        service.findByRecipe("invalid-id", queryParams()),
+      ).rejects.toThrow(BadRequestError);
+    });
+
+    it("should throw NotFoundError when recipe not found", async () => {
+      recipeModel.exists.mockResolvedValue(null);
+
+      await expect(
+        service.findByRecipe(createObjectId().toString(), queryParams()),
+      ).rejects.toThrow(NotFoundError);
+    });
+
+    it("should return empty result when no comments found", async () => {
+      recipeModel.exists.mockResolvedValue(true);
+      commentModel.findFull.mockResolvedValue([[], 0]);
+
+      const result = await service.findByRecipe(
+        createObjectId().toString(),
+        queryParams(),
+      );
+
+      expect(result.items).toEqual([]);
+    });
+  });
+
+  describe("findByAuthor", () => {
+    it("should return paginated comments by author", async () => {
+      const authorId = createObjectId();
+      const populatedComment = {
+        _id: createObjectId(),
+        text: "Great!",
+        author: { _id: authorId, name: "User", email: "user@test.com" },
+        recipe: { _id: createObjectId(), title: "Pasta" },
+        createdAt: new Date("2024-01-01"),
+        updatedAt: new Date("2024-01-01"),
+      };
+      commentModel.findFull.mockResolvedValue([[populatedComment], 1]);
+
+      const result = await service.findByAuthor(
+        authorId.toString(),
+        queryParams(),
+      );
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]?.recipe.title).toBe("Pasta");
+    });
+
+    it("should throw BadRequestError for invalid author ID", async () => {
+      await expect(
+        service.findByAuthor("invalid-id", queryParams()),
+      ).rejects.toThrow(BadRequestError);
+    });
+  });
+
+  describe("create", () => {
+    it("should create a comment and return populated DTO", async () => {
+      recipeModel.exists.mockResolvedValue(true);
+      userModel.exists.mockResolvedValue(true);
+
+      const authorId = createObjectId();
+      const commentDoc = createCommentDoc({ text: "Great recipe!" });
+      const populated = {
+        ...commentDoc,
+        author: { _id: authorId, name: "User", email: "user@test.com" },
+      };
+      commentModel.create.mockResolvedValue({
+        ...commentDoc,
+        populate: vi.fn().mockResolvedValue({
+          toObject: () => populated,
+        }),
+      });
+
+      const recipeId = createObjectId().toString();
+      const init = initiator(authorId.toString());
+      const result = await service.create(recipeId, {
+        data: { text: "Great recipe!" },
+        initiator: init,
+      });
+
+      expect(commentModel.create).toHaveBeenCalledWith({
+        text: "Great recipe!",
+        recipe: recipeId,
+        author: init.id,
+      });
+      expect(result.text).toBe("Great recipe!");
+    });
+
+    it("should throw BadRequestError for invalid recipe ID", async () => {
+      await expect(
+        service.create("invalid-id", {
+          data: { text: "Hi" },
+          initiator: initiator(),
+        }),
+      ).rejects.toThrow(BadRequestError);
+    });
+
+    it("should throw BadRequestError for invalid author ID", async () => {
+      await expect(
+        service.create(createObjectId().toString(), {
+          data: { text: "Hi" },
+          initiator: { id: "invalid", role: "user" },
+        }),
+      ).rejects.toThrow(BadRequestError);
+    });
+
+    it("should throw NotFoundError when recipe not found", async () => {
+      recipeModel.exists.mockResolvedValue(null);
+
+      await expect(
+        service.create(createObjectId().toString(), {
+          data: { text: "Hi" },
+          initiator: initiator(),
+        }),
+      ).rejects.toThrow(NotFoundError);
+    });
+
+    it("should throw NotFoundError when author not found", async () => {
+      recipeModel.exists.mockResolvedValue(true);
+      userModel.exists.mockResolvedValue(null);
+
+      await expect(
+        service.create(createObjectId().toString(), {
+          data: { text: "Hi" },
+          initiator: initiator(),
+        }),
+      ).rejects.toThrow(NotFoundError);
+    });
+  });
+
+  describe("delete", () => {
+    it("should delete comment when author matches", async () => {
+      const authorId = createObjectId();
+      const comment = {
+        ...createCommentDoc(),
+        author: authorId,
+        deleteOne: vi.fn().mockResolvedValue(undefined),
+      };
+      commentModel.findById.mockResolvedValue(comment);
+
+      await service.delete(createObjectId().toString(), {
+        initiator: initiator(authorId.toString()),
+      });
+
+      expect(comment.deleteOne).toHaveBeenCalled();
+    });
+
+    it("should delete comment when user is admin", async () => {
+      const comment = {
+        ...createCommentDoc(),
+        deleteOne: vi.fn().mockResolvedValue(undefined),
+      };
+      commentModel.findById.mockResolvedValue(comment);
+
+      await service.delete(createObjectId().toString(), {
+        initiator: initiator(createObjectId().toString(), "admin"),
+      });
+
+      expect(comment.deleteOne).toHaveBeenCalled();
+    });
+
+    it("should throw BadRequestError for invalid comment ID", async () => {
+      await expect(
+        service.delete("invalid-id", { initiator: initiator() }),
+      ).rejects.toThrow(BadRequestError);
+    });
+
+    it("should throw NotFoundError when comment not found", async () => {
+      commentModel.findById.mockResolvedValue(null);
+
+      await expect(
+        service.delete(createObjectId().toString(), {
+          initiator: initiator(),
+        }),
+      ).rejects.toThrow(NotFoundError);
+    });
+
+    it("should throw ForbiddenError when not author and not admin", async () => {
+      const comment = {
+        ...createCommentDoc(),
+        deleteOne: vi.fn(),
+      };
+      commentModel.findById.mockResolvedValue(comment);
+
+      await expect(
+        service.delete(createObjectId().toString(), {
+          initiator: initiator(),
+        }),
+      ).rejects.toThrow(ForbiddenError);
+    });
+  });
+});

--- a/apps/backend/src/modules/favorites/favorite.service.test.ts
+++ b/apps/backend/src/modules/favorites/favorite.service.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createMockFavoriteModel,
+  createMockRecipeModel,
+  createMockUserModel,
+  createObjectId,
+  createRecipeDoc,
+  initiator,
+  queryParams,
+} from "@/__tests__/helpers.js";
+import { BadRequestError, NotFoundError } from "@/common/errors.js";
+import type { FavoriteModelType } from "@/modules/favorites/favorite.model.js";
+import { createFavoriteService } from "@/modules/favorites/favorite.service.js";
+import type {
+  RecipeDocumentPopulated,
+  RecipeModelType,
+} from "@/modules/recipes/recipe.model.js";
+import type { UserModelType } from "@/modules/users/user.model.js";
+
+describe("favoriteService", () => {
+  const favoriteModel = createMockFavoriteModel();
+  const recipeModel = createMockRecipeModel();
+  const userModel = createMockUserModel();
+
+  const service = createFavoriteService(
+    favoriteModel as unknown as FavoriteModelType,
+    recipeModel as unknown as RecipeModelType,
+    userModel as unknown as UserModelType,
+  );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("add", () => {
+    it("should add a favorite and return favorited: true", async () => {
+      userModel.exists.mockResolvedValue(true);
+      recipeModel.exists.mockResolvedValue(true);
+
+      const init = initiator();
+      const recipeId = createObjectId().toString();
+      const result = await service.add(recipeId, { initiator: init });
+
+      expect(result).toEqual({ favorited: true });
+      expect(favoriteModel.create).toHaveBeenCalledWith({
+        user: init.id,
+        recipe: recipeId,
+      });
+    });
+
+    it("should throw BadRequestError for invalid user ID", async () => {
+      await expect(
+        service.add(createObjectId().toString(), {
+          initiator: { id: "invalid-id", role: "user" },
+        }),
+      ).rejects.toThrow(BadRequestError);
+    });
+
+    it("should throw BadRequestError for invalid recipe ID", async () => {
+      userModel.exists.mockResolvedValue(true);
+
+      await expect(
+        service.add("invalid-id", { initiator: initiator() }),
+      ).rejects.toThrow(BadRequestError);
+    });
+
+    it("should throw NotFoundError when user does not exist", async () => {
+      userModel.exists.mockResolvedValue(false);
+      recipeModel.exists.mockResolvedValue(true);
+
+      await expect(
+        service.add(createObjectId().toString(), { initiator: initiator() }),
+      ).rejects.toThrow(NotFoundError);
+    });
+
+    it("should throw NotFoundError when recipe does not exist", async () => {
+      userModel.exists.mockResolvedValue(true);
+      recipeModel.exists.mockResolvedValue(false);
+
+      await expect(
+        service.add(createObjectId().toString(), { initiator: initiator() }),
+      ).rejects.toThrow(NotFoundError);
+    });
+  });
+
+  describe("remove", () => {
+    it("should remove a favorite and return favorited: false", async () => {
+      userModel.exists.mockResolvedValue(true);
+      recipeModel.exists.mockResolvedValue(true);
+
+      const init = initiator();
+      const recipeId = createObjectId().toString();
+      const result = await service.remove(recipeId, { initiator: init });
+
+      expect(result).toEqual({ favorited: false });
+      expect(favoriteModel.findOneAndDelete).toHaveBeenCalledWith({
+        user: init.id,
+        recipe: recipeId,
+      });
+    });
+  });
+
+  describe("isFavorited", () => {
+    it("should return true when favorite exists", async () => {
+      favoriteModel.exists.mockResolvedValue({ _id: "some-id" });
+
+      const result = await service.isFavorited(createObjectId().toString(), {
+        initiator: initiator(),
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it("should return false when favorite does not exist", async () => {
+      favoriteModel.exists.mockResolvedValue(null);
+
+      const result = await service.isFavorited(createObjectId().toString(), {
+        initiator: initiator(),
+      });
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("findByUser", () => {
+    it("should return paginated recipes from favorites", async () => {
+      userModel.exists.mockResolvedValue(true);
+      const recipe = {
+        ...createRecipeDoc(),
+        category: { _id: createObjectId(), name: "Cat", slug: "cat" },
+        author: { _id: createObjectId(), name: "Author", email: "a@b.c" },
+        isFavorited: true,
+      } satisfies RecipeDocumentPopulated;
+      favoriteModel.findByUser.mockResolvedValue([[{ recipe }], 1]);
+
+      const result = await service.findByUser(
+        createObjectId().toString(),
+        queryParams(),
+      );
+
+      expect(result.items).toHaveLength(1);
+      expect(result.pagination.total).toBe(1);
+    });
+
+    it("should return empty paginated result when no favorites", async () => {
+      userModel.exists.mockResolvedValue(true);
+      favoriteModel.findByUser.mockResolvedValue([null, 0]);
+
+      const result = await service.findByUser(
+        createObjectId().toString(),
+        queryParams(),
+      );
+
+      expect(result.items).toEqual([]);
+      expect(result.pagination.total).toBe(0);
+    });
+  });
+});

--- a/apps/backend/src/modules/recipes/recipe.service.test.ts
+++ b/apps/backend/src/modules/recipes/recipe.service.test.ts
@@ -1,0 +1,337 @@
+import type { Minutes } from "@recipes/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createMockCategoryModel,
+  createMockFavoriteModel,
+  createMockRecipeModel,
+  createMockUserModel,
+  createObjectId,
+  createRecipeDoc,
+  initiator,
+  noInitiator,
+  populateRecipeDoc,
+} from "@/__tests__/helpers.js";
+import {
+  BadRequestError,
+  ForbiddenError,
+  NotFoundError,
+} from "@/common/errors.js";
+import type { CategoryModelType } from "@/modules/categories/category.model.js";
+import type { FavoriteModelType } from "@/modules/favorites/favorite.model.js";
+import type { RecipeModelType } from "@/modules/recipes/recipe.model.js";
+import { createRecipeService } from "@/modules/recipes/recipe.service.js";
+import type { UserModelType } from "@/modules/users/user.model.js";
+
+describe("recipeService", () => {
+  const recipeModel = createMockRecipeModel();
+  const userModel = createMockUserModel();
+  const favoriteModel = createMockFavoriteModel();
+  const categoryModel = createMockCategoryModel();
+  const service = createRecipeService(
+    recipeModel as unknown as RecipeModelType,
+    userModel as unknown as UserModelType,
+    favoriteModel as unknown as FavoriteModelType,
+    categoryModel as unknown as CategoryModelType,
+  );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("findAll", () => {
+    it("should return paginated recipes", async () => {
+      const populated = populateRecipeDoc(createRecipeDoc());
+      recipeModel.searchFull.mockResolvedValue([[populated], 1]);
+
+      const result = await service.findAll({
+        query: { page: 1, limit: 10, sort: "-createdAt" },
+        initiator: noInitiator(),
+      });
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]?.title).toBe("Test Recipe");
+      expect(result.pagination.total).toBe(1);
+    });
+
+    it("should return empty when searchFull returns null", async () => {
+      recipeModel.searchFull.mockResolvedValue([null, 0]);
+
+      const result = await service.findAll({
+        query: { page: 1, limit: 10, sort: "-createdAt" },
+        initiator: noInitiator(),
+      });
+
+      expect(result.items).toEqual([]);
+    });
+
+    it("should return empty when isFavorited filter is set but no initiator", async () => {
+      const result = await service.findAll({
+        query: { page: 1, limit: 10, sort: "-createdAt", isFavorited: true },
+        initiator: noInitiator(),
+      });
+
+      expect(result.items).toEqual([]);
+      expect(recipeModel.searchFull).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("findById", () => {
+    it("should return recipe by ID", async () => {
+      const populated = populateRecipeDoc(createRecipeDoc());
+      recipeModel.findByIdFull.mockResolvedValue(populated);
+
+      const result = await service.findById(createObjectId().toString(), {
+        initiator: noInitiator(),
+      });
+
+      expect(result.title).toBe("Test Recipe");
+    });
+
+    it("should throw BadRequestError for invalid ID", async () => {
+      await expect(
+        service.findById("invalid-id", {
+          initiator: noInitiator(),
+        }),
+      ).rejects.toThrow(BadRequestError);
+    });
+
+    it("should throw NotFoundError when recipe not found", async () => {
+      recipeModel.findByIdFull.mockResolvedValue(null);
+
+      await expect(
+        service.findById(createObjectId().toString(), {
+          initiator: noInitiator(),
+        }),
+      ).rejects.toThrow(NotFoundError);
+    });
+  });
+
+  describe("create", () => {
+    const createData = {
+      title: "New Recipe",
+      description: "A new recipe",
+      ingredients: [{ name: "Flour", quantity: 100, unit: "g" }],
+      instructions: ["Mix"],
+      difficulty: "easy" as const,
+      cookingTime: 20 as Minutes,
+      servings: 2,
+      isPublic: true,
+    };
+
+    it("should create and return a recipe", async () => {
+      categoryModel.exists.mockResolvedValue(true);
+      userModel.exists.mockResolvedValue(true);
+
+      const authorId = createObjectId();
+      const categoryId = createObjectId();
+      const doc = createRecipeDoc({ title: "New Recipe" });
+      const populated = populateRecipeDoc(doc, {
+        author: { _id: authorId, name: "Chef", email: "chef@test.com" },
+        category: { _id: categoryId, name: "Italian", slug: "italian" },
+      });
+
+      recipeModel.create.mockResolvedValue({
+        ...doc,
+        populate: vi.fn().mockResolvedValue({
+          toObject: () => populated,
+        }),
+      });
+
+      const result = await service.create({
+        data: { ...createData, category: categoryId.toString() },
+        initiator: initiator(authorId.toString()),
+      });
+
+      expect(recipeModel.create).toHaveBeenCalled();
+      expect(result.title).toBe("New Recipe");
+    });
+
+    it("should throw BadRequestError for invalid author ID", async () => {
+      await expect(
+        service.create({
+          data: { ...createData, category: createObjectId().toString() },
+          initiator: { id: "invalid", role: "user" },
+        }),
+      ).rejects.toThrow(BadRequestError);
+    });
+
+    it("should throw BadRequestError for invalid category ID", async () => {
+      await expect(
+        service.create({
+          data: { ...createData, category: "invalid" },
+          initiator: initiator(),
+        }),
+      ).rejects.toThrow(BadRequestError);
+    });
+
+    it("should throw NotFoundError when category not found", async () => {
+      categoryModel.exists.mockResolvedValue(null);
+
+      await expect(
+        service.create({
+          data: { ...createData, category: createObjectId().toString() },
+          initiator: initiator(),
+        }),
+      ).rejects.toThrow(NotFoundError);
+    });
+
+    it("should throw NotFoundError when author not found", async () => {
+      categoryModel.exists.mockResolvedValue(true);
+      userModel.exists.mockResolvedValue(null);
+
+      await expect(
+        service.create({
+          data: { ...createData, category: createObjectId().toString() },
+          initiator: initiator(),
+        }),
+      ).rejects.toThrow(NotFoundError);
+    });
+  });
+
+  describe("update", () => {
+    it("should update recipe when author matches", async () => {
+      const authorId = createObjectId();
+      const doc = createRecipeDoc({ author: authorId });
+      const recipe = {
+        ...doc,
+        save: vi.fn().mockResolvedValue(undefined),
+        populate: vi.fn().mockResolvedValue({
+          toObject: () => populateRecipeDoc(doc, { title: "Updated" }),
+        }),
+      };
+      recipeModel.findById.mockResolvedValue(recipe);
+      favoriteModel.findOne.mockReturnValue({
+        lean: vi.fn().mockResolvedValue(null),
+      });
+
+      const result = await service.update(createObjectId().toString(), {
+        data: { title: "Updated" },
+        initiator: initiator(authorId.toString()),
+      });
+
+      expect(recipe.save).toHaveBeenCalled();
+      expect(result.title).toBe("Updated");
+    });
+
+    it("should update recipe when user is admin", async () => {
+      const authorId = createObjectId();
+      const doc = createRecipeDoc({ author: authorId });
+      const recipe = {
+        ...doc,
+        save: vi.fn().mockResolvedValue(undefined),
+        populate: vi.fn().mockResolvedValue({
+          toObject: () => populateRecipeDoc(doc, { title: "Updated" }),
+        }),
+      };
+      recipeModel.findById.mockResolvedValue(recipe);
+      favoriteModel.findOne.mockReturnValue({
+        lean: vi.fn().mockResolvedValue(null),
+      });
+
+      await expect(
+        service.update(createObjectId().toString(), {
+          data: { title: "Updated" },
+          initiator: initiator(createObjectId().toString(), "admin"),
+        }),
+      ).resolves.toBeDefined();
+    });
+
+    it("should throw BadRequestError for invalid ID", async () => {
+      await expect(
+        service.update("invalid-id", {
+          data: {},
+          initiator: initiator(),
+        }),
+      ).rejects.toThrow(BadRequestError);
+    });
+
+    it("should throw NotFoundError when recipe not found", async () => {
+      recipeModel.findById.mockResolvedValue(null);
+
+      await expect(
+        service.update(createObjectId().toString(), {
+          data: {},
+          initiator: initiator(),
+        }),
+      ).rejects.toThrow(NotFoundError);
+    });
+
+    it("should throw ForbiddenError when not author and not admin", async () => {
+      const recipe = createRecipeDoc();
+      recipeModel.findById.mockResolvedValue(recipe);
+
+      await expect(
+        service.update(recipe._id.toString(), {
+          data: {},
+          initiator: initiator(createObjectId().toString()),
+        }),
+      ).rejects.toThrow(ForbiddenError);
+    });
+  });
+
+  describe("delete", () => {
+    it("should delete recipe when author matches", async () => {
+      const authorId = createObjectId();
+      recipeModel.findById.mockReturnValue({
+        select: vi.fn().mockResolvedValue({
+          author: { equals: (id: string) => id === authorId.toString() },
+          deleteOne: vi.fn().mockResolvedValue(undefined),
+        }),
+      });
+
+      await expect(
+        service.delete(createObjectId().toString(), {
+          initiator: initiator(authorId.toString()),
+        }),
+      ).resolves.toBeUndefined();
+    });
+
+    it("should delete recipe when user is admin", async () => {
+      recipeModel.findById.mockReturnValue({
+        select: vi.fn().mockResolvedValue({
+          author: { equals: () => false },
+          deleteOne: vi.fn().mockResolvedValue(undefined),
+        }),
+      });
+
+      await expect(
+        service.delete(createObjectId().toString(), {
+          initiator: initiator(createObjectId().toString(), "admin"),
+        }),
+      ).resolves.toBeUndefined();
+    });
+
+    it("should throw BadRequestError for invalid ID", async () => {
+      await expect(
+        service.delete("invalid-id", { initiator: initiator() }),
+      ).rejects.toThrow(BadRequestError);
+    });
+
+    it("should throw NotFoundError when recipe not found", async () => {
+      recipeModel.findById.mockReturnValue({
+        select: vi.fn().mockResolvedValue(null),
+      });
+
+      await expect(
+        service.delete(createObjectId().toString(), {
+          initiator: initiator(),
+        }),
+      ).rejects.toThrow(NotFoundError);
+    });
+
+    it("should throw ForbiddenError when not author and not admin", async () => {
+      recipeModel.findById.mockReturnValue({
+        select: vi.fn().mockResolvedValue({
+          author: { equals: () => false },
+          deleteOne: vi.fn(),
+        }),
+      });
+
+      await expect(
+        service.delete(createObjectId().toString(), {
+          initiator: initiator(createObjectId().toString(), "user"),
+        }),
+      ).rejects.toThrow(ForbiddenError);
+    });
+  });
+});

--- a/apps/backend/src/modules/users/user.service.test.ts
+++ b/apps/backend/src/modules/users/user.service.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createMockUserModel,
+  createObjectId,
+  createUserDoc,
+  queryParams,
+} from "@/__tests__/helpers.js";
+import { NotFoundError } from "@/common/errors.js";
+import type { CommentService } from "@/modules/comments/comment.service.js";
+import type { FavoriteService } from "@/modules/favorites/favorite.service.js";
+import type { UserModelType } from "@/modules/users/user.model.js";
+import { createUserService } from "@/modules/users/user.service.js";
+
+describe("userService", () => {
+  const userModel = createMockUserModel();
+  const commentService = {
+    findByAuthor: vi.fn(),
+    findByRecipe: vi.fn(),
+    create: vi.fn(),
+    delete: vi.fn(),
+  };
+  const favoriteService = {
+    findByUser: vi.fn(),
+    add: vi.fn(),
+    remove: vi.fn(),
+    isFavorited: vi.fn(),
+  };
+  const service = createUserService(
+    commentService as unknown as CommentService,
+    favoriteService as unknown as FavoriteService,
+    userModel as unknown as UserModelType,
+  );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("getCurrentUser", () => {
+    it("should return user by ID", async () => {
+      const doc = createUserDoc({ email: "user@test.com", name: "Test" });
+      const lean = vi.fn().mockResolvedValue(doc);
+      userModel.findById.mockReturnValue({ lean });
+
+      const result = await service.getCurrentUser(createObjectId().toString());
+
+      expect(result.email).toBe("user@test.com");
+      expect(result.name).toBe("Test");
+      expect(result).not.toHaveProperty("password");
+    });
+
+    it("should throw NotFoundError when user not found", async () => {
+      userModel.findById.mockReturnValue({
+        lean: vi.fn().mockResolvedValue(null),
+      });
+
+      await expect(
+        service.getCurrentUser(createObjectId().toString()),
+      ).rejects.toThrow(NotFoundError);
+    });
+  });
+
+  describe("getFavorites", () => {
+    it("should delegate to favoriteService.findByUser", async () => {
+      const expected = {
+        items: [],
+        pagination: {
+          page: 1,
+          limit: 10,
+          total: 0,
+          totalPages: 0,
+          hasNext: false,
+          hasPrev: false,
+        },
+      };
+      favoriteService.findByUser.mockResolvedValue(expected);
+
+      const result = await service.getFavorites(
+        createObjectId().toString(),
+        queryParams(),
+      );
+
+      expect(favoriteService.findByUser).toHaveBeenCalled();
+      expect(result).toBe(expected);
+    });
+  });
+
+  describe("getComments", () => {
+    it("should delegate to commentService.findByAuthor", async () => {
+      const expected = {
+        items: [],
+        pagination: {
+          page: 1,
+          limit: 10,
+          total: 0,
+          totalPages: 0,
+          hasNext: false,
+          hasPrev: false,
+        },
+      };
+      commentService.findByAuthor.mockResolvedValue(expected);
+
+      const result = await service.getComments(
+        createObjectId().toString(),
+        queryParams(),
+      );
+
+      expect(commentService.findByAuthor).toHaveBeenCalled();
+      expect(result).toBe(expected);
+    });
+  });
+});

--- a/apps/backend/vitest.config.ts
+++ b/apps/backend/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     include: ["src/**/*.test.ts"],
     coverage: {
       provider: "v8",
+      reporter: ["text", "json", "html", "lcov"],
     },
     alias: {
       "@/": new URL("./src/", import.meta.url).pathname,


### PR DESCRIPTION
## Related Issues

<!-- Link related issues: Closes #123, Refs #456 -->

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [x] Tests
- [ ] Other

## Description

Added unit tests for all 6 service modules (62 new tests):

- `category.service.test.ts` — `findAll`, `create`, `deleteById` (success, ConflictError, NotFoundError)
- `favorite.service.test.ts` — `add`, `remove`, `isFavorited`, `findByUser` with validation (BadRequestError, NotFoundError)
- `user.service.test.ts` — `getCurrentUser` (success, NotFound), delegation to `favoriteService.findByUser` and `commentService.findByAuthor`
- `auth.service.test.ts` — `register` (success, ConflictError), `login` (success, not found, wrong password)
- `comment.service.test.ts` — `findByRecipe`, `findByAuthor`, `create`, `delete` with authorization checks (ForbiddenError)
- `recipe.service.test.ts` — `findAll`, `findById`, `create`, `update`, `delete` with authorization checks

All mocks use `as unknown as ModelType` pattern for type-safe dependency injection.

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes (114 tests total)
- [x] Added/updated tests for new functionality
- [ ] Updated documentation (if needed)