### PR TITLE
refactor: extract favorite routes into dedicated module

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -29,6 +29,7 @@ import {
 import {
   createFavoriteService,
   FavoriteModel,
+  favoriteRoutes,
 } from "@/modules/favorites/index.js";
 import {
   createRecipeService,
@@ -108,12 +109,11 @@ export async function buildApp(log: Logger) {
       CategoryModel,
       cache,
     ),
-    favoriteService: createFavoriteService(
-      FavoriteModel,
-      RecipeModel,
-      UserModel,
-    ),
     commentService: createCommentService(CommentModel, RecipeModel, UserModel),
+    prefix: "/api/recipes",
+  });
+  app.register(favoriteRoutes, {
+    service: createFavoriteService(FavoriteModel, RecipeModel, UserModel),
     prefix: "/api/recipes",
   });
   app.register(categoryRoutes, {

--- a/apps/backend/src/modules/favorites/favorite.routes.ts
+++ b/apps/backend/src/modules/favorites/favorite.routes.ts
@@ -1,0 +1,90 @@
+import type { FastifyPluginAsync } from "fastify";
+import type { ZodTypeProvider } from "fastify-type-provider-zod";
+import { z } from "zod";
+import {
+  assertAuthenticated,
+  authGuard,
+} from "@/common/middleware/auth.guard.js";
+import type { FavoriteService } from "@/modules/favorites/index.js";
+import { recipeParamsSchema } from "@/modules/recipes/index.js";
+
+export interface FavoriteModuleOptions {
+  service: FavoriteService;
+}
+
+export const favoriteRoutes: FastifyPluginAsync<FavoriteModuleOptions> = async (
+  fastify,
+  { service },
+) => {
+  fastify
+    .withTypeProvider<ZodTypeProvider>()
+    .get(
+      "/:id/favorite",
+      {
+        schema: {
+          params: recipeParamsSchema,
+          response: {
+            200: z.object({ favorited: z.boolean() }),
+          },
+          tags: ["Favorites"],
+          summary: "Check if recipe is favorited",
+          security: [{ bearerAuth: [] }],
+        },
+        onRequest: authGuard,
+      },
+      async (request, reply) => {
+        assertAuthenticated(request);
+
+        const favorited = await service.isFavorited(request.params.id, {
+          initiator: { id: request.user.userId, role: request.user.role },
+        });
+        return reply.send({ favorited });
+      },
+    )
+    .post(
+      "/:id/favorite",
+      {
+        schema: {
+          params: recipeParamsSchema,
+          response: {
+            200: z.object({ favorited: z.literal(true) }),
+          },
+          tags: ["Favorites"],
+          summary: "Add recipe to favorites",
+          security: [{ bearerAuth: [] }],
+        },
+        onRequest: authGuard,
+      },
+      async (request, reply) => {
+        assertAuthenticated(request);
+
+        const result = await service.add(request.params.id, {
+          initiator: { id: request.user.userId, role: request.user.role },
+        });
+        return reply.send(result);
+      },
+    )
+    .delete(
+      "/:id/favorite",
+      {
+        schema: {
+          params: recipeParamsSchema,
+          response: {
+            200: z.object({ favorited: z.literal(false) }),
+          },
+          tags: ["Favorites"],
+          summary: "Remove recipe from favorites",
+          security: [{ bearerAuth: [] }],
+        },
+        onRequest: authGuard,
+      },
+      async (request, reply) => {
+        assertAuthenticated(request);
+
+        const result = await service.remove(request.params.id, {
+          initiator: { id: request.user.userId, role: request.user.role },
+        });
+        return reply.send(result);
+      },
+    );
+};

--- a/apps/backend/src/modules/favorites/index.ts
+++ b/apps/backend/src/modules/favorites/index.ts
@@ -1,6 +1,4 @@
-// Routes are registered within recipe.routes.ts, not as a standalone module.
-// This is intentional: favorites are a child resource of recipes.
-
 export * from "./favorite.model.js";
+export * from "./favorite.routes.js";
 export * from "./favorite.schema.js";
 export * from "./favorite.service.js";

--- a/apps/backend/src/modules/recipes/recipe.routes.ts
+++ b/apps/backend/src/modules/recipes/recipe.routes.ts
@@ -5,7 +5,6 @@ import {
 } from "@recipes/shared";
 import type { FastifyPluginAsync } from "fastify";
 import type { ZodTypeProvider } from "fastify-type-provider-zod";
-import { z } from "zod";
 import {
   assertAuthenticated,
   authGuard,
@@ -17,7 +16,6 @@ import {
   commentQuerySchema,
   createCommentSchema,
 } from "@/modules/comments/index.js";
-import type { FavoriteService } from "@/modules/favorites/index.js";
 import type { RecipeService } from "@/modules/recipes/index.js";
 import {
   createRecipeSchema,
@@ -28,13 +26,12 @@ import {
 
 export interface RecipeModuleOptions {
   service: RecipeService;
-  favoriteService: FavoriteService;
   commentService: CommentService;
 }
 
 export const recipeRoutes: FastifyPluginAsync<RecipeModuleOptions> = async (
   fastify,
-  { service, favoriteService, commentService },
+  { service, commentService },
 ) => {
   fastify
     .withTypeProvider<ZodTypeProvider>()
@@ -146,74 +143,6 @@ export const recipeRoutes: FastifyPluginAsync<RecipeModuleOptions> = async (
           initiator: { id: request.user.userId, role: request.user.role },
         });
         return reply.status(204).send();
-      },
-    )
-    .post(
-      "/:id/favorite",
-      {
-        schema: {
-          params: recipeParamsSchema,
-          response: {
-            200: z.object({ favorited: z.literal(true) }),
-          },
-          tags: ["Recipes"],
-          summary: "Add recipe to favorites",
-          security: [{ bearerAuth: [] }],
-        },
-        onRequest: authGuard,
-      },
-      async (request, reply) => {
-        assertAuthenticated(request);
-
-        const result = await favoriteService.add(request.params.id, {
-          initiator: { id: request.user.userId, role: request.user.role },
-        });
-        return reply.send(result);
-      },
-    )
-    .delete(
-      "/:id/favorite",
-      {
-        schema: {
-          params: recipeParamsSchema,
-          response: {
-            200: z.object({ favorited: z.literal(false) }),
-          },
-          tags: ["Recipes"],
-          summary: "Remove recipe from favorites",
-          security: [{ bearerAuth: [] }],
-        },
-        onRequest: authGuard,
-      },
-      async (request, reply) => {
-        assertAuthenticated(request);
-
-        const result = await favoriteService.remove(request.params.id, {
-          initiator: { id: request.user.userId, role: request.user.role },
-        });
-        return reply.send(result);
-      },
-    )
-    .get(
-      "/:id/favorite",
-      {
-        schema: {
-          params: recipeParamsSchema,
-          response: {
-            200: z.object({ favorited: z.boolean() }),
-          },
-          tags: ["Recipes"],
-          summary: "Check if recipe is favorited",
-        },
-        onRequest: authGuard,
-      },
-      async (request, reply) => {
-        assertAuthenticated(request);
-
-        const favorited = await favoriteService.isFavorited(request.params.id, {
-          initiator: { id: request.user.userId, role: request.user.role },
-        });
-        return reply.send({ favorited });
       },
     )
     .get(


### PR DESCRIPTION
## PR Type

- [x] Refactoring

## Description

Extract favorite routes from `recipe.routes.ts` into a dedicated `favorites/favorite.routes.ts` module.

Favorites represent a user-recipe relationship (many-to-many), unlike comments which are a true sub-resource of a recipe. This separation gives the favorites module full ownership of its routes alongside its existing model, schema, service, and aggregation files.

**What changed:**
- Created `favorites/favorite.routes.ts` with `FavoriteModuleOptions` interface accepting only `FavoriteService`
- Removed 3 favorite routes (POST/DELETE/GET `/:id/favorite`) from `recipe.routes.ts`
- Removed `FavoriteService` from `RecipeModuleOptions` interface
- Registered `favoriteRoutes` under the same `/api/recipes` prefix in `app.ts`
- Swagger tags changed from `["Recipes"]` to `["Favorites"]`

**No breaking changes** — all API URLs remain identical.

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes