### PR TITLE
feat(cache): add cache service infrastructure

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -30,6 +30,7 @@
     "dotenv": "^16.6.1",
     "fastify": "^5.8.4",
     "fastify-type-provider-zod": "^6.1.0",
+    "ioredis": "^5.10.1",
     "jsonwebtoken": "^9.0.3",
     "lru-cache": "^11.3.3",
     "mongoose": "^9.3.3"

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -31,6 +31,7 @@
     "fastify": "^5.8.4",
     "fastify-type-provider-zod": "^6.1.0",
     "jsonwebtoken": "^9.0.3",
+    "lru-cache": "^11.3.3",
     "mongoose": "^9.3.3"
   },
   "devDependencies": {

--- a/apps/backend/src/common/cache/cache.service.ts
+++ b/apps/backend/src/common/cache/cache.service.ts
@@ -1,0 +1,13 @@
+/**
+ * Cache service interface.
+ *
+ * Cache service is responsible for storing and retrieving data from a cache.
+ * It provides methods for setting, getting, deleting, and flushing cache.
+ */
+export interface CacheService {
+  get<T extends {}>(key: string): Promise<T | undefined>;
+  set<T extends {}>(key: string, value: T, ttlSeconds?: number): Promise<void>;
+  delete(key: string): Promise<void>;
+  deletePattern(pattern: string): Promise<void>;
+  flush(): Promise<void>;
+}

--- a/apps/backend/src/common/cache/create-cache.service.ts
+++ b/apps/backend/src/common/cache/create-cache.service.ts
@@ -1,0 +1,34 @@
+import type { CacheService } from "./cache.service.js";
+import type { MemoryCacheOptions } from "./memory-cache.service.js";
+import { createMemoryCache } from "./memory-cache.service.js";
+import type { RedisCacheOptions } from "./redis-cache.service.js";
+
+export type CacheBackend = "memory" | "redis";
+
+export interface CacheFactoryOptions {
+  backend?: CacheBackend;
+  redis?: RedisCacheOptions;
+  memory?: MemoryCacheOptions;
+}
+
+/**
+ * Creates a new cache service based on the provided options.
+ *
+ * @param options.backend - The cache backend to use. Defaults to "memory".
+ * @param options.redis - Redis cache options. Only used when backend is "redis".
+ * @param options.memory - Memory cache options. Only used when backend is "memory".
+ * @returns A new cache service.
+ */
+export async function createCacheService(
+  options: CacheFactoryOptions = {},
+): Promise<CacheService> {
+  const { backend = "memory" } = options;
+
+  if (backend === "redis") {
+    console.warn(
+      "⚠️  Redis backend is not configured yet, falling back to in-memory cache",
+    );
+  }
+
+  return createMemoryCache(options.memory);
+}

--- a/apps/backend/src/common/cache/create-cache.service.ts
+++ b/apps/backend/src/common/cache/create-cache.service.ts
@@ -2,6 +2,7 @@ import type { CacheService } from "./cache.service.js";
 import type { MemoryCacheOptions } from "./memory-cache.service.js";
 import { createMemoryCache } from "./memory-cache.service.js";
 import type { RedisCacheOptions } from "./redis-cache.service.js";
+import { createRedisCache } from "./redis-cache.service.js";
 
 export type CacheBackend = "memory" | "redis";
 
@@ -11,23 +12,22 @@ export interface CacheFactoryOptions {
   memory?: MemoryCacheOptions;
 }
 
-/**
- * Creates a new cache service based on the provided options.
- *
- * @param options.backend - The cache backend to use. Defaults to "memory".
- * @param options.redis - Redis cache options. Only used when backend is "redis".
- * @param options.memory - Memory cache options. Only used when backend is "memory".
- * @returns A new cache service.
- */
 export async function createCacheService(
   options: CacheFactoryOptions = {},
 ): Promise<CacheService> {
   const { backend = "memory" } = options;
 
-  if (backend === "redis") {
-    console.warn(
-      "⚠️  Redis backend is not configured yet, falling back to in-memory cache",
-    );
+  if (backend === "redis" && options.redis?.url) {
+    try {
+      const cache = createRedisCache(options.redis);
+      console.log("✅ Redis cache connected");
+      return cache;
+    } catch (error) {
+      console.warn(
+        "⚠️  Redis unavailable, falling back to in-memory cache:",
+        error instanceof Error ? error.message : error,
+      );
+    }
   }
 
   return createMemoryCache(options.memory);

--- a/apps/backend/src/common/cache/memory-cache.service.ts
+++ b/apps/backend/src/common/cache/memory-cache.service.ts
@@ -1,0 +1,61 @@
+import { LRUCache } from "lru-cache";
+import type { CacheService } from "./cache.service.js";
+
+export interface MemoryCacheOptions {
+  maxSize?: number;
+  defaultTTL?: number;
+}
+
+/**
+ * Creates a new memory cache service.
+ *
+ * @param options.maxSize - The maximum number of items in the cache. Defaults to 1000.
+ * @param options.defaultTtl - The default TTL for cache items in seconds. Defaults to 300.
+ * @returns A new memory cache service.
+ */
+export function createMemoryCache(
+  options: MemoryCacheOptions = {},
+): CacheService {
+  const { maxSize = 1000, defaultTTL = 300 } = options;
+
+  const cache = new LRUCache<string, NonNullable<unknown>>({
+    max: maxSize,
+    ttl: defaultTTL * 1000,
+    updateAgeOnGet: true,
+  });
+
+  return {
+    async get<T extends {}>(key: string): Promise<T | undefined> {
+      return cache.get(key) as T | undefined;
+    },
+
+    async set<T extends {}>(
+      key: string,
+      value: T,
+      ttlSeconds?: number,
+    ): Promise<void> {
+      cache.set(key, value, {
+        ttl: (ttlSeconds ?? defaultTTL) * 1000,
+      });
+    },
+
+    async delete(key: string): Promise<void> {
+      cache.delete(key);
+    },
+
+    async deletePattern(pattern: string): Promise<void> {
+      const regex = new RegExp(
+        `^${pattern.replace(/\*/g, ".*").replace(/\?/g, ".")}$`,
+      );
+      for (const key of cache.keys()) {
+        if (regex.test(key)) {
+          cache.delete(key);
+        }
+      }
+    },
+
+    async flush(): Promise<void> {
+      cache.clear();
+    },
+  };
+}

--- a/apps/backend/src/common/cache/redis-cache.service.ts
+++ b/apps/backend/src/common/cache/redis-cache.service.ts
@@ -1,0 +1,3 @@
+export interface RedisCacheOptions {
+  url: string;
+}

--- a/apps/backend/src/common/cache/redis-cache.service.ts
+++ b/apps/backend/src/common/cache/redis-cache.service.ts
@@ -1,3 +1,69 @@
+import { Redis } from "ioredis";
+import type { CacheService } from "./cache.service.js";
+
 export interface RedisCacheOptions {
   url: string;
+  defaultTTL?: number;
+  keyPrefix?: string;
+}
+
+export function createRedisCache(options: RedisCacheOptions): CacheService {
+  const { url, defaultTTL = 300, keyPrefix = "" } = options;
+
+  const redis = new Redis(url, {
+    maxRetriesPerRequest: 3,
+    retryStrategy(times) {
+      if (times > 3) return null;
+      return Math.min(times * 200, 2000);
+    },
+    lazyConnect: true,
+  });
+
+  function prefixed(key: string): string {
+    return keyPrefix + key;
+  }
+
+  return {
+    async get<T extends {}>(key: string): Promise<T | undefined> {
+      const raw = await redis.get(prefixed(key));
+      if (raw === null) return undefined;
+      return JSON.parse(raw) as T;
+    },
+
+    async set<T extends {}>(
+      key: string,
+      value: T,
+      ttlSeconds?: number,
+    ): Promise<void> {
+      const ttl = ttlSeconds ?? defaultTTL;
+      await redis.setex(prefixed(key), ttl, JSON.stringify(value));
+    },
+
+    async delete(key: string): Promise<void> {
+      await redis.del(prefixed(key));
+    },
+
+    async deletePattern(pattern: string): Promise<void> {
+      const fullPattern = prefixed(pattern);
+      let cursor = "0";
+
+      do {
+        const [nextCursor, keys] = await redis.scan(
+          cursor,
+          "MATCH",
+          fullPattern,
+          "COUNT",
+          100,
+        );
+        cursor = nextCursor;
+        if (keys.length > 0) {
+          await redis.del(...keys);
+        }
+      } while (cursor !== "0");
+    },
+
+    async flush(): Promise<void> {
+      await redis.flushdb();
+    },
+  };
 }

--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -1,28 +1,43 @@
 import { z } from "zod";
 
-const envSchema = z.object({
-  NODE_ENV: z
-    .enum(["development", "production", "test"])
-    .default("development"),
-  PORT: z.coerce.number().default(3000),
-  HOST: z.string().default("0.0.0.0"),
-  MONGO_URI: z.string(),
-  JWT_SECRET: z.string(),
-  JWT_EXPIRES_IN: z.string().default("7d"),
-  BCRYPT_SALT_ROUNDS: z.coerce.number().default(10),
-  RATE_LIMIT_AUTH_MAX: z.coerce.number().default(5),
-  RATE_LIMIT_AUTH_WINDOW: z.string().default("3 minutes"),
-  RATE_LIMIT_GLOBAL_MAX: z.coerce.number().default(100),
-  RATE_LIMIT_GLOBAL_WINDOW: z.string().default("1 minute"),
-  ROOT_ADMIN_EMAIL: z.string().min(6),
-  ROOT_ADMIN_PASSWORD: z
-    .string()
-    .min(10)
-    .regex(/[A-Z]/, "Must contain at least one uppercase letter")
-    .regex(/[a-z]/, "Must contain at least one lowercase letter")
-    .regex(/[0-9]/, "Must contain at least one number")
-    .regex(/[^A-Za-z0-9]/, "Must contain at least one special character"),
-});
+const envSchema = z
+  .object({
+    NODE_ENV: z
+      .enum(["development", "production", "test"])
+      .default("development"),
+    PORT: z.coerce.number().default(3000),
+    HOST: z.string().default("0.0.0.0"),
+    MONGO_URI: z.string(),
+    JWT_SECRET: z.string(),
+    JWT_EXPIRES_IN: z.string().default("7d"),
+    BCRYPT_SALT_ROUNDS: z.coerce.number().default(10),
+    RATE_LIMIT_AUTH_MAX: z.coerce.number().default(5),
+    RATE_LIMIT_AUTH_WINDOW: z.string().default("3 minutes"),
+    RATE_LIMIT_GLOBAL_MAX: z.coerce.number().default(100),
+    RATE_LIMIT_GLOBAL_WINDOW: z.string().default("1 minute"),
+    ROOT_ADMIN_EMAIL: z.string().min(6),
+    ROOT_ADMIN_PASSWORD: z
+      .string()
+      .min(10)
+      .regex(/[A-Z]/, "Must contain at least one uppercase letter")
+      .regex(/[a-z]/, "Must contain at least one lowercase letter")
+      .regex(/[0-9]/, "Must contain at least one number")
+      .regex(/[^A-Za-z0-9]/, "Must contain at least one special character"),
+    CACHE_BACKEND: z.enum(["memory", "redis"]).default("memory"),
+    REDIS_URL: z.string().optional(),
+  })
+  .refine(
+    (values) => {
+      if (values.CACHE_BACKEND === "redis" && !values.REDIS_URL) {
+        return false;
+      }
+      return true;
+    },
+    {
+      error: "Redis URL is required when using Redis cache",
+      path: ["REDIS_URL"],
+    },
+  );
 
 const parsed = envSchema.safeParse(process.env);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       jsonwebtoken:
         specifier: ^9.0.3
         version: 9.0.3
+      lru-cache:
+        specifier: ^11.3.3
+        version: 11.3.3
       mongoose:
         specifier: ^9.3.3
         version: 9.3.3
@@ -898,8 +901,8 @@ packages:
   lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
-  lru-cache@11.2.7:
-    resolution: {integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==}
+  lru-cache@11.3.3:
+    resolution: {integrity: sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==}
     engines: {node: 20 || >=22}
 
   magic-string@0.30.21:
@@ -2011,7 +2014,7 @@ snapshots:
 
   lodash.once@4.1.1: {}
 
-  lru-cache@11.2.7: {}
+  lru-cache@11.3.3: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -2093,7 +2096,7 @@ snapshots:
 
   path-scurry@2.0.2:
     dependencies:
-      lru-cache: 11.2.7
+      lru-cache: 11.3.3
       minipass: 7.1.3
 
   pathe@2.0.3: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       fastify-type-provider-zod:
         specifier: ^6.1.0
         version: 6.1.0(@fastify/swagger@9.7.0)(fastify@5.8.4)(openapi-types@12.1.3)(zod@4.3.6)
+      ioredis:
+        specifier: ^5.10.1
+        version: 5.10.1
       jsonwebtoken:
         specifier: ^9.0.3
         version: 9.0.3
@@ -370,6 +373,9 @@ packages:
   '@fastify/swagger@9.7.0':
     resolution: {integrity: sha512-Vp1SC1GC2Hrkd3faFILv86BzUNyFz5N4/xdExqtCgkGASOzn/x+eMe4qXIGq7cdT6wif/P/oa6r1Ruqx19paZA==}
 
+  '@ioredis/commands@1.5.1':
+    resolution: {integrity: sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==}
+
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
@@ -610,6 +616,10 @@ packages:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
 
@@ -635,6 +645,10 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -760,6 +774,10 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  ioredis@5.10.1:
+    resolution: {integrity: sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==}
+    engines: {node: '>=12.22.0'}
+
   ipaddr.js@2.3.0:
     resolution: {integrity: sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==}
     engines: {node: '>= 10'}
@@ -880,8 +898,14 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  lodash.defaults@4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
+
+  lodash.isarguments@3.1.0:
+    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
 
   lodash.isboolean@3.0.3:
     resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
@@ -1056,6 +1080,14 @@ packages:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
 
+  redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+
+  redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
@@ -1126,6 +1158,9 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
@@ -1513,6 +1548,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@ioredis/commands@1.5.1': {}
+
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
@@ -1721,6 +1758,8 @@ snapshots:
 
   chai@6.2.2: {}
 
+  cluster-key-slot@1.1.2: {}
+
   colorette@2.0.20: {}
 
   content-disposition@1.0.1: {}
@@ -1734,6 +1773,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  denque@2.1.0: {}
 
   depd@2.0.0: {}
 
@@ -1886,6 +1927,20 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  ioredis@5.10.1:
+    dependencies:
+      '@ioredis/commands': 1.5.1
+      cluster-key-slot: 1.1.2
+      debug: 4.4.3
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   ipaddr.js@2.3.0: {}
 
   istanbul-lib-coverage@3.2.2: {}
@@ -2000,7 +2055,11 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  lodash.defaults@4.2.0: {}
+
   lodash.includes@4.3.0: {}
+
+  lodash.isarguments@3.1.0: {}
 
   lodash.isboolean@3.0.3: {}
 
@@ -2162,6 +2221,12 @@ snapshots:
 
   real-require@0.2.0: {}
 
+  redis-errors@1.2.0: {}
+
+  redis-parser@3.0.0:
+    dependencies:
+      redis-errors: 1.2.0
+
   require-from-string@2.0.2: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -2229,6 +2294,8 @@ snapshots:
   split2@4.2.0: {}
 
   stackback@0.0.2: {}
+
+  standard-as-callback@2.1.0: {}
 
   statuses@2.0.2: {}
 


### PR DESCRIPTION
## Related Issues

<!-- Link related issues: Closes #123, Refs #456 -->

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Tests
- [ ] Other

## Description

Add cache service infrastructure with in-memory (LRU) and Redis backend support.

**Architecture:**
- `CacheService` interface for backend-agnostic cache access
- `createMemoryCache()` — LRU in-memory cache via `lru-cache`
- `createRedisCache()` — Redis cache via `ioredis` with SCAN-based pattern deletion
- `createCacheService()` factory with automatic fallback from Redis to memory

**Key design decisions:**
- All cache methods are async for interface consistency across backends
- `deletePattern` uses SCAN (not KEYS) for production safety
- Redis uses `lazyConnect` and `retryStrategy` for resilience
- Memory cache uses `updateAgeOnGet` for read-through TTL refresh
- Factory falls back to memory if Redis is unavailable

**Configuration:**
- `CACHE_BACKEND=memory|redis` (default: memory)
- `REDIS_URL=redis://...` (required when backend=redis)
- Validation in `env.ts` ensures REDIS_URL is set when using redis backend

Not wired into app/services yet — that will be a separate PR.

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [ ] Added/updated tests for new functionality
- [ ] Updated documentation (if needed)