### PR TITLE
refactor: move query schemas and types to shared package

### DIFF
--- a/apps/backend/src/__tests__/helpers.ts
+++ b/apps/backend/src/__tests__/helpers.ts
@@ -1,4 +1,4 @@
-import type { Minutes } from "@recipes/shared";
+import type { Minutes, UserRole } from "@recipes/shared";
 import type { FastifyReply, FastifyRequest } from "fastify";
 import { Types } from "mongoose";
 import type { Mock } from "vitest";
@@ -12,7 +12,7 @@ import type {
   RecipeDocument,
   RecipeDocumentPopulated,
 } from "@/modules/recipes/recipe.model.js";
-import type { UserDocument, UserRole } from "@/modules/users/user.model.js";
+import type { UserDocument } from "@/modules/users/user.model.js";
 
 type LocalProcedure = (...args: unknown[]) => unknown;
 function viFn<T extends LocalProcedure>(fn?: T): Mock<T> {

--- a/apps/backend/src/common/schemas.ts
+++ b/apps/backend/src/common/schemas.ts
@@ -1,15 +1,4 @@
-import z from "zod";
+import { z } from "zod";
 
 export const idParamSchema = z.string().trim().length(24);
 export type IdParam = z.infer<typeof idParamSchema>;
-
-export const searchQuerySchema = z.object({
-  search: z.string().trim().optional(),
-});
-export type SearchQuery = z.infer<typeof searchQuerySchema>;
-
-export const paginationQuerySchema = z.object({
-  page: z.coerce.number().int().min(1).default(1),
-  limit: z.coerce.number().int().min(1).max(100).default(20),
-});
-export type PaginationQuery = z.infer<typeof paginationQuerySchema>;

--- a/apps/backend/src/common/types/methods.ts
+++ b/apps/backend/src/common/types/methods.ts
@@ -1,5 +1,4 @@
-import type { Prettify } from "@recipes/shared";
-import type { UserRole } from "@/modules/users/user.model.js";
+import type { Prettify, UserRole } from "@recipes/shared";
 
 export type DefaultQuery = { page: number; limit: number };
 export type DefaultInitiator = { readonly id: string; readonly role: UserRole };

--- a/apps/backend/src/common/utils/jwt.ts
+++ b/apps/backend/src/common/utils/jwt.ts
@@ -1,7 +1,7 @@
+import type { UserRole } from "@recipes/shared";
 import jwt from "jsonwebtoken";
 import type { StringValue } from "ms";
 import { env } from "@/config/env.js";
-import type { UserRole } from "@/modules/users/user.model.js";
 
 export interface JwtPayload {
   userId: string;

--- a/apps/backend/src/modules/auth/auth.schema.ts
+++ b/apps/backend/src/modules/auth/auth.schema.ts
@@ -1,6 +1,0 @@
-export {
-  type LoginBody,
-  loginSchema,
-  type RegisterBody,
-  registerSchema,
-} from "@recipes/shared";

--- a/apps/backend/src/modules/auth/index.ts
+++ b/apps/backend/src/modules/auth/index.ts
@@ -1,3 +1,2 @@
 export * from "./auth.routes.js";
-export * from "./auth.schema.js";
 export * from "./auth.service.js";

--- a/apps/backend/src/modules/categories/category.cache.ts
+++ b/apps/backend/src/modules/categories/category.cache.ts
@@ -1,9 +1,9 @@
-import type { SearchCategoryQuery } from "@recipes/shared";
+import type { CategoryQuery } from "@recipes/shared";
 import { hashFilters } from "@/common/utils/cache.js";
 
 export const categoryCache = {
   keys: {
-    list: (filters: SearchCategoryQuery) =>
+    list: (filters: CategoryQuery) =>
       `categories:list:${hashFilters({
         sort: filters.sort,
       })}`,

--- a/apps/backend/src/modules/categories/category.model.ts
+++ b/apps/backend/src/modules/categories/category.model.ts
@@ -1,4 +1,4 @@
-import type { SearchCategoryQuery } from "@recipes/shared";
+import type { CategoryQuery } from "@recipes/shared";
 import type { Model } from "mongoose";
 import { model, Schema } from "mongoose";
 import type { BaseDocument } from "@/common/types/mongoose.js";
@@ -16,7 +16,7 @@ export interface CategoryDocumentWithCount extends CategoryDocument {
 
 export interface CategoryModelType extends Model<CategoryDocument> {
   searchFull(
-    query: SearchCategoryQuery,
+    query: CategoryQuery,
     withCount?: boolean,
   ): Promise<CategoryDocumentWithCount[]>;
 }
@@ -43,7 +43,7 @@ categorySchema.pre("validate", function () {
 });
 
 categorySchema.statics.searchFull = async function (
-  query: SearchCategoryQuery,
+  query: CategoryQuery,
   withCount: boolean = true,
 ): Promise<CategoryDocumentWithCount[]> {
   const result = await this.aggregate<CategoryDocumentWithCount>([

--- a/apps/backend/src/modules/categories/category.routes.ts
+++ b/apps/backend/src/modules/categories/category.routes.ts
@@ -1,4 +1,8 @@
-import { categoryQuerySchema, categorySchema } from "@recipes/shared";
+import {
+  categoryQuerySchema,
+  categorySchema,
+  createCategorySchema,
+} from "@recipes/shared";
 import type { FastifyPluginAsync } from "fastify";
 import type { ZodTypeProvider } from "fastify-type-provider-zod";
 import { z } from "zod";
@@ -7,10 +11,7 @@ import {
   authGuard,
 } from "@/common/middleware/auth.guard.js";
 import { rolesGuard } from "@/common/middleware/role.guard.js";
-import {
-  categoryParamsSchema,
-  createCategorySchema,
-} from "@/modules/categories/category.schema.js";
+import { categoryParamsSchema } from "@/modules/categories/category.schema.js";
 import type { CategoryService } from "@/modules/categories/category.service.js";
 
 export interface CategoryModuleOptions {

--- a/apps/backend/src/modules/categories/category.schema.ts
+++ b/apps/backend/src/modules/categories/category.schema.ts
@@ -1,8 +1,6 @@
 import { z } from "zod";
 import { idParamSchema } from "@/common/schemas.js";
 
-export { type CreateCategoryBody, createCategorySchema } from "@recipes/shared";
-
 export const categoryParamsSchema = z.object({
   id: idParamSchema,
 });

--- a/apps/backend/src/modules/categories/category.service.test.ts
+++ b/apps/backend/src/modules/categories/category.service.test.ts
@@ -1,4 +1,4 @@
-import type { SearchCategoryQuery } from "@recipes/shared";
+import type { CategoryQuery } from "@recipes/shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createCategoryDoc,
@@ -44,7 +44,7 @@ describe("categoryService", () => {
       ];
       categoryModel.searchFull.mockResolvedValue(docs);
 
-      const query = { sort: "name" } satisfies SearchCategoryQuery;
+      const query = { sort: "name" } satisfies CategoryQuery;
       const result = await service.findAll({
         query,
         initiator: noInitiator(),
@@ -61,7 +61,7 @@ describe("categoryService", () => {
     it("should return empty array when no categories exist", async () => {
       categoryModel.searchFull.mockResolvedValue([]);
 
-      const query = { sort: "name" } satisfies SearchCategoryQuery;
+      const query = { sort: "name" } satisfies CategoryQuery;
       const result = await service.findAll({
         query,
         initiator: noInitiator(),
@@ -79,7 +79,7 @@ describe("categoryService", () => {
       ];
       categoryModel.searchFull.mockResolvedValue(docs);
 
-      const query = { sort: "name" } satisfies SearchCategoryQuery;
+      const query = { sort: "name" } satisfies CategoryQuery;
       await service.findAll({
         query,
         initiator: noInitiator(),

--- a/apps/backend/src/modules/categories/category.service.ts
+++ b/apps/backend/src/modules/categories/category.service.ts
@@ -1,7 +1,7 @@
 import type {
   Category,
+  CategoryQuery,
   CreateCategoryBody,
-  SearchCategoryQuery,
 } from "@recipes/shared";
 import type { CacheService } from "@/common/cache/cache.service.js";
 import { ConflictError, NotFoundError } from "@/common/errors.js";
@@ -16,7 +16,7 @@ import type { CategoryModelType } from "@/modules/categories/index.js";
 import type { RecipeModelType } from "@/modules/recipes/index.js";
 
 export interface CategoryService {
-  findAll(params: QueryMethodParams<SearchCategoryQuery>): Promise<Category[]>;
+  findAll(params: QueryMethodParams<CategoryQuery>): Promise<Category[]>;
   create(params: CreateMethodParams<CreateCategoryBody>): Promise<Category>;
   deleteById(categoryId: string, params: DeleteMethodParams): Promise<void>;
 }

--- a/apps/backend/src/modules/categories/category.service.ts
+++ b/apps/backend/src/modules/categories/category.service.ts
@@ -1,4 +1,8 @@
-import type { Category, SearchCategoryQuery } from "@recipes/shared";
+import type {
+  Category,
+  CreateCategoryBody,
+  SearchCategoryQuery,
+} from "@recipes/shared";
 import type { CacheService } from "@/common/cache/cache.service.js";
 import { ConflictError, NotFoundError } from "@/common/errors.js";
 import type {
@@ -8,10 +12,7 @@ import type {
 } from "@/common/types/methods.js";
 import { toCategory } from "@/common/utils/mongo.js";
 import { categoryCache } from "@/modules/categories/category.cache.js";
-import type {
-  CategoryModelType,
-  CreateCategoryBody,
-} from "@/modules/categories/index.js";
+import type { CategoryModelType } from "@/modules/categories/index.js";
 import type { RecipeModelType } from "@/modules/recipes/index.js";
 
 export interface CategoryService {

--- a/apps/backend/src/modules/comments/comment.schema.ts
+++ b/apps/backend/src/modules/comments/comment.schema.ts
@@ -1,7 +1,5 @@
 import { z } from "zod";
-import { idParamSchema, paginationQuerySchema } from "@/common/schemas.js";
-
-export { type CreateCommentBody, createCommentSchema } from "@recipes/shared";
+import { idParamSchema } from "@/common/schemas.js";
 
 export const commentParamsSchema = z.object({
   id: idParamSchema,
@@ -10,9 +8,3 @@ export const commentParamsSchema = z.object({
 export const recipeCommentsParamsSchema = z.object({
   recipeId: idParamSchema,
 });
-
-export const commentQuerySchema = paginationQuerySchema;
-
-export type CommentParams = z.infer<typeof commentParamsSchema>;
-export type RecipeCommentsParams = z.infer<typeof recipeCommentsParamsSchema>;
-export type CommentQuery = z.infer<typeof commentQuerySchema>;

--- a/apps/backend/src/modules/comments/comment.service.ts
+++ b/apps/backend/src/modules/comments/comment.service.ts
@@ -1,4 +1,9 @@
-import type { Comment, CommentForRecipe, Paginated } from "@recipes/shared";
+import type {
+  Comment,
+  CommentForRecipe,
+  CreateCommentBody,
+  Paginated,
+} from "@recipes/shared";
 import { withPagination } from "@recipes/shared";
 import { isValidObjectId } from "mongoose";
 import {
@@ -12,10 +17,7 @@ import type {
   QueryMethodParams,
 } from "@/common/types/methods.js";
 import { toComment, toCommentForRecipe } from "@/common/utils/mongo.js";
-import type {
-  CommentModelType,
-  CreateCommentBody,
-} from "@/modules/comments/index.js";
+import type { CommentModelType } from "@/modules/comments/index.js";
 import type { RecipeModelType } from "@/modules/recipes/index.js";
 import type { UserDocument, UserModelType } from "@/modules/users/index.js";
 

--- a/apps/backend/src/modules/favorites/favorite.schema.ts
+++ b/apps/backend/src/modules/favorites/favorite.schema.ts
@@ -1,11 +1,6 @@
 import z from "zod";
-import { idParamSchema, paginationQuerySchema } from "@/common/schemas.js";
+import { idParamSchema } from "@/common/schemas.js";
 
 export const favoriteParamsSchema = z.object({
   recipeId: idParamSchema,
 });
-
-export const favoriteQuerySchema = paginationQuerySchema;
-
-export type FavoriteParams = z.infer<typeof favoriteParamsSchema>;
-export type FavoriteQuery = z.infer<typeof favoriteQuerySchema>;

--- a/apps/backend/src/modules/favorites/favorite.service.ts
+++ b/apps/backend/src/modules/favorites/favorite.service.ts
@@ -1,17 +1,16 @@
-import type { Paginated, Recipe } from "@recipes/shared";
+import type { Paginated, PaginationQuery, Recipe } from "@recipes/shared";
 import { withPagination } from "@recipes/shared";
 import { isValidObjectId } from "mongoose";
 import { BadRequestError, NotFoundError } from "@/common/errors.js";
-import type { PaginationQuery } from "@/common/schemas.js";
 import type {
   DefaultInitiator,
   InitiatedMethodParams,
   QueryMethodParams,
 } from "@/common/types/methods.js";
 import { toRecipe } from "@/common/utils/mongo.js";
-import type { FavoriteModelType } from "@/modules/favorites/index.js";
-import type { RecipeModelType } from "@/modules/recipes/index.js";
-import type { UserModelType } from "@/modules/users/index.js";
+import type { FavoriteModelType } from "@/modules/favorites/favorite.model.js";
+import type { RecipeModelType } from "@/modules/recipes/recipe.model.js";
+import type { UserModelType } from "@/modules/users/user.model.js";
 
 export interface FavoriteService {
   add(

--- a/apps/backend/src/modules/recipes/recipe.cache.ts
+++ b/apps/backend/src/modules/recipes/recipe.cache.ts
@@ -1,10 +1,10 @@
-import type { SearchRecipeQuery } from "@recipes/shared";
+import type { RecipeQuery } from "@recipes/shared";
 import { hashFilters } from "@/common/utils/cache.js";
 
 export const recipeCache = {
   keys: {
     byId: (id: string) => `recipes:id:${id}`,
-    list: (filters: SearchRecipeQuery) =>
+    list: (filters: RecipeQuery) =>
       `recipes:list:${filters.page}:${filters.limit}:${hashFilters({
         categoryId: filters.categoryId,
         difficulty: filters.difficulty,

--- a/apps/backend/src/modules/recipes/recipe.cache.ts
+++ b/apps/backend/src/modules/recipes/recipe.cache.ts
@@ -1,24 +1,15 @@
-import crypto from "node:crypto";
-import type { SearchRecipeQuery } from "./recipe.schema.js";
-
-function hashFilters(query: SearchRecipeQuery): string {
-  const stable = {
-    categoryId: query.categoryId,
-    difficulty: query.difficulty,
-    sort: query.sort,
-  };
-  return crypto
-    .createHash("md5")
-    .update(JSON.stringify(stable))
-    .digest("hex")
-    .slice(0, 8);
-}
+import type { SearchRecipeQuery } from "@recipes/shared";
+import { hashFilters } from "@/common/utils/cache.js";
 
 export const recipeCache = {
   keys: {
     byId: (id: string) => `recipes:id:${id}`,
     list: (filters: SearchRecipeQuery) =>
-      `recipes:list:${filters.page}:${filters.limit}:${hashFilters(filters)}`,
+      `recipes:list:${filters.page}:${filters.limit}:${hashFilters({
+        categoryId: filters.categoryId,
+        difficulty: filters.difficulty,
+        sort: filters.sort,
+      })}`,
     allPattern: () => "recipes:*",
   },
   ttl: {

--- a/apps/backend/src/modules/recipes/recipe.model.ts
+++ b/apps/backend/src/modules/recipes/recipe.model.ts
@@ -1,8 +1,8 @@
 import type {
   Difficulty,
   Minutes,
+  RecipeQuery,
   Replace,
-  SearchRecipeQuery,
 } from "@recipes/shared";
 import type { Model, Types } from "mongoose";
 import { model, Schema } from "mongoose";
@@ -62,7 +62,7 @@ export interface RecipeDocumentPopulated
 
 export interface RecipeModelType extends Model<RecipeDocument> {
   searchFull(
-    params: QueryMethodParams<SearchRecipeQuery>,
+    params: QueryMethodParams<RecipeQuery>,
   ): Promise<[RecipeDocumentPopulated[], number] | [null, 0]>;
   findByIdFull(
     id: string,
@@ -126,7 +126,7 @@ const recipeSchema = new Schema<RecipeDocument, RecipeModelType>(
 recipeSchema.statics.searchFull = async function ({
   query,
   initiator,
-}: QueryMethodParams<SearchRecipeQuery>) {
+}: QueryMethodParams<RecipeQuery>) {
   const { page, limit, sort, isFavorited, search, categoryId, difficulty } =
     query;
 

--- a/apps/backend/src/modules/recipes/recipe.model.ts
+++ b/apps/backend/src/modules/recipes/recipe.model.ts
@@ -1,4 +1,9 @@
-import type { Difficulty, Minutes, Replace } from "@recipes/shared";
+import type {
+  Difficulty,
+  Minutes,
+  Replace,
+  SearchRecipeQuery,
+} from "@recipes/shared";
 import type { Model, Types } from "mongoose";
 import { model, Schema } from "mongoose";
 import type {
@@ -16,7 +21,6 @@ import {
 } from "@/common/utils/mongoose.aggregation.js";
 import type { CategoryDocument } from "@/modules/categories/index.js";
 import { CATEGORY_MODEL_NAME } from "@/modules/categories/index.js";
-import type { SearchRecipeQuery } from "@/modules/recipes/index.js";
 import type { UserDocument } from "@/modules/users/index.js";
 import { USER_MODEL_NAME } from "@/modules/users/index.js";
 import {

--- a/apps/backend/src/modules/recipes/recipe.routes.ts
+++ b/apps/backend/src/modules/recipes/recipe.routes.ts
@@ -1,7 +1,12 @@
 import {
   commentForRecipeSchema,
+  commentQuerySchema,
+  createCommentSchema,
+  createRecipeSchema,
   paginatedSchema,
+  recipeQuerySchema,
   recipeSchema,
+  updateRecipeSchema,
 } from "@recipes/shared";
 import type { FastifyPluginAsync } from "fastify";
 import type { ZodTypeProvider } from "fastify-type-provider-zod";
@@ -11,18 +16,9 @@ import {
   optionalAuth,
 } from "@/common/middleware/auth.guard.js";
 import type { CommentService } from "@/modules/comments/index.js";
-import {
-  commentParamsSchema,
-  commentQuerySchema,
-  createCommentSchema,
-} from "@/modules/comments/index.js";
+import { commentParamsSchema } from "@/modules/comments/index.js";
 import type { RecipeService } from "@/modules/recipes/index.js";
-import {
-  createRecipeSchema,
-  recipeParamsSchema,
-  recipeQuerySchema,
-  updateRecipeSchema,
-} from "@/modules/recipes/index.js";
+import { recipeParamsSchema } from "@/modules/recipes/index.js";
 
 export interface RecipeModuleOptions {
   service: RecipeService;

--- a/apps/backend/src/modules/recipes/recipe.schema.ts
+++ b/apps/backend/src/modules/recipes/recipe.schema.ts
@@ -1,30 +1,6 @@
-import { difficultySchema } from "@recipes/shared";
 import { z } from "zod";
-import {
-  idParamSchema,
-  paginationQuerySchema,
-  searchQuerySchema,
-} from "@/common/schemas.js";
-
-export {
-  type CreateRecipeBody,
-  createRecipeSchema,
-  type UpdateRecipeBody,
-  updateRecipeSchema,
-} from "@recipes/shared";
+import { idParamSchema } from "@/common/schemas.js";
 
 export const recipeParamsSchema = z.object({
   id: idParamSchema,
 });
-
-export const recipeQuerySchema = z
-  .object({
-    sort: z.string().trim().default("-createdAt"),
-    categoryId: idParamSchema.optional(),
-    difficulty: difficultySchema.optional(),
-    isFavorited: z.stringbool().optional(),
-  })
-  .extend(paginationQuerySchema.shape)
-  .extend(searchQuerySchema.shape);
-
-export type SearchRecipeQuery = z.infer<typeof recipeQuerySchema>;

--- a/apps/backend/src/modules/recipes/recipe.service.test.ts
+++ b/apps/backend/src/modules/recipes/recipe.service.test.ts
@@ -1,4 +1,4 @@
-import type { Minutes, SearchRecipeQuery } from "@recipes/shared";
+import type { Minutes, RecipeQuery } from "@recipes/shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createMockCache,
@@ -52,7 +52,7 @@ describe("recipeService", () => {
         page: 1,
         limit: 10,
         sort: "-createdAt",
-      } satisfies SearchRecipeQuery;
+      } satisfies RecipeQuery;
       const result = await service.findAll({
         query,
         initiator: noInitiator(),
@@ -71,7 +71,7 @@ describe("recipeService", () => {
         page: 1,
         limit: 10,
         sort: "-createdAt",
-      } satisfies SearchRecipeQuery;
+      } satisfies RecipeQuery;
       const result = await service.findAll({
         query,
         initiator: noInitiator(),
@@ -87,7 +87,7 @@ describe("recipeService", () => {
         limit: 10,
         sort: "-createdAt",
         isFavorited: true,
-      } satisfies SearchRecipeQuery;
+      } satisfies RecipeQuery;
       const result = await service.findAll({
         query,
         initiator: noInitiator(),

--- a/apps/backend/src/modules/recipes/recipe.service.test.ts
+++ b/apps/backend/src/modules/recipes/recipe.service.test.ts
@@ -1,4 +1,4 @@
-import type { Minutes } from "@recipes/shared";
+import type { Minutes, SearchRecipeQuery } from "@recipes/shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createMockCache,
@@ -48,7 +48,11 @@ describe("recipeService", () => {
       const populated = populateRecipeDoc(createRecipeDoc());
       recipeModel.searchFull.mockResolvedValue([[populated], 1]);
 
-      const query = { page: 1, limit: 10, sort: "-createdAt" };
+      const query = {
+        page: 1,
+        limit: 10,
+        sort: "-createdAt",
+      } satisfies SearchRecipeQuery;
       const result = await service.findAll({
         query,
         initiator: noInitiator(),
@@ -63,7 +67,11 @@ describe("recipeService", () => {
     it("should return empty when searchFull returns null", async () => {
       recipeModel.searchFull.mockResolvedValue([null, 0]);
 
-      const query = { page: 1, limit: 10, sort: "-createdAt" };
+      const query = {
+        page: 1,
+        limit: 10,
+        sort: "-createdAt",
+      } satisfies SearchRecipeQuery;
       const result = await service.findAll({
         query,
         initiator: noInitiator(),
@@ -79,7 +87,7 @@ describe("recipeService", () => {
         limit: 10,
         sort: "-createdAt",
         isFavorited: true,
-      };
+      } satisfies SearchRecipeQuery;
       const result = await service.findAll({
         query,
         initiator: noInitiator(),

--- a/apps/backend/src/modules/recipes/recipe.service.ts
+++ b/apps/backend/src/modules/recipes/recipe.service.ts
@@ -2,7 +2,7 @@ import type {
   CreateRecipeBody,
   Paginated,
   Recipe,
-  SearchRecipeQuery,
+  RecipeQuery,
   UpdateRecipeBody,
 } from "@recipes/shared";
 import { withPagination } from "@recipes/shared";
@@ -32,9 +32,7 @@ import { recipeCache } from "@/modules/recipes/recipe.cache.js";
 import type { UserDocument, UserModelType } from "@/modules/users/index.js";
 
 export interface RecipeService {
-  findAll(
-    params: QueryMethodParams<SearchRecipeQuery>,
-  ): Promise<Paginated<Recipe>>;
+  findAll(params: QueryMethodParams<RecipeQuery>): Promise<Paginated<Recipe>>;
   findById(
     id: string,
     params: InitiatedMethodParams<OptionalInitiator>,

--- a/apps/backend/src/modules/recipes/recipe.service.ts
+++ b/apps/backend/src/modules/recipes/recipe.service.ts
@@ -1,4 +1,10 @@
-import type { Paginated, Recipe } from "@recipes/shared";
+import type {
+  CreateRecipeBody,
+  Paginated,
+  Recipe,
+  SearchRecipeQuery,
+  UpdateRecipeBody,
+} from "@recipes/shared";
 import { withPagination } from "@recipes/shared";
 import { isValidObjectId } from "mongoose";
 import type { CacheService } from "@/common/cache/cache.service.js";
@@ -21,12 +27,7 @@ import type {
   CategoryModelType,
 } from "@/modules/categories/index.js";
 import type { FavoriteModelType } from "@/modules/favorites/index.js";
-import type {
-  CreateRecipeBody,
-  RecipeModelType,
-  SearchRecipeQuery,
-  UpdateRecipeBody,
-} from "@/modules/recipes/index.js";
+import type { RecipeModelType } from "@/modules/recipes/index.js";
 import { recipeCache } from "@/modules/recipes/recipe.cache.js";
 import type { UserDocument, UserModelType } from "@/modules/users/index.js";
 

--- a/apps/backend/src/modules/users/user.model.ts
+++ b/apps/backend/src/modules/users/user.model.ts
@@ -1,10 +1,9 @@
+import type { UserRole } from "@recipes/shared";
 import bcrypt from "bcryptjs";
 import type { Model } from "mongoose";
 import { model, Schema } from "mongoose";
 import type { BaseDocument } from "@/common/types/mongoose.js";
 import { env } from "@/config/env.js";
-
-export type UserRole = "user" | "admin";
 
 export interface UserDocument extends BaseDocument {
   email: string;

--- a/apps/backend/src/modules/users/user.routes.ts
+++ b/apps/backend/src/modules/users/user.routes.ts
@@ -1,5 +1,7 @@
 import {
   commentForRecipeSchema,
+  commentQuerySchema,
+  favoriteQuerySchema,
   paginatedSchema,
   recipeSchema,
   userSchema,
@@ -10,8 +12,6 @@ import {
   assertAuthenticated,
   authGuard,
 } from "@/common/middleware/auth.guard.js";
-import { commentQuerySchema } from "@/modules/comments/index.js";
-import { favoriteQuerySchema } from "@/modules/favorites/favorite.schema.js";
 import type { UserService } from "@/modules/users/index.js";
 
 export interface UserPluginOptions {

--- a/apps/backend/src/modules/users/user.service.ts
+++ b/apps/backend/src/modules/users/user.service.ts
@@ -1,6 +1,11 @@
-import type { Comment, Paginated, Recipe, User } from "@recipes/shared";
+import type {
+  Comment,
+  Paginated,
+  PaginationQuery,
+  Recipe,
+  User,
+} from "@recipes/shared";
 import { NotFoundError } from "@/common/errors.js";
-import type { PaginationQuery } from "@/common/schemas.js";
 import type {
   DefaultInitiator,
   QueryMethodParams,

--- a/apps/frontend/src/empty.test.ts
+++ b/apps/frontend/src/empty.test.ts
@@ -1,0 +1,7 @@
+import { describe, expect, it } from "vitest";
+
+describe("test", () => {
+  it("should pass", () => {
+    expect(true).toBe(true);
+  });
+});

--- a/apps/frontend/src/features/categories/categories.api.ts
+++ b/apps/frontend/src/features/categories/categories.api.ts
@@ -1,8 +1,8 @@
-import type { Category, SearchCategoryQuery } from "@recipes/shared";
+import type { Category, CategoryQuery } from "@recipes/shared";
 import { apiClient } from "@/common/api/client";
 
 export function getCategories(
-  filters: Partial<SearchCategoryQuery> = {},
+  filters: Partial<CategoryQuery> = {},
 ): Promise<Category[]> {
   return apiClient<Category[]>("/api/categories", {
     method: "GET",

--- a/apps/frontend/src/features/categories/categories.queries.ts
+++ b/apps/frontend/src/features/categories/categories.queries.ts
@@ -1,4 +1,4 @@
-import type { SearchCategoryQuery } from "@recipes/shared";
+import type { CategoryQuery } from "@recipes/shared";
 import { useQuery } from "@tanstack/vue-query";
 import type { MaybeRef } from "vue";
 import { toValue } from "vue";
@@ -13,9 +13,7 @@ const categoryKeys = {
  *
  * @returns List of categories.
  */
-export function useCategories(
-  filters: MaybeRef<Partial<SearchCategoryQuery>> = {},
-) {
+export function useCategories(filters: MaybeRef<Partial<CategoryQuery>> = {}) {
   return useQuery({
     queryKey: categoryKeys.all,
     queryFn: () => getCategories(toValue(filters)),

--- a/apps/frontend/src/features/recipes/recipes.api.ts
+++ b/apps/frontend/src/features/recipes/recipes.api.ts
@@ -1,21 +1,11 @@
 import type {
   CreateRecipeBody,
-  Difficulty,
   Paginated,
   Recipe,
+  RecipeQuery,
   UpdateRecipeBody,
 } from "@recipes/shared";
 import { apiClient } from "@/common/api/client";
-
-export interface RecipeFilters {
-  page?: number;
-  limit?: number;
-  search?: string;
-  categoryId?: string;
-  difficulty?: Difficulty;
-  isFavorited?: boolean;
-  sort?: string;
-}
 
 /**
  * Retrieve recipes with the given filters.
@@ -24,7 +14,7 @@ export interface RecipeFilters {
  * @returns Paginated list of recipes.
  */
 export function getRecipes(
-  filters: RecipeFilters = {},
+  filters: Partial<RecipeQuery> = {},
 ): Promise<Paginated<Recipe>> {
   return apiClient<Paginated<Recipe>>("/api/recipes", {
     query: {

--- a/apps/frontend/src/features/recipes/recipes.queries.ts
+++ b/apps/frontend/src/features/recipes/recipes.queries.ts
@@ -1,4 +1,4 @@
-import type { UpdateRecipeBody } from "@recipes/shared";
+import type { RecipeQuery, UpdateRecipeBody } from "@recipes/shared";
 import {
   useInfiniteQuery,
   useMutation,
@@ -7,7 +7,6 @@ import {
 } from "@tanstack/vue-query";
 import type { MaybeRef } from "vue";
 import { toValue } from "vue";
-import type { RecipeFilters } from "./recipes.api";
 import {
   createRecipe,
   deleteRecipe,
@@ -19,9 +18,10 @@ import {
 export const recipeKeys = {
   all: ["recipes"] as const,
   lists: () => [...recipeKeys.all, "list"] as const,
-  list: (query: RecipeFilters) => [...recipeKeys.lists(), query] as const,
+  list: (query: Partial<RecipeQuery>) =>
+    [...recipeKeys.lists(), query] as const,
   detail: (id: string) => [...recipeKeys.all, id] as const,
-  infinite: (query: RecipeFilters) =>
+  infinite: (query: Partial<RecipeQuery>) =>
     [...recipeKeys.list(query), "infinite"] as const,
 } as const;
 
@@ -31,7 +31,7 @@ export const recipeKeys = {
  * @param filters - filters for the query.
  * @returns Paginated list of recipes.
  */
-export function useRecipes(filters: MaybeRef<RecipeFilters>) {
+export function useRecipes(filters: MaybeRef<Partial<RecipeQuery>>) {
   return useQuery({
     queryKey: recipeKeys.list(toValue(filters)),
     queryFn: () => getRecipes(toValue(filters)),
@@ -45,7 +45,7 @@ export function useRecipes(filters: MaybeRef<RecipeFilters>) {
  * @returns Paginated list of recipes.
  */
 export function useInfiniteRecipes(
-  filters: MaybeRef<Omit<RecipeFilters, "page">>,
+  filters: MaybeRef<Omit<Partial<RecipeQuery>, "page">>,
 ) {
   return useInfiniteQuery({
     queryKey: recipeKeys.infinite(toValue(filters)),

--- a/packages/shared/src/categories/category.types.ts
+++ b/packages/shared/src/categories/category.types.ts
@@ -11,4 +11,4 @@ export type CreateCategoryBody = z.infer<typeof createCategorySchema>;
 export type Category = z.infer<typeof categorySchema>;
 export type CategorySummary = z.infer<typeof categorySummarySchema>;
 
-export type SearchCategoryQuery = z.infer<typeof categoryQuerySchema>;
+export type CategoryQuery = z.infer<typeof categoryQuerySchema>;

--- a/packages/shared/src/comments/comment.schema.ts
+++ b/packages/shared/src/comments/comment.schema.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { paginationQuerySchema } from "../query.js";
 import { recipeSummarySchema } from "../recipes/recipe.schema.js";
 import { userSummarySchema } from "../users/user.schema.js";
 
@@ -16,3 +17,5 @@ export const commentSchema = z.object({
 });
 
 export const commentForRecipeSchema = commentSchema.omit({ recipe: true });
+
+export const commentQuerySchema = paginationQuerySchema;

--- a/packages/shared/src/comments/comment.types.ts
+++ b/packages/shared/src/comments/comment.types.ts
@@ -1,6 +1,7 @@
 import type { z } from "zod";
 import type {
   commentForRecipeSchema,
+  commentQuerySchema,
   commentSchema,
   createCommentSchema,
 } from "./comment.schema.js";
@@ -8,3 +9,5 @@ import type {
 export type CreateCommentBody = z.infer<typeof createCommentSchema>;
 export type Comment = z.infer<typeof commentSchema>;
 export type CommentForRecipe = z.infer<typeof commentForRecipeSchema>;
+
+export type CommentQuery = z.infer<typeof commentQuerySchema>;

--- a/packages/shared/src/favorites/favorite.schema.ts
+++ b/packages/shared/src/favorites/favorite.schema.ts
@@ -1,0 +1,3 @@
+import { paginationQuerySchema } from "../query.js";
+
+export const favoriteQuerySchema = paginationQuerySchema;

--- a/packages/shared/src/favorites/favorite.types.ts
+++ b/packages/shared/src/favorites/favorite.types.ts
@@ -1,0 +1,4 @@
+import type { z } from "zod";
+import type { favoriteQuerySchema } from "./favorite.schema.js";
+
+export type FavoriteQuery = z.infer<typeof favoriteQuerySchema>;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -18,6 +18,9 @@ export type * from "./recipes/recipe.types.js";
 export * from "./recipes/ingredient.schema.js";
 export type * from "./recipes/ingredient.types.js";
 
+export * from "./favorites/favorite.schema.js";
+export type * from "./favorites/favorite.types.js";
+
 export * from "./pagination.js";
 export * from "./utils.js";
 export * from "./query.js";

--- a/packages/shared/src/pagination.ts
+++ b/packages/shared/src/pagination.ts
@@ -1,10 +1,5 @@
 import { z } from "zod";
 
-export interface PaginationQuery {
-  page: number;
-  limit: number;
-}
-
 export interface Paginated<T> {
   items: T[];
   pagination: {

--- a/packages/shared/src/query.ts
+++ b/packages/shared/src/query.ts
@@ -49,3 +49,14 @@ export function createSortSchema<const T extends string>(
   const variants = fields.flatMap((f) => [f, `-${f}`] as const);
   return z.enum(variants);
 }
+
+export const searchQuerySchema = z.object({
+  search: z.string().trim().optional(),
+});
+export type SearchQuery = z.infer<typeof searchQuerySchema>;
+
+export const paginationQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+});
+export type PaginationQuery = z.infer<typeof paginationQuerySchema>;

--- a/packages/shared/src/recipes/recipe.schema.ts
+++ b/packages/shared/src/recipes/recipe.schema.ts
@@ -1,6 +1,10 @@
 import { z } from "zod";
 import { categorySummarySchema } from "../categories/category.schema.js";
-import { paginationQuerySchema, searchQuerySchema } from "../query.js";
+import {
+  createSortSchema,
+  paginationQuerySchema,
+  searchQuerySchema,
+} from "../query.js";
 import { userSummarySchema } from "../users/user.schema.js";
 import { ingredientSchema } from "./ingredient.schema.js";
 
@@ -47,7 +51,7 @@ export const recipeSchema = z.object({
 
 export const recipeQuerySchema = z
   .object({
-    sort: z.string().trim().default("-createdAt"),
+    sort: createSortSchema(["-createdAt", "cookingTime"]).default("-createdAt"),
     categoryId: z.string().optional(),
     difficulty: difficultySchema.optional(),
     isFavorited: z.stringbool().optional(),

--- a/packages/shared/src/recipes/recipe.schema.ts
+++ b/packages/shared/src/recipes/recipe.schema.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { categorySummarySchema } from "../categories/category.schema.js";
+import { paginationQuerySchema, searchQuerySchema } from "../query.js";
 import { userSummarySchema } from "../users/user.schema.js";
 import { ingredientSchema } from "./ingredient.schema.js";
 
@@ -43,3 +44,15 @@ export const recipeSchema = z.object({
   createdAt: z.string(),
   updatedAt: z.string(),
 });
+
+export const recipeQuerySchema = z
+  .object({
+    sort: z.string().trim().default("-createdAt"),
+    categoryId: z.string().optional(),
+    difficulty: difficultySchema.optional(),
+    isFavorited: z.stringbool().optional(),
+  })
+  .extend(paginationQuerySchema.shape)
+  .extend(searchQuerySchema.shape);
+
+export type SearchRecipeQuery = z.infer<typeof recipeQuerySchema>;

--- a/packages/shared/src/recipes/recipe.schema.ts
+++ b/packages/shared/src/recipes/recipe.schema.ts
@@ -59,4 +59,4 @@ export const recipeQuerySchema = z
   .extend(paginationQuerySchema.shape)
   .extend(searchQuerySchema.shape);
 
-export type SearchRecipeQuery = z.infer<typeof recipeQuerySchema>;
+export type RecipeQuery = z.infer<typeof recipeQuerySchema>;

--- a/packages/shared/src/users/user.types.ts
+++ b/packages/shared/src/users/user.types.ts
@@ -1,5 +1,7 @@
 import type { z } from "zod";
 import type { userSchema, userSummarySchema } from "./user.schema.js";
 
+export type UserRole = "user" | "admin";
+
 export type UserSummary = z.infer<typeof userSummarySchema>;
 export type User = z.infer<typeof userSchema>;


### PR DESCRIPTION
## Related Issues

<!-- Link related issues: Closes #123, Refs #456 -->

## PR Type

- [x] Refactoring

## Description

Move query schemas, types, and common utilities from backend to `@recipes/shared` so the frontend can import them directly. Eliminates local type duplication (`RecipeFilters`) and establishes a single source of truth for API contracts.

### Shared package (`@recipes/shared`)

- **`query.ts`** — move `paginationQuerySchema` and `searchQuerySchema` from backend `common/schemas.ts`
- **`recipes/recipe.schema.ts`** — add `recipeQuerySchema` using `createSortSchema(["-createdAt", "cookingTime"])`, export `RecipeQuery` type
- **`comments/comment.schema.ts`** — add `commentQuerySchema` (= `paginationQuerySchema`)
- **`favorites/`** — new module with `favoriteQuerySchema` and `FavoriteQuery` type
- **`users/user.types.ts`** — add `UserRole` type

### Backend

- **`common/schemas.ts`** — slim down to only `idParamSchema` (route param validation)
- **`modules/*/`** — import query schemas/types from `@recipes/shared` instead of defining locally
- **`modules/auth/auth.schema.ts`** — remove (pure re-exports now handled by shared barrel)

### Frontend

- **`features/recipes/recipes.api.ts`** — replace local `RecipeFilters` with `Partial<RecipeQuery>` from shared
- **`features/recipes/recipes.queries.ts`** — import `RecipeQuery` from shared
- **`features/categories/`** — import `CategoryQuery` from shared (renamed from `SearchCategoryQuery`)
- **`features/favorites/`** — import `PaginationQuery` from shared (already was)

### Benefits

- Frontend gets full type-safety for API query parameters from shared
- Schema changes automatically sync types across backend and frontend
- No more local type duplication
- Backend query string coercion (`z.coerce`) works seamlessly on both sides

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Added/updated tests for new functionality
- [ ] Updated documentation (if needed)