### PR TITLE
refactor(cache): remove hardcoded TTL defaults and add JSDoc

### DIFF
--- a/apps/backend/src/common/cache/cache.service.ts
+++ b/apps/backend/src/common/cache/cache.service.ts
@@ -2,13 +2,44 @@
  * Cache service interface.
  *
  * Cache service is responsible for storing and retrieving data from a cache.
- * It provides methods for setting, getting, deleting, and flushing cache.
+ * It provides methods for setting, getting, deleting, flushing cache, and closing the cache service.
  */
 export interface CacheService {
+  /**
+   * Gets the value of the entry with the given key.
+   *
+   * @param key - The key of the entry to get.
+   * @returns The value of the entry with the given key, or `undefined` if the entry does not exist.
+   */
   get<T extends {}>(key: string): Promise<T | undefined>;
+
+  /**
+   * Sets the value of the entry with the given key.
+   *
+   * @param key - The key of the entry to set.
+   * @param ttlSeconds - The time-to-live (TTL) in seconds for the entry. If not provided, the entry will not expire. If the cache service has a default TTL value set, that value will be used. If both parameters are specified, this parameter will be used.
+   */
   set<T extends {}>(key: string, value: T, ttlSeconds?: number): Promise<void>;
+
+  /**
+   * Deletes the entry with the given key.
+   */
   delete(key: string): Promise<void>;
+
+  /**
+   * Deletes all entries that match the given pattern.
+   *
+   * The pattern is a glob pattern that matches keys. For example, to delete all entries with the prefix "user:", you can use the pattern "user:*".
+   */
   deletePattern(pattern: string): Promise<void>;
+
+  /**
+   * Flushes the cache and removes all entries.
+   */
   flush(): Promise<void>;
+
+  /**
+   * Closes the cache service and releases any resources it holds.
+   */
   close(): Promise<void>;
 }

--- a/apps/backend/src/common/cache/memory-cache.service.ts
+++ b/apps/backend/src/common/cache/memory-cache.service.ts
@@ -10,17 +10,17 @@ export interface MemoryCacheOptions {
  * Creates a new memory cache service.
  *
  * @param options.maxSize - The maximum number of items in the cache. Defaults to 1000.
- * @param options.defaultTtl - The default TTL for cache items in seconds. Defaults to 300.
+ * @param options.defaultTTL - The default TTL for cache items in seconds. If not set, items do not expire.
  * @returns A new memory cache service.
  */
 export function createMemoryCache(
   options: MemoryCacheOptions = {},
 ): CacheService {
-  const { maxSize = 1000, defaultTTL = 300 } = options;
+  const { maxSize = 1000, defaultTTL } = options;
 
   const cache = new LRUCache<string, NonNullable<unknown>>({
     max: maxSize,
-    ttl: defaultTTL * 1000,
+    ttl: (defaultTTL ?? 0) * 1000,
     updateAgeOnGet: true,
   });
 
@@ -34,9 +34,15 @@ export function createMemoryCache(
       value: T,
       ttlSeconds?: number,
     ): Promise<void> {
-      cache.set(key, value, {
-        ttl: (ttlSeconds ?? defaultTTL) * 1000,
-      });
+      if (ttlSeconds) {
+        cache.set(key, value, { ttl: ttlSeconds * 1000 });
+        return;
+      } else if (defaultTTL) {
+        cache.set(key, value, { ttl: defaultTTL * 1000 });
+        return;
+      }
+
+      cache.set(key, value);
     },
 
     async delete(key: string): Promise<void> {

--- a/apps/backend/src/common/cache/redis-cache.service.ts
+++ b/apps/backend/src/common/cache/redis-cache.service.ts
@@ -8,7 +8,7 @@ export interface RedisCacheOptions {
 }
 
 export function createRedisCache(options: RedisCacheOptions): CacheService {
-  const { url, defaultTTL = 300, keyPrefix = "" } = options;
+  const { url, defaultTTL, keyPrefix = "" } = options;
 
   const redis = new Redis(url, {
     maxRetriesPerRequest: 3,
@@ -35,8 +35,15 @@ export function createRedisCache(options: RedisCacheOptions): CacheService {
       value: T,
       ttlSeconds?: number,
     ): Promise<void> {
-      const ttl = ttlSeconds ?? defaultTTL;
-      await redis.setex(prefixed(key), ttl, JSON.stringify(value));
+      if (ttlSeconds) {
+        await redis.setex(prefixed(key), ttlSeconds, JSON.stringify(value));
+        return;
+      } else if (defaultTTL) {
+        await redis.setex(prefixed(key), defaultTTL, JSON.stringify(value));
+        return;
+      }
+
+      await redis.set(prefixed(key), JSON.stringify(value));
     },
 
     async delete(key: string): Promise<void> {


### PR DESCRIPTION
## PR Type

- [x] Refactoring

## Description

- Remove hardcoded `defaultTTL = 300` fallback from both Redis and Memory cache implementations
- Make TTL resolution explicit: `ttlSeconds` > `defaultTTL` > no expiry (permanent key)
- Add JSDoc documentation to all `CacheService` interface methods

Previously every cached key silently received a 300s TTL even when neither `ttlSeconds` nor `defaultTTL` was provided, making it impossible to store permanent entries.

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [ ] Added/updated tests for new functionality
- [x] Updated documentation (if needed)