### PR TITLE
fix: resolve circular dependency between model modules

### DIFF
--- a/apps/backend/src/modules/categories/category.model.ts
+++ b/apps/backend/src/modules/categories/category.model.ts
@@ -68,9 +68,8 @@ categorySchema.statics.searchFull = async function (
   return result;
 };
 
-export const CATEGORY_MODEL_NAME = "Category";
 export const CategoryModel = model<CategoryDocument, CategoryModelType>(
-  CATEGORY_MODEL_NAME,
+  "Category",
   categorySchema,
 );
 

--- a/apps/backend/src/modules/comments/comment.model.ts
+++ b/apps/backend/src/modules/comments/comment.model.ts
@@ -11,9 +11,8 @@ import {
   withTotalCount,
 } from "@/common/utils/mongoose.aggregation.js";
 import type { RecipeDocument } from "@/modules/recipes/index.js";
-import { RECIPE_MODEL_NAME, withAuthor } from "@/modules/recipes/index.js";
+import { withAuthor } from "@/modules/recipes/index.js";
 import type { UserDocument } from "@/modules/users/index.js";
-import { USER_MODEL_NAME } from "@/modules/users/index.js";
 import { withRecipe } from "./comment.aggregation.js";
 
 export interface CommentDocument extends BaseDocument {
@@ -53,12 +52,12 @@ const commentSchema = new Schema<CommentDocument, CommentModelType>(
     },
     recipe: {
       type: Schema.Types.ObjectId,
-      ref: RECIPE_MODEL_NAME,
+      ref: "Recipe",
       required: true,
     },
     author: {
       type: Schema.Types.ObjectId,
-      ref: USER_MODEL_NAME,
+      ref: "User",
       required: true,
     },
   },
@@ -98,9 +97,8 @@ commentSchema.statics.findFull = async function (
 
 commentSchema.index({ recipe: 1, createdAt: -1 });
 
-export const COMMENT_MODEL_NAME = "Comment";
 export const CommentModel = model<CommentDocument, CommentModelType>(
-  COMMENT_MODEL_NAME,
+  "Comment",
   commentSchema,
 );
 

--- a/apps/backend/src/modules/favorites/favorite.model.ts
+++ b/apps/backend/src/modules/favorites/favorite.model.ts
@@ -11,8 +11,6 @@ import {
   withTotalCount,
 } from "@/common/utils/mongoose.aggregation.js";
 import type { RecipeDocumentPopulated } from "@/modules/recipes/index.js";
-import { RECIPE_MODEL_NAME } from "@/modules/recipes/index.js";
-import { USER_MODEL_NAME } from "@/modules/users/index.js";
 import { withRecipe } from "./favorite.aggregation.js";
 
 export interface FavoriteDocument extends BaseDocumentWithoutUpdate {
@@ -37,10 +35,10 @@ export interface FavoriteModelType extends Model<FavoriteDocument> {
 
 const favoriteSchema = new Schema<FavoriteDocument, FavoriteModelType>(
   {
-    user: { type: Schema.Types.ObjectId, ref: USER_MODEL_NAME, required: true },
+    user: { type: Schema.Types.ObjectId, ref: "User", required: true },
     recipe: {
       type: Schema.Types.ObjectId,
-      ref: RECIPE_MODEL_NAME,
+      ref: "Recipe",
       required: true,
     },
   },
@@ -78,9 +76,8 @@ favoriteSchema.statics.findByUser = async function (
 favoriteSchema.index({ user: 1, recipe: 1 }, { unique: true });
 favoriteSchema.index({ user: 1, createdAt: -1 });
 
-export const FAVORITE_MODEL_NAME = "Favorite";
 export const FavoriteModel = model<FavoriteDocument, FavoriteModelType>(
-  FAVORITE_MODEL_NAME,
+  "Favorite",
   favoriteSchema,
 );
 

--- a/apps/backend/src/modules/recipe-ratings/recipe-rating.model.ts
+++ b/apps/backend/src/modules/recipe-ratings/recipe-rating.model.ts
@@ -1,8 +1,6 @@
 import type { Model, Types } from "mongoose";
 import { model, Schema } from "mongoose";
 import type { BaseDocumentWithoutUpdate } from "@/common/types/mongoose.js";
-import { RECIPE_MODEL_NAME } from "@/modules/recipes/recipe.model.js";
-import { USER_MODEL_NAME } from "@/modules/users/user.model.js";
 
 export interface RecipeRatingDocument extends BaseDocumentWithoutUpdate {
   user: Types.ObjectId;
@@ -17,10 +15,10 @@ const recipeRatingSchema = new Schema<
   RecipeRatingModelType
 >(
   {
-    user: { type: Schema.Types.ObjectId, ref: USER_MODEL_NAME, required: true },
+    user: { type: Schema.Types.ObjectId, ref: "User", required: true },
     recipe: {
       type: Schema.Types.ObjectId,
-      ref: RECIPE_MODEL_NAME,
+      ref: "Recipe",
       required: true,
     },
     value: { type: Number, required: true, min: 1, max: 5 },
@@ -33,10 +31,9 @@ const recipeRatingSchema = new Schema<
 
 recipeRatingSchema.index({ user: 1, recipe: 1 }, { unique: true });
 
-export const RECIPE_RATING_MODEL_NAME = "RecipeRating";
 export const RecipeRatingModel = model<
   RecipeRatingDocument,
   RecipeRatingModelType
->(RECIPE_RATING_MODEL_NAME, recipeRatingSchema);
+>("RecipeRating", recipeRatingSchema);
 
 export const recipeRatingsCollectionName = RecipeRatingModel.collection.name;

--- a/apps/backend/src/modules/recipes/recipe.model.ts
+++ b/apps/backend/src/modules/recipes/recipe.model.ts
@@ -20,9 +20,7 @@ import {
   withTotalCount,
 } from "@/common/utils/mongoose.aggregation.js";
 import type { CategoryDocument } from "@/modules/categories/index.js";
-import { CATEGORY_MODEL_NAME } from "@/modules/categories/index.js";
 import type { UserDocument } from "@/modules/users/index.js";
-import { USER_MODEL_NAME } from "@/modules/users/index.js";
 import {
   byVisibility,
   withAuthor,
@@ -106,12 +104,12 @@ const recipeSchema = new Schema<RecipeDocument, RecipeModelType>(
     },
     category: {
       type: Schema.Types.ObjectId,
-      ref: CATEGORY_MODEL_NAME,
+      ref: "Category",
       required: true,
     },
     author: {
       type: Schema.Types.ObjectId,
-      ref: USER_MODEL_NAME,
+      ref: "User",
       required: true,
     },
     difficulty: {
@@ -201,9 +199,8 @@ recipeSchema.statics.findByIdFull = async function (
 recipeSchema.index({ title: "text", description: "text" });
 recipeSchema.index({ category: 1, createdAt: -1 });
 
-export const RECIPE_MODEL_NAME = "Recipe";
 export const RecipeModel = model<RecipeDocument, RecipeModelType>(
-  RECIPE_MODEL_NAME,
+  "Recipe",
   recipeSchema,
 );
 


### PR DESCRIPTION
## Related Issues

Refs #51

## PR Type

- [x] Bugfix
- [x] Refactoring

## Description

Fix `ReferenceError: Cannot access 'RECIPE_MODEL_NAME' before initialization` caused by circular imports introduced in #51.

### Problem

#51 added cross-module imports for collection name variables (e.g. `categoriesCollectionName` in `category.model.ts` imports from `recipe.model.ts`). This created circular dependency chains:

```
recipe.model.ts → imports CATEGORY_MODEL_NAME → category.model.ts → imports recipesCollectionName → recipe.model.ts (CIRCULAR)
```

Node.js couldn't resolve the dependency order at module initialization time.

### Solution

Replace model name constants (`RECIPE_MODEL_NAME`, `USER_MODEL_NAME`, etc.) with inline strings in `ref` fields and `model()` calls. Model names are stable and won't change — only collection names can vary (via custom `collection` options). Removed all cross-module imports of model name constants.

Collection name exports (`recipesCollectionName`, `categoriesCollectionName`, etc.) are kept — they're computed at runtime via `Model.collection.name` after all models are initialized.

### Files changed

- `category.model.ts` — inline `"Category"`, remove `CATEGORY_MODEL_NAME` export
- `comment.model.ts` — inline `"Recipe"`, `"User"`, `"Comment"`, remove constants and imports
- `favorite.model.ts` — inline `"User"`, `"Recipe"`, `"Favorite"`, remove constants and imports
- `recipe-rating.model.ts` — inline `"User"`, `"Recipe"`, `"RecipeRating"`, remove constants and imports
- `recipe.model.ts` — inline `"Category"`, `"User"`, `"Recipe"`, remove constants and imports

## Checklist

- [x] \`pnpm lint` passes
- [x] \`pnpm test` passes
- [ ] Added/updated tests for new functionality
- [ ] Updated documentation (if needed)