### PR TITLE
feat(recipe): add ratings system

### DIFF
--- a/apps/backend/src/__tests__/helpers.ts
+++ b/apps/backend/src/__tests__/helpers.ts
@@ -237,6 +237,15 @@ export function createMockFavoriteModel(overrides: Record<string, Mock> = {}) {
   };
 }
 
+export function createMockRatingModel(overrides: Record<string, Mock> = {}) {
+  return {
+    findOneAndUpdate: viFn(),
+    findOneAndDelete: viFn(),
+    exists: viFn(),
+    ...overrides,
+  };
+}
+
 // ── Cache mock ──
 
 export interface MockCache extends CacheService {

--- a/apps/backend/src/__tests__/helpers.ts
+++ b/apps/backend/src/__tests__/helpers.ts
@@ -156,6 +156,9 @@ export function populateRecipeDoc(
     category: { _id: createObjectId(), name: "Italian", slug: "italian" },
     author: { _id: createObjectId(), name: "Chef", email: "chef@test.com" },
     isFavorited: false,
+    userRating: null,
+    averageRating: null,
+    ratingCount: 0,
     ...overrides,
   };
 }

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -126,6 +126,7 @@ export async function buildApp(log: Logger) {
       RecipeRatingModel,
       RecipeModel,
       UserModel,
+      cache,
     ),
     prefix: "/api/recipes",
   });

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -32,6 +32,11 @@ import {
   favoriteRoutes,
 } from "@/modules/favorites/index.js";
 import {
+  createRecipeRatingService,
+  RecipeRatingModel,
+  recipeRatingRoutes,
+} from "@/modules/recipe-ratings/index.js";
+import {
   createRecipeService,
   RecipeModel,
   recipeRoutes,
@@ -114,6 +119,14 @@ export async function buildApp(log: Logger) {
   });
   app.register(favoriteRoutes, {
     service: createFavoriteService(FavoriteModel, RecipeModel, UserModel),
+    prefix: "/api/recipes",
+  });
+  app.register(recipeRatingRoutes, {
+    service: createRecipeRatingService(
+      RecipeRatingModel,
+      RecipeModel,
+      UserModel,
+    ),
     prefix: "/api/recipes",
   });
   app.register(categoryRoutes, {

--- a/apps/backend/src/common/utils/mongo.test.ts
+++ b/apps/backend/src/common/utils/mongo.test.ts
@@ -114,6 +114,9 @@ describe("toRecipe", () => {
         email: "chef@test.com",
       },
       isFavorited: true,
+      userRating: 4,
+      averageRating: 4.2,
+      ratingCount: 10,
     } satisfies RecipeDocumentPopulated;
 
     const result = toRecipe(doc, doc.isFavorited);
@@ -131,6 +134,23 @@ describe("toRecipe", () => {
       email: "chef@test.com",
       name: "Chef",
     });
+    expect(result.userRating).toBe(4);
+    expect(result.averageRating).toBe(4.2);
+    expect(result.ratingCount).toBe(10);
+  });
+
+  it("should default rating fields when missing", () => {
+    const doc = {
+      ...createRecipeDoc(),
+      category: { _id: createObjectId(), name: "Cat", slug: "cat" },
+      author: { _id: createObjectId(), name: "Auth", email: "a@b.c" },
+    };
+
+    const result = toRecipe(doc, false);
+
+    expect(result.userRating).toBeNull();
+    expect(result.averageRating).toBeNull();
+    expect(result.ratingCount).toBe(0);
   });
 
   it("should map isFavorited=false", () => {

--- a/apps/backend/src/common/utils/mongo.ts
+++ b/apps/backend/src/common/utils/mongo.ts
@@ -29,7 +29,11 @@ export function toRecipe<T extends RecipeDocument>(
       category: Pick<CategoryDocument, "_id" | "name" | "slug">;
       author: Pick<UserDocument, "_id" | "name" | "email">;
     }
-  >,
+  > & {
+    userRating?: number | null;
+    averageRating?: number | null;
+    ratingCount?: number;
+  },
   isFavorited: boolean,
 ): Recipe {
   return {
@@ -53,6 +57,9 @@ export function toRecipe<T extends RecipeDocument>(
     servings: doc.servings,
     isPublic: doc.isPublic,
     isFavorited,
+    userRating: doc.userRating ?? null,
+    averageRating: doc.averageRating ?? null,
+    ratingCount: doc.ratingCount ?? 0,
     createdAt: doc.createdAt.toISOString(),
     updatedAt: doc.updatedAt.toISOString(),
   };

--- a/apps/backend/src/modules/favorites/favorite.service.test.ts
+++ b/apps/backend/src/modules/favorites/favorite.service.test.ts
@@ -6,15 +6,13 @@ import {
   createObjectId,
   createRecipeDoc,
   initiator,
+  populateRecipeDoc,
   queryParams,
 } from "@/__tests__/helpers.js";
 import { BadRequestError, NotFoundError } from "@/common/errors.js";
 import type { FavoriteModelType } from "@/modules/favorites/favorite.model.js";
 import { createFavoriteService } from "@/modules/favorites/favorite.service.js";
-import type {
-  RecipeDocumentPopulated,
-  RecipeModelType,
-} from "@/modules/recipes/recipe.model.js";
+import type { RecipeModelType } from "@/modules/recipes/recipe.model.js";
 import type { UserModelType } from "@/modules/users/user.model.js";
 
 describe("favoriteService", () => {
@@ -125,12 +123,9 @@ describe("favoriteService", () => {
   describe("findByUser", () => {
     it("should return paginated recipes from favorites", async () => {
       userModel.exists.mockResolvedValue(true);
-      const recipe = {
-        ...createRecipeDoc(),
-        category: { _id: createObjectId(), name: "Cat", slug: "cat" },
-        author: { _id: createObjectId(), name: "Author", email: "a@b.c" },
+      const recipe = populateRecipeDoc(createRecipeDoc(), {
         isFavorited: true,
-      } satisfies RecipeDocumentPopulated;
+      });
       favoriteModel.findByUser.mockResolvedValue([[{ recipe }], 1]);
 
       const result = await service.findByUser(

--- a/apps/backend/src/modules/recipe-ratings/index.ts
+++ b/apps/backend/src/modules/recipe-ratings/index.ts
@@ -1,0 +1,3 @@
+export * from "./recipe-rating.model.js";
+export * from "./recipe-rating.routes.js";
+export * from "./recipe-rating.service.js";

--- a/apps/backend/src/modules/recipe-ratings/recipe-rating.model.ts
+++ b/apps/backend/src/modules/recipe-ratings/recipe-rating.model.ts
@@ -1,0 +1,40 @@
+import type { Model, Types } from "mongoose";
+import { model, Schema } from "mongoose";
+import type { BaseDocumentWithoutUpdate } from "@/common/types/mongoose.js";
+import { RECIPE_MODEL_NAME } from "@/modules/recipes/recipe.model.js";
+import { USER_MODEL_NAME } from "@/modules/users/user.model.js";
+
+export interface RecipeRatingDocument extends BaseDocumentWithoutUpdate {
+  user: Types.ObjectId;
+  recipe: Types.ObjectId;
+  value: number;
+}
+
+export interface RecipeRatingModelType extends Model<RecipeRatingDocument> {}
+
+const recipeRatingSchema = new Schema<
+  RecipeRatingDocument,
+  RecipeRatingModelType
+>(
+  {
+    user: { type: Schema.Types.ObjectId, ref: USER_MODEL_NAME, required: true },
+    recipe: {
+      type: Schema.Types.ObjectId,
+      ref: RECIPE_MODEL_NAME,
+      required: true,
+    },
+    value: { type: Number, required: true, min: 1, max: 5 },
+  },
+  {
+    collection: "recipeRatings",
+    timestamps: { createdAt: true, updatedAt: false },
+  },
+);
+
+recipeRatingSchema.index({ user: 1, recipe: 1 }, { unique: true });
+
+export const RECIPE_RATING_MODEL_NAME = "RecipeRating";
+export const RecipeRatingModel = model<
+  RecipeRatingDocument,
+  RecipeRatingModelType
+>(RECIPE_RATING_MODEL_NAME, recipeRatingSchema);

--- a/apps/backend/src/modules/recipe-ratings/recipe-rating.routes.ts
+++ b/apps/backend/src/modules/recipe-ratings/recipe-rating.routes.ts
@@ -1,0 +1,69 @@
+import { recipeRatingBodySchema } from "@recipes/shared";
+import type { FastifyPluginAsync } from "fastify";
+import type { ZodTypeProvider } from "fastify-type-provider-zod";
+import { z } from "zod";
+import {
+  assertAuthenticated,
+  authGuard,
+} from "@/common/middleware/auth.guard.js";
+import type { RecipeRatingService } from "@/modules/recipe-ratings/index.js";
+import { recipeParamsSchema } from "@/modules/recipes/index.js";
+
+export interface RecipeRatingModuleOptions {
+  service: RecipeRatingService;
+}
+
+export const recipeRatingRoutes: FastifyPluginAsync<
+  RecipeRatingModuleOptions
+> = async (fastify, { service }) => {
+  fastify
+    .withTypeProvider<ZodTypeProvider>()
+    .put(
+      "/:id/rating",
+      {
+        schema: {
+          params: recipeParamsSchema,
+          body: recipeRatingBodySchema,
+          response: {
+            200: z.object({ value: z.number().int().min(1).max(5) }),
+          },
+          tags: ["Ratings"],
+          summary: "Rate a recipe",
+          security: [{ bearerAuth: [] }],
+        },
+        onRequest: authGuard,
+      },
+      async (request, reply) => {
+        assertAuthenticated(request);
+
+        const result = await service.rate(request.params.id, {
+          data: request.body,
+          initiator: { id: request.user.userId, role: request.user.role },
+        });
+        return reply.send(result);
+      },
+    )
+    .delete(
+      "/:id/rating",
+      {
+        schema: {
+          params: recipeParamsSchema,
+          response: {
+            204: z.void(),
+          },
+          tags: ["Ratings"],
+          summary: "Remove rating from recipe",
+          security: [{ bearerAuth: [] }],
+        },
+        onRequest: authGuard,
+      },
+      async (request, reply) => {
+        assertAuthenticated(request);
+
+        await service.remove(request.params.id, {
+          initiator: { id: request.user.userId, role: request.user.role },
+        });
+        return reply.status(204).send();
+      },
+    );
+};

--- a/apps/backend/src/modules/recipe-ratings/recipe-rating.service.test.ts
+++ b/apps/backend/src/modules/recipe-ratings/recipe-rating.service.test.ts
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createMockRatingModel,
+  createMockRecipeModel,
+  createMockUserModel,
+  createObjectId,
+  initiator,
+} from "@/__tests__/helpers.js";
+import { BadRequestError, NotFoundError } from "@/common/errors.js";
+import type { RecipeModelType } from "@/modules/recipes/recipe.model.js";
+import type { UserModelType } from "@/modules/users/user.model.js";
+import type { RecipeRatingModelType } from "./recipe-rating.model.js";
+import { createRecipeRatingService } from "./recipe-rating.service.js";
+
+describe("recipeRatingService", () => {
+  const ratingModel = createMockRatingModel();
+  const recipeModel = createMockRecipeModel();
+  const userModel = createMockUserModel();
+
+  const service = createRecipeRatingService(
+    ratingModel as unknown as RecipeRatingModelType,
+    recipeModel as unknown as RecipeModelType,
+    userModel as unknown as UserModelType,
+  );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("rate", () => {
+    it("should create a new rating", async () => {
+      userModel.exists.mockResolvedValue(true);
+      recipeModel.exists.mockResolvedValue(true);
+      ratingModel.findOneAndUpdate.mockResolvedValue({
+        value: 4,
+      });
+
+      const init = initiator();
+      const recipeId = createObjectId().toString();
+      const result = await service.rate(recipeId, {
+        data: { value: 4 },
+        initiator: init,
+      });
+
+      expect(result).toEqual({ value: 4 });
+      expect(ratingModel.findOneAndUpdate).toHaveBeenCalledWith(
+        { user: init.id, recipe: recipeId },
+        { value: 4 },
+        { upsert: true, returnDocument: "after" },
+      );
+    });
+
+    it("should update an existing rating", async () => {
+      userModel.exists.mockResolvedValue(true);
+      recipeModel.exists.mockResolvedValue(true);
+      ratingModel.findOneAndUpdate.mockResolvedValue({
+        value: 5,
+      });
+
+      const init = initiator();
+      const recipeId = createObjectId().toString();
+      const result = await service.rate(recipeId, {
+        data: { value: 5 },
+        initiator: init,
+      });
+
+      expect(result).toEqual({ value: 5 });
+    });
+
+    it("should throw BadRequestError for invalid user ID", async () => {
+      await expect(
+        service.rate(createObjectId().toString(), {
+          data: { value: 3 },
+          initiator: { id: "invalid-id", role: "user" },
+        }),
+      ).rejects.toThrow(BadRequestError);
+    });
+
+    it("should throw BadRequestError for invalid recipe ID", async () => {
+      userModel.exists.mockResolvedValue(true);
+
+      await expect(
+        service.rate("invalid-id", {
+          data: { value: 3 },
+          initiator: initiator(),
+        }),
+      ).rejects.toThrow(BadRequestError);
+    });
+
+    it("should throw NotFoundError when user does not exist", async () => {
+      userModel.exists.mockResolvedValue(false);
+      recipeModel.exists.mockResolvedValue(true);
+
+      await expect(
+        service.rate(createObjectId().toString(), {
+          data: { value: 3 },
+          initiator: initiator(),
+        }),
+      ).rejects.toThrow(NotFoundError);
+    });
+
+    it("should throw NotFoundError when recipe does not exist", async () => {
+      userModel.exists.mockResolvedValue(true);
+      recipeModel.exists.mockResolvedValue(false);
+
+      await expect(
+        service.rate(createObjectId().toString(), {
+          data: { value: 3 },
+          initiator: initiator(),
+        }),
+      ).rejects.toThrow(NotFoundError);
+    });
+  });
+
+  describe("remove", () => {
+    it("should remove an existing rating", async () => {
+      userModel.exists.mockResolvedValue(true);
+      recipeModel.exists.mockResolvedValue(true);
+      ratingModel.findOneAndDelete.mockResolvedValue({
+        _id: createObjectId(),
+      });
+
+      const init = initiator();
+      const recipeId = createObjectId().toString();
+      await service.remove(recipeId, { initiator: init });
+
+      expect(ratingModel.findOneAndDelete).toHaveBeenCalledWith({
+        user: init.id,
+        recipe: recipeId,
+      });
+    });
+
+    it("should throw NotFoundError when rating does not exist", async () => {
+      userModel.exists.mockResolvedValue(true);
+      recipeModel.exists.mockResolvedValue(true);
+      ratingModel.findOneAndDelete.mockResolvedValue(null);
+
+      await expect(
+        service.remove(createObjectId().toString(), {
+          initiator: initiator(),
+        }),
+      ).rejects.toThrow(NotFoundError);
+    });
+
+    it("should throw BadRequestError for invalid user ID", async () => {
+      await expect(
+        service.remove(createObjectId().toString(), {
+          initiator: { id: "invalid-id", role: "user" },
+        }),
+      ).rejects.toThrow(BadRequestError);
+    });
+
+    it("should throw NotFoundError when recipe does not exist", async () => {
+      userModel.exists.mockResolvedValue(true);
+      recipeModel.exists.mockResolvedValue(false);
+
+      await expect(
+        service.remove(createObjectId().toString(), {
+          initiator: initiator(),
+        }),
+      ).rejects.toThrow(NotFoundError);
+    });
+  });
+});

--- a/apps/backend/src/modules/recipe-ratings/recipe-rating.service.test.ts
+++ b/apps/backend/src/modules/recipe-ratings/recipe-rating.service.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  createMockCache,
   createMockRatingModel,
   createMockRecipeModel,
   createMockUserModel,
@@ -7,6 +8,7 @@ import {
   initiator,
 } from "@/__tests__/helpers.js";
 import { BadRequestError, NotFoundError } from "@/common/errors.js";
+import { recipeCache } from "@/modules/recipes/recipe.cache.js";
 import type { RecipeModelType } from "@/modules/recipes/recipe.model.js";
 import type { UserModelType } from "@/modules/users/user.model.js";
 import type { RecipeRatingModelType } from "./recipe-rating.model.js";
@@ -16,11 +18,13 @@ describe("recipeRatingService", () => {
   const ratingModel = createMockRatingModel();
   const recipeModel = createMockRecipeModel();
   const userModel = createMockUserModel();
+  const cache = createMockCache();
 
   const service = createRecipeRatingService(
     ratingModel as unknown as RecipeRatingModelType,
     recipeModel as unknown as RecipeModelType,
     userModel as unknown as UserModelType,
+    cache,
   );
 
   beforeEach(() => {
@@ -47,6 +51,9 @@ describe("recipeRatingService", () => {
         { user: init.id, recipe: recipeId },
         { value: 4 },
         { upsert: true, returnDocument: "after" },
+      );
+      expect(cache.deletePattern).toHaveBeenCalledWith(
+        recipeCache.keys.allPattern(),
       );
     });
 
@@ -128,6 +135,9 @@ describe("recipeRatingService", () => {
         user: init.id,
         recipe: recipeId,
       });
+      expect(cache.deletePattern).toHaveBeenCalledWith(
+        recipeCache.keys.allPattern(),
+      );
     });
 
     it("should throw NotFoundError when rating does not exist", async () => {

--- a/apps/backend/src/modules/recipe-ratings/recipe-rating.service.ts
+++ b/apps/backend/src/modules/recipe-ratings/recipe-rating.service.ts
@@ -1,10 +1,12 @@
 import type { RecipeRatingBody } from "@recipes/shared";
 import { isObjectIdOrHexString } from "mongoose";
+import type { CacheService } from "@/common/cache/cache.service.js";
 import { BadRequestError, NotFoundError } from "@/common/errors.js";
 import type {
   CreateMethodParams,
   DeleteMethodParams,
 } from "@/common/types/methods.js";
+import { recipeCache } from "@/modules/recipes/recipe.cache.js";
 import type { RecipeModelType } from "@/modules/recipes/recipe.model.js";
 import type { UserModelType } from "@/modules/users/user.model.js";
 import type { RecipeRatingModelType } from "./recipe-rating.model.js";
@@ -21,6 +23,7 @@ export function createRecipeRatingService(
   ratingModel: RecipeRatingModelType,
   recipeModel: RecipeModelType,
   userModel: UserModelType,
+  cache: CacheService,
 ): RecipeRatingService {
   async function validateUser(userId: string): Promise<void> {
     if (!isObjectIdOrHexString(userId)) {
@@ -55,6 +58,8 @@ export function createRecipeRatingService(
         { upsert: true, returnDocument: "after" },
       );
 
+      await cache.deletePattern(recipeCache.keys.allPattern());
+
       return { value: rating.value };
     },
 
@@ -72,6 +77,8 @@ export function createRecipeRatingService(
           `Rating for ${recipeId} by ${initiator.id} not found`,
         );
       }
+
+      await cache.deletePattern(recipeCache.keys.allPattern());
     },
   };
 }

--- a/apps/backend/src/modules/recipe-ratings/recipe-rating.service.ts
+++ b/apps/backend/src/modules/recipe-ratings/recipe-rating.service.ts
@@ -1,0 +1,77 @@
+import type { RecipeRatingBody } from "@recipes/shared";
+import { isObjectIdOrHexString } from "mongoose";
+import { BadRequestError, NotFoundError } from "@/common/errors.js";
+import type {
+  CreateMethodParams,
+  DeleteMethodParams,
+} from "@/common/types/methods.js";
+import type { RecipeModelType } from "@/modules/recipes/recipe.model.js";
+import type { UserModelType } from "@/modules/users/user.model.js";
+import type { RecipeRatingModelType } from "./recipe-rating.model.js";
+
+export interface RecipeRatingService {
+  rate(
+    recipeId: string,
+    params: CreateMethodParams<RecipeRatingBody>,
+  ): Promise<{ value: number }>;
+  remove(recipeId: string, params: DeleteMethodParams): Promise<void>;
+}
+
+export function createRecipeRatingService(
+  ratingModel: RecipeRatingModelType,
+  recipeModel: RecipeModelType,
+  userModel: UserModelType,
+): RecipeRatingService {
+  async function validateUser(userId: string): Promise<void> {
+    if (!isObjectIdOrHexString(userId)) {
+      throw new BadRequestError(`Invalid user ID: ${userId}`);
+    }
+
+    const userExists = await userModel.exists({ _id: userId });
+    if (!userExists) {
+      throw new NotFoundError(`User not found: ${userId}`);
+    }
+  }
+
+  async function validateRecipe(recipeId: string): Promise<void> {
+    if (!isObjectIdOrHexString(recipeId)) {
+      throw new BadRequestError(`Invalid recipe ID: ${recipeId}`);
+    }
+
+    const recipeExists = await recipeModel.exists({ _id: recipeId });
+    if (!recipeExists) {
+      throw new NotFoundError(`Recipe not found: ${recipeId}`);
+    }
+  }
+
+  return {
+    rate: async (recipeId, { data, initiator }) => {
+      await validateUser(initiator.id);
+      await validateRecipe(recipeId);
+
+      const rating = await ratingModel.findOneAndUpdate(
+        { user: initiator.id, recipe: recipeId },
+        { value: data.value },
+        { upsert: true, returnDocument: "after" },
+      );
+
+      return { value: rating.value };
+    },
+
+    remove: async (recipeId, { initiator }) => {
+      await validateUser(initiator.id);
+      await validateRecipe(recipeId);
+
+      const result = await ratingModel.findOneAndDelete({
+        user: initiator.id,
+        recipe: recipeId,
+      });
+
+      if (!result) {
+        throw new NotFoundError(
+          `Rating for ${recipeId} by ${initiator.id} not found`,
+        );
+      }
+    },
+  };
+}

--- a/apps/backend/src/modules/recipes/recipe.aggregation.ts
+++ b/apps/backend/src/modules/recipes/recipe.aggregation.ts
@@ -107,3 +107,84 @@ export function withFavorited(userId?: string) {
     { $unset: "favoritedBy" },
   ] satisfies PipelineStage[];
 }
+
+export function withUserRating(userId?: string) {
+  if (!userId) {
+    return [
+      {
+        $addFields: {
+          userRating: null,
+        },
+      },
+    ] satisfies PipelineStage[];
+  }
+  const userOid = toObjectId(userId);
+
+  return [
+    {
+      $lookup: {
+        from: "recipeRatings",
+        localField: "_id",
+        foreignField: "recipe",
+        pipeline: [
+          {
+            $match: {
+              user: userOid,
+            },
+          },
+          {
+            $project: {
+              _id: 0,
+              value: 1,
+            },
+          },
+        ],
+        as: "userRatingDoc",
+      },
+    },
+    { $unwind: { path: "$userRatingDoc", preserveNullAndEmptyArrays: true } },
+    {
+      $addFields: {
+        userRating: "$userRatingDoc.value",
+      },
+    },
+    { $unset: "userRatingDoc" },
+  ] satisfies PipelineStage[];
+}
+
+export function withAverageRating() {
+  return [
+    {
+      $lookup: {
+        from: "recipeRatings",
+        localField: "_id",
+        foreignField: "recipe",
+        pipeline: [
+          {
+            $group: {
+              _id: null,
+              avg: { $avg: "$value" },
+              count: { $sum: 1 },
+            },
+          },
+          {
+            $project: {
+              _id: 0,
+              avg: { $round: ["$avg", 1] },
+              count: 1,
+            },
+          },
+        ],
+        as: "ratingStats",
+      },
+    },
+    { $unwind: { path: "$ratingStats", preserveNullAndEmptyArrays: true } },
+    {
+      $addFields: {
+        averageRating: "$ratingStats.avg",
+        ratingCount: { $ifNull: ["$ratingStats.count", 0] },
+      },
+    },
+    { $unset: "ratingStats" },
+  ] satisfies PipelineStage[];
+}

--- a/apps/backend/src/modules/recipes/recipe.model.ts
+++ b/apps/backend/src/modules/recipes/recipe.model.ts
@@ -26,8 +26,10 @@ import { USER_MODEL_NAME } from "@/modules/users/index.js";
 import {
   byVisibility,
   withAuthor,
+  withAverageRating,
   withCategories,
   withFavorited,
+  withUserRating,
 } from "./recipe.aggregation.js";
 
 export interface IngredientDocument {
@@ -58,6 +60,9 @@ export interface RecipeDocumentPopulated
     }
   > {
   isFavorited: boolean;
+  userRating: number | null;
+  averageRating: number | null;
+  ratingCount: number;
 }
 
 export interface RecipeModelType extends Model<RecipeDocument> {
@@ -144,6 +149,8 @@ recipeSchema.statics.searchFull = async function ({
     { $unset: "__v" },
 
     ...withFavorited(initiator.id),
+    ...withUserRating(initiator.id),
+    ...withAverageRating(),
     {
       $match: {
         ...(isFavorited !== undefined && { isFavorited }),
@@ -180,6 +187,8 @@ recipeSchema.statics.findByIdFull = async function (
     ...withCategories(),
     ...withAuthor(),
     ...withFavorited(initiator.id),
+    ...withUserRating(initiator.id),
+    ...withAverageRating(),
   ]);
 
   if (!recipes.length) {

--- a/apps/backend/src/modules/recipes/recipe.service.test.ts
+++ b/apps/backend/src/modules/recipes/recipe.service.test.ts
@@ -97,6 +97,48 @@ describe("recipeService", () => {
       expect(recipeModel.searchFull).not.toHaveBeenCalled();
       expect(cache.get).not.toHaveBeenCalled();
     });
+
+    it("should return rating data from aggregation", async () => {
+      const populated = populateRecipeDoc(createRecipeDoc(), {
+        userRating: 4,
+        averageRating: 4.2,
+        ratingCount: 15,
+      });
+      recipeModel.searchFull.mockResolvedValue([[populated], 1]);
+
+      const query = {
+        page: 1,
+        limit: 10,
+        sort: "-createdAt",
+      } satisfies RecipeQuery;
+      const result = await service.findAll({
+        query,
+        initiator: noInitiator(),
+      });
+
+      expect(result.items[0]?.userRating).toBe(4);
+      expect(result.items[0]?.averageRating).toBe(4.2);
+      expect(result.items[0]?.ratingCount).toBe(15);
+    });
+
+    it("should return null ratings when recipe has no ratings", async () => {
+      const populated = populateRecipeDoc(createRecipeDoc());
+      recipeModel.searchFull.mockResolvedValue([[populated], 1]);
+
+      const query = {
+        page: 1,
+        limit: 10,
+        sort: "-createdAt",
+      } satisfies RecipeQuery;
+      const result = await service.findAll({
+        query,
+        initiator: noInitiator(),
+      });
+
+      expect(result.items[0]?.userRating).toBeNull();
+      expect(result.items[0]?.averageRating).toBeNull();
+      expect(result.items[0]?.ratingCount).toBe(0);
+    });
   });
 
   describe("findById", () => {
@@ -150,6 +192,24 @@ describe("recipeService", () => {
       ).rejects.toThrow(NotFoundError);
       expect(cache.get).toHaveBeenCalledWith(recipeCache.keys.byId(id));
     });
+
+    it("should return rating data from aggregation", async () => {
+      const populated = populateRecipeDoc(createRecipeDoc(), {
+        userRating: 5,
+        averageRating: 3.8,
+        ratingCount: 42,
+      });
+      recipeModel.findByIdFull.mockResolvedValue(populated);
+
+      const id = createObjectId().toString();
+      const result = await service.findById(id, {
+        initiator: noInitiator(),
+      });
+
+      expect(result.userRating).toBe(5);
+      expect(result.averageRating).toBe(3.8);
+      expect(result.ratingCount).toBe(42);
+    });
   });
 
   describe("create", () => {
@@ -190,6 +250,9 @@ describe("recipeService", () => {
 
       expect(recipeModel.create).toHaveBeenCalled();
       expect(result.title).toBe("New Recipe");
+      expect(result.userRating).toBeNull();
+      expect(result.averageRating).toBeNull();
+      expect(result.ratingCount).toBe(0);
       expect(cache.deletePattern).toHaveBeenCalledWith(
         recipeCache.keys.allPattern(),
       );
@@ -261,6 +324,9 @@ describe("recipeService", () => {
 
       expect(recipe.save).toHaveBeenCalled();
       expect(result.title).toBe("Updated");
+      expect(result.userRating).toBeNull();
+      expect(result.averageRating).toBeNull();
+      expect(result.ratingCount).toBe(0);
       expect(cache.delete).toHaveBeenCalledWith(recipeCache.keys.byId(id));
       expect(cache.deletePattern).toHaveBeenCalledWith(
         recipeCache.keys.allPattern(),

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -21,6 +21,9 @@ export type * from "./recipes/ingredient.types.js";
 export * from "./favorites/favorite.schema.js";
 export type * from "./favorites/favorite.types.js";
 
+export * from "./recipe-rating/recipe-rating.schema.js";
+export type * from "./recipe-rating/recipe-rating.types.js";
+
 export * from "./pagination.js";
 export * from "./utils.js";
 export * from "./query.js";

--- a/packages/shared/src/recipe-rating/recipe-rating.schema.ts
+++ b/packages/shared/src/recipe-rating/recipe-rating.schema.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const recipeRatingBodySchema = z.object({
+  value: z.number().int().min(1).max(5),
+});

--- a/packages/shared/src/recipe-rating/recipe-rating.types.ts
+++ b/packages/shared/src/recipe-rating/recipe-rating.types.ts
@@ -1,0 +1,4 @@
+import type { z } from "zod";
+import type { recipeRatingBodySchema } from "./recipe-rating.schema.js";
+
+export type RecipeRatingBody = z.infer<typeof recipeRatingBodySchema>;

--- a/packages/shared/src/recipes/recipe.schema.ts
+++ b/packages/shared/src/recipes/recipe.schema.ts
@@ -45,13 +45,16 @@ export const recipeSchema = z.object({
   servings: z.number(),
   isPublic: z.boolean(),
   isFavorited: z.boolean(),
+  userRating: z.number().int().min(1).max(5).nullable(),
+  averageRating: z.number().nullable(),
+  ratingCount: z.number().int().nonnegative(),
   createdAt: z.string(),
   updatedAt: z.string(),
 });
 
 export const recipeQuerySchema = z
   .object({
-    sort: createSortSchema(["-createdAt", "cookingTime"]).default("-createdAt"),
+    sort: createSortSchema(["createdAt", "cookingTime"]).default("-createdAt"),
     categoryId: z.string().optional(),
     difficulty: difficultySchema.optional(),
     isFavorited: z.stringbool().optional(),


### PR DESCRIPTION
## Related Issues

<!-- Link related issues: Closes #123, Refs #456 -->

## PR Type

- [x] Feature

## Description

Add recipe ratings system — users can rate recipes 1-5 stars, with average rating and count visible on recipe responses.

### New module: `recipe-ratings`

- `rating.model.ts` — Mongoose schema `{ user, recipe, value(1-5) }`, unique index `{ user, recipe }`, collection `recipeRatings`
- `rating.schema.ts` — Zod body validation `{ value: 1-5 }`
- `rating.service.ts` — `rate()` (upsert via `findOneAndUpdate`), `remove()` (with NotFoundError if not found)
- `rating.routes.ts` — `PUT /:id/rating`, `DELETE /:id/rating` (both auth required)

### Recipe integration

- `recipe.aggregation.ts` — `withUserRating(userId?)` and `withAverageRating()` pipeline helpers
- `recipe.model.ts` — `RecipeDocumentPopulated` extended with `userRating`, `averageRating`, `ratingCount`; pipelines injected into `searchFull` and `findByIdFull`
- `recipe.schema.ts` (shared) — `recipeSchema` extended with `userRating: number | null`, `averageRating: number | null`, `ratingCount: number`
- `toRecipe()` — accepts doc with optional rating fields, defaults to `null`/`0`

### API

```
PUT    /api/recipes/:id/rating   { value: 4 }  → { value: 4 }
DELETE /api/recipes/:id/rating   → 204
```

Recipe responses now include:
```json
{
  "userRating": 4,
  "averageRating": 4.2,
  "ratingCount": 127
}
```

## Screenshots

<!-- If applicable, add screenshots or recordings of the changes -->

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Added/updated tests for new functionality
- [ ] Updated documentation (if needed)