### PR TITLE
refactor: replace console with pino logger and add critical logging

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -33,7 +33,8 @@
     "ioredis": "^5.10.1",
     "jsonwebtoken": "^9.0.3",
     "lru-cache": "^11.3.3",
-    "mongoose": "^9.3.3"
+    "mongoose": "^9.3.3",
+    "pino": "^10.3.1"
   },
   "devDependencies": {
     "@types/jsonwebtoken": "^9.0.10",

--- a/apps/backend/src/__tests__/helpers.ts
+++ b/apps/backend/src/__tests__/helpers.ts
@@ -5,6 +5,7 @@ import type { Mock } from "vitest";
 import { vi } from "vitest";
 import type { CacheService } from "@/common/cache/cache.service.js";
 import { createMemoryCache } from "@/common/cache/memory-cache.service.js";
+import type { Logger } from "@/common/logger.js";
 import type { CategoryDocument } from "@/modules/categories/category.model.js";
 import type { CommentDocument } from "@/modules/comments/comment.model.js";
 import type {
@@ -16,6 +17,35 @@ import type { UserDocument, UserRole } from "@/modules/users/user.model.js";
 type LocalProcedure = (...args: unknown[]) => unknown;
 function viFn<T extends LocalProcedure>(fn?: T): Mock<T> {
   return vi.fn(fn);
+}
+
+// ── Logger mocks ──
+
+export interface MockLogger extends Logger {
+  spies: {
+    fatal: Mock;
+    error: Mock;
+    warn: Mock;
+    info: Mock;
+    debug: Mock;
+    trace: Mock;
+  };
+}
+
+export function createMockLogger(): MockLogger {
+  const spies = {
+    fatal: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    trace: vi.fn(),
+  };
+
+  return {
+    ...spies,
+    spies,
+  } as unknown as MockLogger;
 }
 
 // ── Fastify mocks ──

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -11,7 +11,7 @@ import {
 } from "fastify-type-provider-zod";
 import type { CacheService } from "@/common/cache/cache.service.js";
 import { createCacheService } from "@/common/cache/create-cache.service.js";
-import { logger } from "@/common/logger.js";
+import type { Logger } from "@/common/logger.js";
 import { errorHandler } from "@/common/middleware/errorHandler.js";
 import { env } from "@/config/env.js";
 import { createRateLimitOptions } from "@/config/rate-limit.js";
@@ -47,9 +47,9 @@ declare module "fastify" {
   }
 }
 
-export async function buildApp() {
+export async function buildApp(log: Logger) {
   const app = Fastify({
-    loggerInstance: logger,
+    loggerInstance: log,
   });
 
   const cache = await createCacheService(
@@ -89,7 +89,7 @@ export async function buildApp() {
 
   // Routes
   app.register(authRoutes, {
-    service: createAuthService(UserModel),
+    service: createAuthService(UserModel, log),
     prefix: "/api/auth",
   });
   app.register(userRoutes, {

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -11,6 +11,7 @@ import {
 } from "fastify-type-provider-zod";
 import type { CacheService } from "@/common/cache/cache.service.js";
 import { createCacheService } from "@/common/cache/create-cache.service.js";
+import { logger } from "@/common/logger.js";
 import { errorHandler } from "@/common/middleware/errorHandler.js";
 import { env } from "@/config/env.js";
 import { createRateLimitOptions } from "@/config/rate-limit.js";
@@ -48,19 +49,16 @@ declare module "fastify" {
 
 export async function buildApp() {
   const app = Fastify({
-    logger: {
-      level: env.NODE_ENV === "production" ? "info" : "debug",
-      transport:
-        env.NODE_ENV === "development"
-          ? { target: "pino-pretty", options: { colorize: true } }
-          : undefined,
-    },
+    loggerInstance: logger,
   });
 
-  const cache = await createCacheService({
-    backend: env.CACHE_BACKEND,
-    redis: env.REDIS_URL ? { url: env.REDIS_URL } : undefined,
-  });
+  const cache = await createCacheService(
+    {
+      backend: env.CACHE_BACKEND,
+      redis: env.REDIS_URL ? { url: env.REDIS_URL } : undefined,
+    },
+    app.log,
+  );
 
   app.decorate("cache", cache);
 

--- a/apps/backend/src/common/bootstrap/admin.test.ts
+++ b/apps/backend/src/common/bootstrap/admin.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createMockLogger } from "@/__tests__/helpers.js";
 import { ensureRootAdmin } from "@/common/bootstrap/admin.js";
 
 const { UserModel } = await vi.hoisted(async () => ({
@@ -16,6 +17,8 @@ vi.mock("@/modules/users/user.model.js", () => ({
 }));
 
 describe("ensureRootAdmin", () => {
+  const log = createMockLogger();
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -24,7 +27,7 @@ describe("ensureRootAdmin", () => {
     UserModel.findOne.mockResolvedValue(null);
     UserModel.create.mockResolvedValue({});
 
-    await ensureRootAdmin();
+    await ensureRootAdmin(log);
 
     expect(UserModel.findOne).toHaveBeenCalledWith({ role: "admin" });
     expect(UserModel.create).toHaveBeenCalledWith({
@@ -33,14 +36,16 @@ describe("ensureRootAdmin", () => {
       name: "Root Admin",
       role: "admin",
     });
+    expect(log.info).toHaveBeenCalled();
   });
 
   it("should not create admin when one already exists", async () => {
     UserModel.findOne.mockResolvedValue({ email: "existing@admin.com" });
 
-    await ensureRootAdmin();
+    await ensureRootAdmin(log);
 
     expect(UserModel.findOne).toHaveBeenCalledWith({ role: "admin" });
     expect(UserModel.create).not.toHaveBeenCalled();
+    expect(log.info).not.toHaveBeenCalled();
   });
 });

--- a/apps/backend/src/common/bootstrap/admin.ts
+++ b/apps/backend/src/common/bootstrap/admin.ts
@@ -5,6 +5,7 @@ import { UserModel } from "@/modules/users/user.model.js";
 export async function ensureRootAdmin(log: Logger): Promise<void> {
   const existing = await UserModel.findOne({ role: "admin" });
   if (existing) {
+    log.info({ email: env.ROOT_ADMIN_EMAIL }, "Root admin already exists");
     return;
   }
 

--- a/apps/backend/src/common/bootstrap/admin.ts
+++ b/apps/backend/src/common/bootstrap/admin.ts
@@ -1,7 +1,8 @@
+import type { Logger } from "@/common/logger.js";
 import { env } from "@/config/env.js";
 import { UserModel } from "@/modules/users/user.model.js";
 
-export async function ensureRootAdmin(): Promise<void> {
+export async function ensureRootAdmin(log: Logger): Promise<void> {
   const existing = await UserModel.findOne({ role: "admin" });
   if (existing) {
     return;
@@ -14,5 +15,5 @@ export async function ensureRootAdmin(): Promise<void> {
     role: "admin",
   });
 
-  console.log(`✓ Root admin created: ${env.ROOT_ADMIN_EMAIL}`);
+  log.info({ email: env.ROOT_ADMIN_EMAIL }, "Root admin created");
 }

--- a/apps/backend/src/common/cache/create-cache.service.ts
+++ b/apps/backend/src/common/cache/create-cache.service.ts
@@ -1,3 +1,4 @@
+import type { Logger } from "@/common/logger.js";
 import type { CacheService } from "./cache.service.js";
 import type { MemoryCacheOptions } from "./memory-cache.service.js";
 import { createMemoryCache } from "./memory-cache.service.js";
@@ -14,18 +15,19 @@ export interface CacheFactoryOptions {
 
 export async function createCacheService(
   options: CacheFactoryOptions = {},
+  log: Logger,
 ): Promise<CacheService> {
   const { backend = "memory" } = options;
 
   if (backend === "redis" && options.redis?.url) {
     try {
-      const cache = createRedisCache(options.redis);
-      console.log("✅ Redis cache connected");
+      const cache = createRedisCache(options.redis, log);
+      log.info("Redis cache connected");
       return cache;
     } catch (error) {
-      console.warn(
-        "⚠️  Redis unavailable, falling back to in-memory cache:",
-        error instanceof Error ? error.message : error,
+      log.warn(
+        { err: error },
+        "Redis unavailable, falling back to in-memory cache",
       );
     }
   }

--- a/apps/backend/src/common/cache/redis-cache.service.ts
+++ b/apps/backend/src/common/cache/redis-cache.service.ts
@@ -1,4 +1,5 @@
 import { Redis } from "ioredis";
+import type { Logger } from "@/common/logger.js";
 import type { CacheService } from "./cache.service.js";
 
 export interface RedisCacheOptions {
@@ -7,7 +8,10 @@ export interface RedisCacheOptions {
   keyPrefix?: string;
 }
 
-export function createRedisCache(options: RedisCacheOptions): CacheService {
+export function createRedisCache(
+  options: RedisCacheOptions,
+  log: Logger,
+): CacheService {
   const { url, defaultTTL, keyPrefix = "" } = options;
 
   const redis = new Redis(url, {
@@ -17,6 +21,14 @@ export function createRedisCache(options: RedisCacheOptions): CacheService {
       return Math.min(times * 200, 2000);
     },
     lazyConnect: true,
+  });
+
+  redis.on("error", (err) => {
+    log.error(err, "Redis connection error");
+  });
+
+  redis.on("reconnecting", () => {
+    log.warn("Redis reconnecting");
   });
 
   function prefixed(key: string): string {

--- a/apps/backend/src/common/logger.ts
+++ b/apps/backend/src/common/logger.ts
@@ -1,0 +1,12 @@
+import pino from "pino";
+import { env } from "@/config/env.js";
+
+export const logger = pino({
+  level: env.NODE_ENV === "production" ? "info" : "debug",
+  transport:
+    env.NODE_ENV === "development"
+      ? { target: "pino-pretty", options: { colorize: true } }
+      : undefined,
+});
+
+export type { Logger } from "pino";

--- a/apps/backend/src/common/middleware/auth.guard.ts
+++ b/apps/backend/src/common/middleware/auth.guard.ts
@@ -44,7 +44,11 @@ export async function authGuard(request: FastifyRequest, reply: FastifyReply) {
   try {
     const token = extractToken(request);
     request.user = verifyToken(token);
-  } catch {
+  } catch (error) {
+    request.log.warn(
+      { err: error, ip: request.ip, url: request.url },
+      "Authentication failed",
+    );
     return reply.status(401).send({ error: "Invalid or expired token" });
   }
 }

--- a/apps/backend/src/config/database.ts
+++ b/apps/backend/src/config/database.ts
@@ -16,6 +16,7 @@ export async function connectDatabase(log: Logger): Promise<void> {
   });
 }
 
-export async function disconnectDatabase(): Promise<void> {
+export async function disconnectDatabase(log: Logger): Promise<void> {
   await mongoose.disconnect();
+  log.info("MongoDB disconnected");
 }

--- a/apps/backend/src/config/database.ts
+++ b/apps/backend/src/config/database.ts
@@ -14,9 +14,12 @@ export async function connectDatabase(log: Logger): Promise<void> {
   mongoose.connection.on("error", (err) => {
     log.error(err, "MongoDB connection error");
   });
+  mongoose.connection.on("reconnected", () => {
+    log.warn("MongoDB reconnected");
+  });
 }
 
 export async function disconnectDatabase(log: Logger): Promise<void> {
   await mongoose.disconnect();
-  log.info("MongoDB disconnected");
+  log.info("MongoDB disconnected gracefully");
 }

--- a/apps/backend/src/config/database.ts
+++ b/apps/backend/src/config/database.ts
@@ -1,17 +1,18 @@
 import mongoose from "mongoose";
+import type { Logger } from "@/common/logger.js";
 import { env } from "./env.js";
 
-export async function connectDatabase(): Promise<void> {
+export async function connectDatabase(log: Logger): Promise<void> {
   try {
     await mongoose.connect(env.MONGO_URI);
-    console.log("✅ MongoDB connected");
+    log.info("MongoDB connected");
   } catch (error) {
-    console.error("❌ MongoDB connection error:", error);
+    log.fatal(error, "MongoDB connection error");
     process.exit(1);
   }
 
   mongoose.connection.on("error", (err) => {
-    console.error("MongoDB error:", err);
+    log.error(err, "MongoDB connection error");
   });
 }
 

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -4,11 +4,21 @@ import { logger } from "./common/logger.js";
 import { connectDatabase, disconnectDatabase } from "./config/database.js";
 import { env } from "./config/env.js";
 
+process.on("unhandledRejection", (reason) => {
+  logger.fatal({ err: reason }, "Unhandled promise rejection");
+  process.exit(1);
+});
+
+process.on("uncaughtException", (error) => {
+  logger.fatal({ err: error }, "Uncaught exception");
+  process.exit(1);
+});
+
 async function start() {
   await connectDatabase(logger);
   await ensureRootAdmin(logger);
 
-  const app = await buildApp();
+  const app = await buildApp(logger);
 
   try {
     await app.listen({ port: env.PORT, host: env.HOST });
@@ -22,8 +32,13 @@ async function start() {
   for (const signal of signals) {
     process.on(signal, async () => {
       app.log.info({ signal }, "Received signal, shutting down gracefully");
-      await app.close();
-      await disconnectDatabase();
+      try {
+        await app.close();
+        app.log.info("HTTP server closed");
+        await disconnectDatabase(logger);
+      } catch (err) {
+        app.log.error(err, "Error during shutdown");
+      }
       process.exit(0);
     });
   }

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -1,11 +1,12 @@
 import { buildApp } from "./app.js";
 import { ensureRootAdmin } from "./common/bootstrap/admin.js";
+import { logger } from "./common/logger.js";
 import { connectDatabase, disconnectDatabase } from "./config/database.js";
 import { env } from "./config/env.js";
 
 async function start() {
-  await connectDatabase();
-  await ensureRootAdmin();
+  await connectDatabase(logger);
+  await ensureRootAdmin(logger);
 
   const app = await buildApp();
 

--- a/apps/backend/src/modules/auth/auth.service.test.ts
+++ b/apps/backend/src/modules/auth/auth.service.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createMockUserModel, createUserDoc } from "@/__tests__/helpers.js";
+import {
+  createMockLogger,
+  createMockUserModel,
+  createUserDoc,
+} from "@/__tests__/helpers.js";
 import { ConflictError, UnauthorizedError } from "@/common/errors.js";
 import type { UserModelType } from "@/modules/users/user.model.js";
 import { createAuthService } from "./auth.service.js";
@@ -12,7 +16,8 @@ vi.mock("@/common/utils/jwt.js", () => ({ signToken }));
 
 describe("authService", () => {
   const userModel = createMockUserModel();
-  const service = createAuthService(userModel as unknown as UserModelType);
+  const log = createMockLogger();
+  const service = createAuthService(userModel as unknown as UserModelType, log);
 
   beforeEach(() => {
     vi.clearAllMocks();

--- a/apps/backend/src/modules/auth/auth.service.ts
+++ b/apps/backend/src/modules/auth/auth.service.ts
@@ -1,5 +1,6 @@
 import type { AuthResponse, LoginBody, RegisterBody } from "@recipes/shared";
 import { ConflictError, UnauthorizedError } from "@/common/errors.js";
+import type { Logger } from "@/common/logger.js";
 import { signToken } from "@/common/utils/jwt.js";
 import { toUser } from "@/common/utils/mongo.js";
 import type { UserModelType } from "@/modules/users/index.js";
@@ -9,11 +10,18 @@ export interface AuthService {
   login(data: LoginBody): Promise<AuthResponse>;
 }
 
-export function createAuthService(userModel: UserModelType): AuthService {
+export function createAuthService(
+  userModel: UserModelType,
+  log: Logger,
+): AuthService {
   return {
     register: async (data) => {
       const exists = await userModel.exists({ email: data.email });
       if (exists) {
+        log.warn(
+          { email: data.email },
+          "Registration attempt with existing email",
+        );
         throw new ConflictError("Email already in use");
       }
 
@@ -23,6 +31,8 @@ export function createAuthService(userModel: UserModelType): AuthService {
         email: user.email,
         role: user.role,
       });
+
+      log.info({ userId: user.id, email: user.email }, "User registered");
 
       return {
         user: toUser(user.toObject()),
@@ -34,6 +44,7 @@ export function createAuthService(userModel: UserModelType): AuthService {
         .findOne({ email: data.email })
         .select("+password");
       if (!user || !(await user.comparePassword(data.password))) {
+        log.warn({ email: data.email }, "Failed login attempt");
         throw new UnauthorizedError("Invalid email or password");
       }
 
@@ -42,6 +53,8 @@ export function createAuthService(userModel: UserModelType): AuthService {
         email: user.email,
         role: user.role,
       });
+
+      log.info({ userId: user.id, email: user.email }, "User logged in");
 
       return {
         user: toUser(user.toObject()),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       mongoose:
         specifier: ^9.3.3
         version: 9.3.3
+      pino:
+        specifier: ^10.3.1
+        version: 10.3.1
     devDependencies:
       '@types/jsonwebtoken':
         specifier: ^9.0.10


### PR DESCRIPTION
## PR Type

- [x] Feature
- [x] Refactoring

## Description

Replace all `console.log/error/warn` calls with a structured pino logger and add critical logging that was previously missing.

**Logger setup:**
- Create standalone pino logger (`src/common/logger.ts`) with the same config as Fastify (level, pino-pretty for dev)
- Pass logger instance to `Fastify` via `loggerInstance`, and to `connectDatabase`, `ensureRootAdmin`, `createCacheService`, `createAuthService`
- `env.ts` intentionally keeps `console.error` — runs at import time before logger init

**Critical logging added:**
- `unhandledRejection` / `uncaughtException` global handlers — `fatal` log + exit(1)
- Shutdown sequence — logs each step (HTTP close, MongoDB disconnect), catches errors
- Auth guard — `warn` on failed JWT verification with IP and URL context
- Auth service — `info` on register/login, `warn` on duplicate email or failed login

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Added/updated tests for new functionality
- [ ] Updated documentation (if needed)