### PR TITLE
refactor: use stable collection names in aggregations

### DIFF
--- a/apps/backend/src/modules/categories/category.model.ts
+++ b/apps/backend/src/modules/categories/category.model.ts
@@ -3,6 +3,7 @@ import type { Model } from "mongoose";
 import { model, Schema } from "mongoose";
 import type { BaseDocument } from "@/common/types/mongoose.js";
 import { withSort } from "@/common/utils/mongoose.aggregation.js";
+import { recipesCollectionName } from "../recipes/recipe.model.js";
 
 export interface CategoryDocument extends BaseDocument {
   name: string;
@@ -51,7 +52,7 @@ categorySchema.statics.searchFull = async function (
       ? [
           {
             $lookup: {
-              from: "recipes",
+              from: recipesCollectionName,
               localField: "_id",
               foreignField: "category",
               as: "recipes",

--- a/apps/backend/src/modules/categories/category.model.ts
+++ b/apps/backend/src/modules/categories/category.model.ts
@@ -72,3 +72,5 @@ export const CategoryModel = model<CategoryDocument, CategoryModelType>(
   CATEGORY_MODEL_NAME,
   categorySchema,
 );
+
+export const categoriesCollectionName = CategoryModel.collection.name;

--- a/apps/backend/src/modules/comments/comment.aggregation.ts
+++ b/apps/backend/src/modules/comments/comment.aggregation.ts
@@ -1,6 +1,9 @@
 import type { PipelineStage } from "mongoose";
 import type { OptionalInitiator } from "@/common/types/methods.js";
-import { byVisibility } from "@/modules/recipes/index.js";
+import {
+  byVisibility,
+  recipesCollectionName,
+} from "@/modules/recipes/index.js";
 
 export function withRecipe(
   initiator: OptionalInitiator,
@@ -8,7 +11,7 @@ export function withRecipe(
   return [
     {
       $lookup: {
-        from: "recipes",
+        from: recipesCollectionName,
         localField: "recipe",
         foreignField: "_id",
         pipeline: [

--- a/apps/backend/src/modules/comments/comment.model.ts
+++ b/apps/backend/src/modules/comments/comment.model.ts
@@ -103,3 +103,5 @@ export const CommentModel = model<CommentDocument, CommentModelType>(
   COMMENT_MODEL_NAME,
   commentSchema,
 );
+
+export const commentsCollectionName = CommentModel.collection.name;

--- a/apps/backend/src/modules/favorites/favorite.aggregation.ts
+++ b/apps/backend/src/modules/favorites/favorite.aggregation.ts
@@ -4,7 +4,8 @@ import {
   byVisibility,
   withAuthor,
   withCategories,
-} from "@/modules/recipes/index.js";
+} from "@/modules/recipes/recipe.aggregation.js";
+import { recipesCollectionName } from "@/modules/recipes/recipe.model.js";
 
 export function withRecipe(
   initiator: OptionalInitiator,
@@ -12,7 +13,7 @@ export function withRecipe(
   return [
     {
       $lookup: {
-        from: "recipes",
+        from: recipesCollectionName,
         localField: "recipe",
         foreignField: "_id",
         pipeline: [

--- a/apps/backend/src/modules/favorites/favorite.model.ts
+++ b/apps/backend/src/modules/favorites/favorite.model.ts
@@ -83,3 +83,5 @@ export const FavoriteModel = model<FavoriteDocument, FavoriteModelType>(
   FAVORITE_MODEL_NAME,
   favoriteSchema,
 );
+
+export const favoritesCollectionName = FavoriteModel.collection.name;

--- a/apps/backend/src/modules/recipe-ratings/recipe-rating.model.ts
+++ b/apps/backend/src/modules/recipe-ratings/recipe-rating.model.ts
@@ -38,3 +38,5 @@ export const RecipeRatingModel = model<
   RecipeRatingDocument,
   RecipeRatingModelType
 >(RECIPE_RATING_MODEL_NAME, recipeRatingSchema);
+
+export const recipeRatingsCollectionName = RecipeRatingModel.collection.name;

--- a/apps/backend/src/modules/recipes/recipe.aggregation.ts
+++ b/apps/backend/src/modules/recipes/recipe.aggregation.ts
@@ -1,6 +1,10 @@
 import type { PipelineStage } from "mongoose";
 import type { OptionalInitiator } from "@/common/types/methods.js";
 import { toObjectId } from "@/common/utils/mongo.js";
+import { categoriesCollectionName } from "@/modules/categories/category.model.js";
+import { favoritesCollectionName } from "@/modules/favorites/favorite.model.js";
+import { recipeRatingsCollectionName } from "@/modules/recipe-ratings/recipe-rating.model.js";
+import { usersCollectionName } from "@/modules/users/user.model.js";
 
 export function byVisibility({ id, role }: OptionalInitiator) {
   if (role === "admin") {
@@ -20,7 +24,7 @@ export function withCategories() {
   return [
     {
       $lookup: {
-        from: "categories",
+        from: categoriesCollectionName,
         localField: "category",
         foreignField: "_id",
         pipeline: [
@@ -43,7 +47,7 @@ export function withAuthor() {
   return [
     {
       $lookup: {
-        from: "users",
+        from: usersCollectionName,
         localField: "author",
         foreignField: "_id",
         pipeline: [
@@ -77,7 +81,7 @@ export function withFavorited(userId?: string) {
   return [
     {
       $lookup: {
-        from: "favorites",
+        from: favoritesCollectionName,
         localField: "_id",
         foreignField: "recipe",
         pipeline: [
@@ -123,7 +127,7 @@ export function withUserRating(userId?: string) {
   return [
     {
       $lookup: {
-        from: "recipeRatings",
+        from: recipeRatingsCollectionName,
         localField: "_id",
         foreignField: "recipe",
         pipeline: [
@@ -156,7 +160,7 @@ export function withAverageRating() {
   return [
     {
       $lookup: {
-        from: "recipeRatings",
+        from: recipeRatingsCollectionName,
         localField: "_id",
         foreignField: "recipe",
         pipeline: [

--- a/apps/backend/src/modules/recipes/recipe.model.ts
+++ b/apps/backend/src/modules/recipes/recipe.model.ts
@@ -206,3 +206,5 @@ export const RecipeModel = model<RecipeDocument, RecipeModelType>(
   RECIPE_MODEL_NAME,
   recipeSchema,
 );
+
+export const recipesCollectionName = RecipeModel.collection.name;

--- a/apps/backend/src/modules/users/user.model.ts
+++ b/apps/backend/src/modules/users/user.model.ts
@@ -53,3 +53,5 @@ export const UserModel = model<UserDocument, UserModelType>(
   USER_MODEL_NAME,
   userSchema,
 );
+
+export const usersCollectionName = UserModel.collection.name;


### PR DESCRIPTION
## Related Issues

<!-- Link related issues: Closes #123, Refs #456 -->

## PR Type

- [x] Refactoring

## Description

Replace hardcoded string collection names in `$lookup` aggregation pipelines with stable variables derived from `Model.collection.name`.

### Problem

Hardcoded strings like `from: "recipes"` in `$lookup` rely on Mongoose's default pluralization behavior. If a model uses a custom `collection` option (e.g. `recipeRatings` instead of `reciperatings`), the `$lookup` silently fails to find documents — the aggregation returns empty or null results.

This was the root cause of the rating lookup bug fixed in the previous PR.

### Solution

Each model exports a `<name>CollectionName` constant derived from `Model.collection.name`:
- `recipesCollectionName` from `RecipeModel`
- `categoriesCollectionName` from `CategoryModel`
- `usersCollectionName` from `UserModel`
- `favoritesCollectionName` from `FavoriteModel`
- `recipeRatingsCollectionName` from `RecipeRatingModel`
- `commentsCollectionName` from `CommentModel`

All `$lookup` `from` fields now reference these constants instead of hardcoded strings.

## Screenshots

<!-- If applicable, add screenshots or recordings of the changes -->

## Checklist

- [x] \`pnpm lint` passes
- [x] \`pnpm test` passes
- [ ] Added/updated tests for new functionality
- [ ] Updated documentation (if needed)