### PR TITLE
feat(cache): integrate cache into category and recipe modules

### DIFF
--- a/apps/backend/src/__tests__/helpers.ts
+++ b/apps/backend/src/__tests__/helpers.ts
@@ -4,6 +4,7 @@ import { Types } from "mongoose";
 import type { Mock } from "vitest";
 import { vi } from "vitest";
 import type { CacheService } from "@/common/cache/cache.service.js";
+import { createMemoryCache } from "@/common/cache/memory-cache.service.js";
 import type { CategoryDocument } from "@/modules/categories/category.model.js";
 import type { CommentDocument } from "@/modules/comments/comment.model.js";
 import type {
@@ -207,30 +208,30 @@ export function createMockFavoriteModel(overrides: Record<string, Mock> = {}) {
 
 // ── Cache mock ──
 
-export function createMockCache(): CacheService {
-  const store = new Map<string, unknown>();
+export interface MockCache extends CacheService {
+  spies: {
+    get: Mock;
+    set: Mock;
+    delete: Mock;
+    deletePattern: Mock;
+    flush: Mock;
+  };
+}
+
+export function createMockCache(): MockCache {
+  const memoryCache = createMemoryCache();
+
+  const spies = {
+    get: vi.spyOn(memoryCache, "get"),
+    set: vi.spyOn(memoryCache, "set"),
+    delete: vi.spyOn(memoryCache, "delete"),
+    deletePattern: vi.spyOn(memoryCache, "deletePattern"),
+    flush: vi.spyOn(memoryCache, "flush"),
+  };
 
   return {
-    async get<T extends {}>(key: string) {
-      return store.get(key) as T | undefined;
-    },
-    async set<T extends {}>(key: string, value: T) {
-      store.set(key, value);
-    },
-    async delete(key: string) {
-      store.delete(key);
-    },
-    async deletePattern(pattern: string) {
-      const regex = new RegExp(`^${pattern.replace(/\*/g, ".*")}$`);
-      for (const key of store.keys()) {
-        if (regex.test(key)) {
-          store.delete(key);
-        }
-      }
-    },
-    async flush() {
-      store.clear();
-    },
+    ...memoryCache,
+    spies,
   };
 }
 

--- a/apps/backend/src/__tests__/helpers.ts
+++ b/apps/backend/src/__tests__/helpers.ts
@@ -3,6 +3,7 @@ import type { FastifyReply, FastifyRequest } from "fastify";
 import { Types } from "mongoose";
 import type { Mock } from "vitest";
 import { vi } from "vitest";
+import type { CacheService } from "@/common/cache/cache.service.js";
 import type { CategoryDocument } from "@/modules/categories/category.model.js";
 import type { CommentDocument } from "@/modules/comments/comment.model.js";
 import type {
@@ -201,6 +202,35 @@ export function createMockFavoriteModel(overrides: Record<string, Mock> = {}) {
     exists: viFn(),
     findOne: viFn(),
     ...overrides,
+  };
+}
+
+// ── Cache mock ──
+
+export function createMockCache(): CacheService {
+  const store = new Map<string, unknown>();
+
+  return {
+    async get<T extends {}>(key: string) {
+      return store.get(key) as T | undefined;
+    },
+    async set<T extends {}>(key: string, value: T) {
+      store.set(key, value);
+    },
+    async delete(key: string) {
+      store.delete(key);
+    },
+    async deletePattern(pattern: string) {
+      const regex = new RegExp(`^${pattern.replace(/\*/g, ".*")}$`);
+      for (const key of store.keys()) {
+        if (regex.test(key)) {
+          store.delete(key);
+        }
+      }
+    },
+    async flush() {
+      store.clear();
+    },
   };
 }
 

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -9,6 +9,8 @@ import {
   serializerCompiler,
   validatorCompiler,
 } from "fastify-type-provider-zod";
+import type { CacheService } from "@/common/cache/cache.service.js";
+import { createCacheService } from "@/common/cache/create-cache.service.js";
 import { errorHandler } from "@/common/middleware/errorHandler.js";
 import { env } from "@/config/env.js";
 import { createRateLimitOptions } from "@/config/rate-limit.js";
@@ -38,7 +40,13 @@ import {
   userRoutes,
 } from "@/modules/users/index.js";
 
-export function buildApp() {
+declare module "fastify" {
+  interface FastifyInstance {
+    cache: CacheService;
+  }
+}
+
+export async function buildApp() {
   const app = Fastify({
     logger: {
       level: env.NODE_ENV === "production" ? "info" : "debug",
@@ -48,6 +56,13 @@ export function buildApp() {
           : undefined,
     },
   });
+
+  const cache = await createCacheService({
+    backend: env.CACHE_BACKEND,
+    redis: env.REDIS_URL ? { url: env.REDIS_URL } : undefined,
+  });
+
+  app.decorate("cache", cache);
 
   // Validation & serialization
   app.setValidatorCompiler(validatorCompiler);
@@ -93,6 +108,7 @@ export function buildApp() {
       UserModel,
       FavoriteModel,
       CategoryModel,
+      cache,
     ),
     favoriteService: createFavoriteService(
       FavoriteModel,
@@ -103,8 +119,12 @@ export function buildApp() {
     prefix: "/api/recipes",
   });
   app.register(categoryRoutes, {
-    service: createCategoryService(CategoryModel, RecipeModel),
+    service: createCategoryService(CategoryModel, RecipeModel, cache),
     prefix: "/api/categories",
+  });
+
+  app.addHook("onClose", async () => {
+    await cache.flush();
   });
 
   return app;

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -7,7 +7,7 @@ async function start() {
   await connectDatabase();
   await ensureRootAdmin();
 
-  const app = buildApp();
+  const app = await buildApp();
 
   try {
     await app.listen({ port: env.PORT, host: env.HOST });

--- a/apps/backend/src/modules/categories/category.cache.ts
+++ b/apps/backend/src/modules/categories/category.cache.ts
@@ -1,0 +1,8 @@
+export const categoryCache = {
+  keys: {
+    all: () => "categories:all",
+  },
+  ttl: {
+    list: 3600,
+  },
+} as const;

--- a/apps/backend/src/modules/categories/category.service.test.ts
+++ b/apps/backend/src/modules/categories/category.service.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createCategoryDoc,
+  createMockCache,
   createMockCategoryModel,
   createMockRecipeModel,
   createObjectId,
@@ -14,13 +15,16 @@ import type { RecipeModelType } from "@/modules/recipes/index.js";
 describe("categoryService", () => {
   const categoryModel = createMockCategoryModel();
   const recipeModel = createMockRecipeModel();
+  const cache = createMockCache();
   const service = createCategoryService(
     categoryModel as unknown as CategoryModelType,
     recipeModel as unknown as RecipeModelType,
+    cache,
   );
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
+    await cache.flush();
   });
 
   describe("findAll", () => {

--- a/apps/backend/src/modules/categories/category.service.test.ts
+++ b/apps/backend/src/modules/categories/category.service.test.ts
@@ -8,6 +8,7 @@ import {
   initiator,
 } from "@/__tests__/helpers.js";
 import { ConflictError, NotFoundError } from "@/common/errors.js";
+import { categoryCache } from "@/modules/categories/category.cache.js";
 import type { CategoryModelType } from "@/modules/categories/category.model.js";
 import { createCategoryService } from "@/modules/categories/category.service.js";
 import type { RecipeModelType } from "@/modules/recipes/index.js";
@@ -31,7 +32,7 @@ describe("categoryService", () => {
     it("should return all categories sorted by name", async () => {
       const docs = [
         createCategoryDoc({ name: "Desserts", slug: "desserts" }),
-        createCategoryDoc({ name: "Soups", slug: "soups" }),
+        createCategoryDoc({ name: "Soups", slug: "oups" }),
       ];
       categoryModel.find.mockReturnValue({
         sort: vi.fn().mockReturnValue({
@@ -44,6 +45,7 @@ describe("categoryService", () => {
       expect(categoryModel.find).toHaveBeenCalled();
       expect(result).toHaveLength(2);
       expect(result[0]?.name).toBe("Desserts");
+      expect(cache.get).toHaveBeenCalledWith(categoryCache.keys.all());
     });
 
     it("should return empty array when no categories exist", async () => {
@@ -56,6 +58,25 @@ describe("categoryService", () => {
       const result = await service.findAll();
 
       expect(result).toEqual([]);
+    });
+
+    it("should return cached result on second call", async () => {
+      const docs = [createCategoryDoc({ name: "Desserts", slug: "desserts" })];
+      categoryModel.find.mockReturnValue({
+        sort: vi.fn().mockReturnValue({
+          lean: vi.fn().mockResolvedValue(docs),
+        }),
+      });
+
+      await service.findAll();
+      expect(cache.get).toHaveBeenCalledWith(categoryCache.keys.all());
+      vi.clearAllMocks();
+
+      const result = await service.findAll();
+
+      expect(categoryModel.find).not.toHaveBeenCalled();
+      expect(result).toHaveLength(1);
+      expect(cache.get).toHaveBeenCalledWith(categoryCache.keys.all());
     });
   });
 
@@ -77,6 +98,7 @@ describe("categoryService", () => {
       });
       expect(result.name).toBe("New Category");
       expect(result.slug).toBe("new-category");
+      expect(cache.delete).toHaveBeenCalledWith(categoryCache.keys.all());
     });
   });
 
@@ -90,6 +112,7 @@ describe("categoryService", () => {
 
       expect(recipeModel.countDocuments).toHaveBeenCalledWith({ category: id });
       expect(categoryModel.findByIdAndDelete).toHaveBeenCalledWith(id);
+      expect(cache.delete).toHaveBeenCalledWith(categoryCache.keys.all());
     });
 
     it("should throw ConflictError when recipes exist", async () => {

--- a/apps/backend/src/modules/categories/category.service.ts
+++ b/apps/backend/src/modules/categories/category.service.ts
@@ -1,10 +1,12 @@
 import type { Category } from "@recipes/shared";
+import type { CacheService } from "@/common/cache/cache.service.js";
 import { ConflictError, NotFoundError } from "@/common/errors.js";
 import type {
   CreateMethodParams,
   DeleteMethodParams,
 } from "@/common/types/methods.js";
 import { toCategory } from "@/common/utils/mongo.js";
+import { categoryCache } from "@/modules/categories/category.cache.js";
 import type {
   CategoryModelType,
   CreateCategoryBody,
@@ -20,16 +22,33 @@ export interface CategoryService {
 export function createCategoryService(
   categoryModel: CategoryModelType,
   recipeModel: RecipeModelType,
+  cache: CacheService,
 ): CategoryService {
   return {
     findAll: async () => {
+      const cacheKey = categoryCache.keys.all();
+
+      const cached = await cache.get<Category[]>(cacheKey);
+      if (cached !== undefined) {
+        return cached;
+      }
+
       const categories = await categoryModel.find().sort({ name: 1 }).lean();
-      return categories.map(toCategory);
+      const result = categories.map(toCategory);
+
+      await cache.set(cacheKey, result, categoryCache.ttl.list);
+
+      return result;
     },
+
     create: async ({ data }) => {
       const category = await categoryModel.create(data);
+
+      await cache.delete(categoryCache.keys.all());
+
       return toCategory(category.toObject());
     },
+
     deleteById: async (categoryId) => {
       const recipeCount = await recipeModel.countDocuments({
         category: categoryId,
@@ -42,6 +61,8 @@ export function createCategoryService(
       if (!result) {
         throw new NotFoundError("Category not found");
       }
+
+      await cache.delete(categoryCache.keys.all());
     },
   };
 }

--- a/apps/backend/src/modules/categories/index.ts
+++ b/apps/backend/src/modules/categories/index.ts
@@ -1,3 +1,4 @@
+export * from "./category.cache.js";
 export * from "./category.model.js";
 export * from "./category.routes.js";
 export * from "./category.schema.js";

--- a/apps/backend/src/modules/recipes/index.ts
+++ b/apps/backend/src/modules/recipes/index.ts
@@ -1,4 +1,5 @@
 export * from "./recipe.aggregation.js";
+export * from "./recipe.cache.js";
 export * from "./recipe.model.js";
 export * from "./recipe.routes.js";
 export * from "./recipe.schema.js";

--- a/apps/backend/src/modules/recipes/recipe.cache.ts
+++ b/apps/backend/src/modules/recipes/recipe.cache.ts
@@ -1,12 +1,28 @@
+import crypto from "node:crypto";
+import type { SearchRecipeQuery } from "./recipe.schema.js";
+
+function hashFilters(query: SearchRecipeQuery): string {
+  const stable = {
+    categoryId: query.categoryId,
+    difficulty: query.difficulty,
+    sort: query.sort,
+  };
+  return crypto
+    .createHash("md5")
+    .update(JSON.stringify(stable))
+    .digest("hex")
+    .slice(0, 8);
+}
+
 export const recipeCache = {
   keys: {
     byId: (id: string) => `recipes:id:${id}`,
-    list: (filtersHash: string) => `recipes:list:${filtersHash}`,
+    list: (filters: SearchRecipeQuery) =>
+      `recipes:list:${filters.page}:${filters.limit}:${hashFilters(filters)}`,
     allPattern: () => "recipes:*",
   },
   ttl: {
     byId: 600,
     list: 120,
-    search: 60,
   },
 } as const;

--- a/apps/backend/src/modules/recipes/recipe.cache.ts
+++ b/apps/backend/src/modules/recipes/recipe.cache.ts
@@ -1,0 +1,12 @@
+export const recipeCache = {
+  keys: {
+    byId: (id: string) => `recipes:id:${id}`,
+    list: (filtersHash: string) => `recipes:list:${filtersHash}`,
+    allPattern: () => "recipes:*",
+  },
+  ttl: {
+    byId: 600,
+    list: 120,
+    search: 60,
+  },
+} as const;

--- a/apps/backend/src/modules/recipes/recipe.service.test.ts
+++ b/apps/backend/src/modules/recipes/recipe.service.test.ts
@@ -19,6 +19,7 @@ import {
 } from "@/common/errors.js";
 import type { CategoryModelType } from "@/modules/categories/category.model.js";
 import type { FavoriteModelType } from "@/modules/favorites/favorite.model.js";
+import { recipeCache } from "@/modules/recipes/recipe.cache.js";
 import type { RecipeModelType } from "@/modules/recipes/recipe.model.js";
 import { createRecipeService } from "@/modules/recipes/recipe.service.js";
 import type { UserModelType } from "@/modules/users/user.model.js";
@@ -47,35 +48,46 @@ describe("recipeService", () => {
       const populated = populateRecipeDoc(createRecipeDoc());
       recipeModel.searchFull.mockResolvedValue([[populated], 1]);
 
+      const query = { page: 1, limit: 10, sort: "-createdAt" };
       const result = await service.findAll({
-        query: { page: 1, limit: 10, sort: "-createdAt" },
+        query,
         initiator: noInitiator(),
       });
 
       expect(result.items).toHaveLength(1);
       expect(result.items[0]?.title).toBe("Test Recipe");
       expect(result.pagination.total).toBe(1);
+      expect(cache.get).toHaveBeenCalledWith(recipeCache.keys.list(query));
     });
 
     it("should return empty when searchFull returns null", async () => {
       recipeModel.searchFull.mockResolvedValue([null, 0]);
 
+      const query = { page: 1, limit: 10, sort: "-createdAt" };
       const result = await service.findAll({
-        query: { page: 1, limit: 10, sort: "-createdAt" },
+        query,
         initiator: noInitiator(),
       });
 
       expect(result.items).toEqual([]);
+      expect(cache.get).toHaveBeenCalledWith(recipeCache.keys.list(query));
     });
 
     it("should return empty when isFavorited filter is set but no initiator", async () => {
+      const query = {
+        page: 1,
+        limit: 10,
+        sort: "-createdAt",
+        isFavorited: true,
+      };
       const result = await service.findAll({
-        query: { page: 1, limit: 10, sort: "-createdAt", isFavorited: true },
+        query,
         initiator: noInitiator(),
       });
 
       expect(result.items).toEqual([]);
       expect(recipeModel.searchFull).not.toHaveBeenCalled();
+      expect(cache.get).not.toHaveBeenCalled();
     });
   });
 
@@ -84,11 +96,31 @@ describe("recipeService", () => {
       const populated = populateRecipeDoc(createRecipeDoc());
       recipeModel.findByIdFull.mockResolvedValue(populated);
 
-      const result = await service.findById(createObjectId().toString(), {
+      const id = createObjectId().toString();
+      const result = await service.findById(id, {
         initiator: noInitiator(),
       });
 
       expect(result.title).toBe("Test Recipe");
+      expect(cache.get).toHaveBeenCalledWith(recipeCache.keys.byId(id));
+    });
+
+    it("should return cached recipe on second call for unauthenticated user", async () => {
+      const populated = populateRecipeDoc(createRecipeDoc());
+      recipeModel.findByIdFull.mockResolvedValue(populated);
+
+      const id = createObjectId().toString();
+      await service.findById(id, { initiator: noInitiator() });
+
+      vi.clearAllMocks();
+
+      const result = await service.findById(id, {
+        initiator: noInitiator(),
+      });
+
+      expect(recipeModel.findByIdFull).not.toHaveBeenCalled();
+      expect(result.title).toBe("Test Recipe");
+      expect(cache.get).toHaveBeenCalledWith(recipeCache.keys.byId(id));
     });
 
     it("should throw BadRequestError for invalid ID", async () => {
@@ -102,11 +134,13 @@ describe("recipeService", () => {
     it("should throw NotFoundError when recipe not found", async () => {
       recipeModel.findByIdFull.mockResolvedValue(null);
 
+      const id = createObjectId().toString();
       await expect(
-        service.findById(createObjectId().toString(), {
+        service.findById(id, {
           initiator: noInitiator(),
         }),
       ).rejects.toThrow(NotFoundError);
+      expect(cache.get).toHaveBeenCalledWith(recipeCache.keys.byId(id));
     });
   });
 
@@ -148,6 +182,9 @@ describe("recipeService", () => {
 
       expect(recipeModel.create).toHaveBeenCalled();
       expect(result.title).toBe("New Recipe");
+      expect(cache.deletePattern).toHaveBeenCalledWith(
+        recipeCache.keys.allPattern(),
+      );
     });
 
     it("should throw BadRequestError for invalid author ID", async () => {
@@ -208,13 +245,18 @@ describe("recipeService", () => {
         lean: vi.fn().mockResolvedValue(null),
       });
 
-      const result = await service.update(createObjectId().toString(), {
+      const id = createObjectId().toString();
+      const result = await service.update(id, {
         data: { title: "Updated" },
         initiator: initiator(authorId.toString()),
       });
 
       expect(recipe.save).toHaveBeenCalled();
       expect(result.title).toBe("Updated");
+      expect(cache.delete).toHaveBeenCalledWith(recipeCache.keys.byId(id));
+      expect(cache.deletePattern).toHaveBeenCalledWith(
+        recipeCache.keys.allPattern(),
+      );
     });
 
     it("should update recipe when user is admin", async () => {
@@ -232,12 +274,17 @@ describe("recipeService", () => {
         lean: vi.fn().mockResolvedValue(null),
       });
 
+      const id = createObjectId().toString();
       await expect(
-        service.update(createObjectId().toString(), {
+        service.update(id, {
           data: { title: "Updated" },
           initiator: initiator(createObjectId().toString(), "admin"),
         }),
       ).resolves.toBeDefined();
+      expect(cache.delete).toHaveBeenCalledWith(recipeCache.keys.byId(id));
+      expect(cache.deletePattern).toHaveBeenCalledWith(
+        recipeCache.keys.allPattern(),
+      );
     });
 
     it("should throw BadRequestError for invalid ID", async () => {
@@ -283,11 +330,16 @@ describe("recipeService", () => {
         }),
       });
 
+      const id = createObjectId().toString();
       await expect(
-        service.delete(createObjectId().toString(), {
+        service.delete(id, {
           initiator: initiator(authorId.toString()),
         }),
       ).resolves.toBeUndefined();
+      expect(cache.delete).toHaveBeenCalledWith(recipeCache.keys.byId(id));
+      expect(cache.deletePattern).toHaveBeenCalledWith(
+        recipeCache.keys.allPattern(),
+      );
     });
 
     it("should delete recipe when user is admin", async () => {
@@ -298,11 +350,16 @@ describe("recipeService", () => {
         }),
       });
 
+      const id = createObjectId().toString();
       await expect(
-        service.delete(createObjectId().toString(), {
+        service.delete(id, {
           initiator: initiator(createObjectId().toString(), "admin"),
         }),
       ).resolves.toBeUndefined();
+      expect(cache.delete).toHaveBeenCalledWith(recipeCache.keys.byId(id));
+      expect(cache.deletePattern).toHaveBeenCalledWith(
+        recipeCache.keys.allPattern(),
+      );
     });
 
     it("should throw BadRequestError for invalid ID", async () => {

--- a/apps/backend/src/modules/recipes/recipe.service.test.ts
+++ b/apps/backend/src/modules/recipes/recipe.service.test.ts
@@ -1,6 +1,7 @@
 import type { Minutes } from "@recipes/shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  createMockCache,
   createMockCategoryModel,
   createMockFavoriteModel,
   createMockRecipeModel,
@@ -27,15 +28,18 @@ describe("recipeService", () => {
   const userModel = createMockUserModel();
   const favoriteModel = createMockFavoriteModel();
   const categoryModel = createMockCategoryModel();
+  const cache = createMockCache();
   const service = createRecipeService(
     recipeModel as unknown as RecipeModelType,
     userModel as unknown as UserModelType,
     favoriteModel as unknown as FavoriteModelType,
     categoryModel as unknown as CategoryModelType,
+    cache,
   );
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
+    await cache.flush();
   });
 
   describe("findAll", () => {

--- a/apps/backend/src/modules/recipes/recipe.service.ts
+++ b/apps/backend/src/modules/recipes/recipe.service.ts
@@ -1,4 +1,3 @@
-import crypto from "node:crypto";
 import type { Paginated, Recipe } from "@recipes/shared";
 import { withPagination } from "@recipes/shared";
 import { isValidObjectId } from "mongoose";
@@ -30,20 +29,6 @@ import type {
 } from "@/modules/recipes/index.js";
 import { recipeCache } from "@/modules/recipes/recipe.cache.js";
 import type { UserDocument, UserModelType } from "@/modules/users/index.js";
-
-function hashFilters(query: SearchRecipeQuery): string {
-  const stable = {
-    search: query.search,
-    categoryId: query.categoryId,
-    difficulty: query.difficulty,
-    sort: query.sort,
-  };
-  return crypto
-    .createHash("md5")
-    .update(JSON.stringify(stable))
-    .digest("hex")
-    .slice(0, 8);
-}
 
 export interface RecipeService {
   findAll(
@@ -79,10 +64,7 @@ export function createRecipeService(
       const isAuthenticated = !!initiator.id;
 
       if (!isAuthenticated) {
-        const filtersHash = hashFilters(query);
-        const cacheKey = recipeCache.keys.list(
-          `${filtersHash}:${page}:${limit}`,
-        );
+        const cacheKey = recipeCache.keys.list(query);
 
         const cached = await cache.get<Paginated<Recipe>>(cacheKey);
         if (cached !== undefined) {
@@ -106,10 +88,7 @@ export function createRecipeService(
       );
 
       if (!isAuthenticated) {
-        const filtersHash = hashFilters(query);
-        const cacheKey = recipeCache.keys.list(
-          `${filtersHash}:${page}:${limit}`,
-        );
+        const cacheKey = recipeCache.keys.list(query);
         await cache.set(cacheKey, result, recipeCache.ttl.list);
       }
 

--- a/apps/backend/src/modules/recipes/recipe.service.ts
+++ b/apps/backend/src/modules/recipes/recipe.service.ts
@@ -1,6 +1,8 @@
+import crypto from "node:crypto";
 import type { Paginated, Recipe } from "@recipes/shared";
 import { withPagination } from "@recipes/shared";
 import { isValidObjectId } from "mongoose";
+import type { CacheService } from "@/common/cache/cache.service.js";
 import {
   BadRequestError,
   ForbiddenError,
@@ -26,7 +28,22 @@ import type {
   SearchRecipeQuery,
   UpdateRecipeBody,
 } from "@/modules/recipes/index.js";
+import { recipeCache } from "@/modules/recipes/recipe.cache.js";
 import type { UserDocument, UserModelType } from "@/modules/users/index.js";
+
+function hashFilters(query: SearchRecipeQuery): string {
+  const stable = {
+    search: query.search,
+    categoryId: query.categoryId,
+    difficulty: query.difficulty,
+    sort: query.sort,
+  };
+  return crypto
+    .createHash("md5")
+    .update(JSON.stringify(stable))
+    .digest("hex")
+    .slice(0, 8);
+}
 
 export interface RecipeService {
   findAll(
@@ -49,6 +66,7 @@ export function createRecipeService(
   userModel: UserModelType,
   favoriteModel: FavoriteModelType,
   categoryModel: CategoryModelType,
+  cache: CacheService,
 ): RecipeService {
   return {
     findAll: async ({ query, initiator }) => {
@@ -56,6 +74,20 @@ export function createRecipeService(
 
       if (isFavorited && !initiator.id) {
         return withPagination([], 0, page, limit);
+      }
+
+      const isAuthenticated = !!initiator.id;
+
+      if (!isAuthenticated) {
+        const filtersHash = hashFilters(query);
+        const cacheKey = recipeCache.keys.list(
+          `${filtersHash}:${page}:${limit}`,
+        );
+
+        const cached = await cache.get<Paginated<Recipe>>(cacheKey);
+        if (cached !== undefined) {
+          return cached;
+        }
       }
 
       const [recipes, total] = await recipeModel.searchFull({
@@ -66,12 +98,22 @@ export function createRecipeService(
         return withPagination([], 0, page, limit);
       }
 
-      return withPagination(
+      const result = withPagination(
         recipes.map((recipe) => toRecipe(recipe, recipe.isFavorited)),
         total,
         page,
         limit,
       );
+
+      if (!isAuthenticated) {
+        const filtersHash = hashFilters(query);
+        const cacheKey = recipeCache.keys.list(
+          `${filtersHash}:${page}:${limit}`,
+        );
+        await cache.set(cacheKey, result, recipeCache.ttl.list);
+      }
+
+      return result;
     },
 
     findById: async (id, params) => {
@@ -79,12 +121,29 @@ export function createRecipeService(
         throw new BadRequestError("Invalid recipe ID");
       }
 
+      const isAuthenticated = !!params.initiator.id;
+
+      if (!isAuthenticated) {
+        const cacheKey = recipeCache.keys.byId(id);
+        const cached = await cache.get<Recipe>(cacheKey);
+        if (cached !== undefined) {
+          return cached;
+        }
+      }
+
       const recipe = await recipeModel.findByIdFull(id, params);
       if (!recipe) {
         throw new NotFoundError("Recipe not found");
       }
 
-      return toRecipe(recipe, recipe.isFavorited);
+      const result = toRecipe(recipe, recipe.isFavorited);
+
+      if (!isAuthenticated) {
+        const cacheKey = recipeCache.keys.byId(id);
+        await cache.set(cacheKey, result, recipeCache.ttl.byId);
+      }
+
+      return result;
     },
 
     create: async ({ data, initiator }) => {
@@ -116,6 +175,9 @@ export function createRecipeService(
         { path: "author", select: "name email" },
         { path: "category", select: "name slug" },
       ]);
+
+      await cache.deletePattern(recipeCache.keys.allPattern());
+
       return toRecipe(populated.toObject<typeof populated>(), false);
     },
 
@@ -149,6 +211,11 @@ export function createRecipeService(
         })
         .lean());
 
+      await Promise.all([
+        cache.delete(recipeCache.keys.byId(id)),
+        cache.deletePattern(recipeCache.keys.allPattern()),
+      ]);
+
       return toRecipe(populated.toObject<typeof populated>(), isFavorited);
     },
 
@@ -166,6 +233,11 @@ export function createRecipeService(
       }
 
       await recipe.deleteOne();
+
+      await Promise.all([
+        cache.delete(recipeCache.keys.byId(id)),
+        cache.deletePattern(recipeCache.keys.allPattern()),
+      ]);
     },
   };
 }


### PR DESCRIPTION
## Related Issues

## PR Type

- [x] Feature
- [x] Tests

## Description

Integrate cache service into categories and recipes modules.

**Architecture:**
- Each module owns its cache config (`category.cache.ts`, `recipe.cache.ts`) with keys and TTLs
- Cache-aside pattern: reads check cache first, writes invalidate
- Only public (unauthenticated) requests are cached to avoid personalized data issues

**What's cached:**
| Method | Cached | TTL | Notes |
|---|---|---|---|
| `GET /categories` | Yes | 1h | All users |
| `GET /recipes/:id` | Yes | 10min | Unauthenticated only |
| `GET /recipes` | Yes | 2min | Unauthenticated only, per filter hash |
| `POST/PATCH/DELETE` | Invalidation | — | Clears related keys |

**Test improvements:**
- Hybrid mock cache: real `createMemoryCache` + `vi.spyOn()` spies
- New tests verify cache hit (DB not called on second request)
- New tests verify invalidation on create/update/delete

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes (116 tests)
- [x] Added/updated tests for new functionality
- [ ] Updated documentation (if needed)