### PR TITLE
refactor: extract shared validation utils

### DIFF
--- a/apps/backend/src/common/utils/validation.ts
+++ b/apps/backend/src/common/utils/validation.ts
@@ -1,0 +1,42 @@
+import type { Model } from "mongoose";
+import { isObjectIdOrHexString } from "mongoose";
+import { BadRequestError, NotFoundError } from "@/common/errors.js";
+
+type NoSubstring<S extends string, Forbidden extends string> =
+  Lowercase<S> extends `${string}${Lowercase<Forbidden>}${string}`
+    ? `Label "${S}" must not contain "${Forbidden}"`
+    : S;
+
+/**
+ * Asserts that a given ID is a valid ObjectId
+ *
+ * @param id - ID to validate
+ * @param label - Name of the entity being validated
+ * @throws {BadRequestError} if the ID is not a valid ObjectId
+ */
+export function assertValidId<const T extends string>(
+  id: string,
+  label: NoSubstring<T, "id">,
+): void {
+  if (!isObjectIdOrHexString(id)) {
+    throw new BadRequestError(`Invalid ${label} ID: ${id}`);
+  }
+}
+
+/**
+ * Asserts that a given ID exists in a given model
+ *
+ * @param model - Model to check
+ * @param id - ID to check
+ * @param forceLabel - Force a specific label to use in the error message
+ * @throws {NotFoundError} if the ID does not exist in the model
+ */
+export async function assertExists(
+  model: Model<unknown>,
+  id: string,
+): Promise<void> {
+  const exists = await model.exists({ _id: id });
+  if (!exists) {
+    throw new NotFoundError(`${model.modelName} not found`);
+  }
+}

--- a/apps/backend/src/modules/comments/comment.service.ts
+++ b/apps/backend/src/modules/comments/comment.service.ts
@@ -5,18 +5,14 @@ import type {
   Paginated,
 } from "@recipes/shared";
 import { withPagination } from "@recipes/shared";
-import { isValidObjectId } from "mongoose";
-import {
-  BadRequestError,
-  ForbiddenError,
-  NotFoundError,
-} from "@/common/errors.js";
+import { ForbiddenError, NotFoundError } from "@/common/errors.js";
 import type {
   CreateMethodParams,
   DeleteMethodParams,
   QueryMethodParams,
 } from "@/common/types/methods.js";
 import { toComment, toCommentForRecipe } from "@/common/utils/mongo.js";
+import { assertExists, assertValidId } from "@/common/utils/validation.js";
 import type { CommentModelType } from "@/modules/comments/index.js";
 import type { RecipeModelType } from "@/modules/recipes/index.js";
 import type { UserDocument, UserModelType } from "@/modules/users/index.js";
@@ -44,13 +40,9 @@ export function createCommentService(
 ): CommentService {
   return {
     findByRecipe: async (recipeId, { query, initiator }) => {
-      if (!isValidObjectId(recipeId)) {
-        throw new BadRequestError("Invalid recipe ID");
-      }
-      const recipeExists = await recipeModel.exists({ _id: recipeId });
-      if (!recipeExists) {
-        throw new NotFoundError("Recipe not found");
-      }
+      assertValidId(recipeId, "Recipe");
+      await assertExists(recipeModel, recipeId);
+
       const { page, limit } = query;
 
       const [comments, total] = await commentModel.findFull(
@@ -70,9 +62,8 @@ export function createCommentService(
     },
 
     findByAuthor: async (authorId, { query, initiator }) => {
-      if (!isValidObjectId(authorId)) {
-        throw new BadRequestError("Invalid author ID");
-      }
+      assertValidId(authorId, "Author");
+
       const { page, limit } = query;
 
       const [comments, total] = await commentModel.findFull(
@@ -87,21 +78,11 @@ export function createCommentService(
     },
 
     create: async (recipeId, { data, initiator }) => {
-      if (!isValidObjectId(recipeId)) {
-        throw new BadRequestError("Invalid recipe ID");
-      }
-      if (!isValidObjectId(initiator.id)) {
-        throw new BadRequestError("Invalid author ID");
-      }
+      assertValidId(recipeId, "Recipe");
+      assertValidId(initiator.id, "Author");
 
-      const recipeExists = await recipeModel.exists({ _id: recipeId });
-      if (!recipeExists) {
-        throw new NotFoundError("Recipe not found");
-      }
-      const authorExists = await userModel.exists({ _id: initiator.id });
-      if (!authorExists) {
-        throw new NotFoundError("Author not found");
-      }
+      await assertExists(recipeModel, recipeId);
+      await assertExists(userModel, initiator.id);
 
       const comment = await commentModel.create({
         text: data.text,
@@ -116,9 +97,7 @@ export function createCommentService(
     },
 
     delete: async (commentId, { initiator }) => {
-      if (!isValidObjectId(commentId)) {
-        throw new BadRequestError("Invalid comment ID");
-      }
+      assertValidId(commentId, "Comment");
 
       const comment = await commentModel.findById(commentId);
       if (!comment) {

--- a/apps/backend/src/modules/favorites/favorite.service.ts
+++ b/apps/backend/src/modules/favorites/favorite.service.ts
@@ -1,13 +1,12 @@
 import type { Paginated, PaginationQuery, Recipe } from "@recipes/shared";
 import { withPagination } from "@recipes/shared";
-import { isValidObjectId } from "mongoose";
-import { BadRequestError, NotFoundError } from "@/common/errors.js";
 import type {
   DefaultInitiator,
   InitiatedMethodParams,
   QueryMethodParams,
 } from "@/common/types/methods.js";
 import { toRecipe } from "@/common/utils/mongo.js";
+import { assertExists, assertValidId } from "@/common/utils/validation.js";
 import type { FavoriteModelType } from "@/modules/favorites/favorite.model.js";
 import type { RecipeModelType } from "@/modules/recipes/recipe.model.js";
 import type { UserModelType } from "@/modules/users/user.model.js";
@@ -36,25 +35,14 @@ export function createFavoriteService(
   recipeModel: RecipeModelType,
   userModel: UserModelType,
 ): FavoriteService {
-  async function validateUser(userId: string): Promise<void> {
-    if (!isValidObjectId(userId)) {
-      throw new BadRequestError("Invalid user ID");
-    }
-
-    const userExists = await userModel.exists({ _id: userId });
-    if (!userExists) {
-      throw new NotFoundError("User not found");
-    }
+  async function validateUser(id: string): Promise<void> {
+    assertValidId(id, "User");
+    await assertExists(userModel, id);
   }
-  async function validateRecipe(recipeId: string): Promise<void> {
-    if (!isValidObjectId(recipeId)) {
-      throw new BadRequestError("Invalid recipe ID");
-    }
 
-    const recipeExists = await recipeModel.exists({ _id: recipeId });
-    if (!recipeExists) {
-      throw new NotFoundError("Recipe not found");
-    }
+  async function validateRecipe(id: string): Promise<void> {
+    assertValidId(id, "Recipe");
+    await assertExists(recipeModel, id);
   }
 
   return {

--- a/apps/backend/src/modules/recipe-ratings/recipe-rating.service.ts
+++ b/apps/backend/src/modules/recipe-ratings/recipe-rating.service.ts
@@ -1,11 +1,11 @@
 import type { RecipeRatingBody } from "@recipes/shared";
-import { isObjectIdOrHexString } from "mongoose";
 import type { CacheService } from "@/common/cache/cache.service.js";
-import { BadRequestError, NotFoundError } from "@/common/errors.js";
+import { NotFoundError } from "@/common/errors.js";
 import type {
   CreateMethodParams,
   DeleteMethodParams,
 } from "@/common/types/methods.js";
+import { assertExists, assertValidId } from "@/common/utils/validation.js";
 import { recipeCache } from "@/modules/recipes/recipe.cache.js";
 import type { RecipeModelType } from "@/modules/recipes/recipe.model.js";
 import type { UserModelType } from "@/modules/users/user.model.js";
@@ -26,25 +26,13 @@ export function createRecipeRatingService(
   cache: CacheService,
 ): RecipeRatingService {
   async function validateUser(userId: string): Promise<void> {
-    if (!isObjectIdOrHexString(userId)) {
-      throw new BadRequestError(`Invalid user ID: ${userId}`);
-    }
-
-    const userExists = await userModel.exists({ _id: userId });
-    if (!userExists) {
-      throw new NotFoundError(`User not found: ${userId}`);
-    }
+    assertValidId(userId, "User");
+    await assertExists(userModel, userId);
   }
 
   async function validateRecipe(recipeId: string): Promise<void> {
-    if (!isObjectIdOrHexString(recipeId)) {
-      throw new BadRequestError(`Invalid recipe ID: ${recipeId}`);
-    }
-
-    const recipeExists = await recipeModel.exists({ _id: recipeId });
-    if (!recipeExists) {
-      throw new NotFoundError(`Recipe not found: ${recipeId}`);
-    }
+    assertValidId(recipeId, "Recipe");
+    await assertExists(recipeModel, recipeId);
   }
 
   return {

--- a/apps/backend/src/modules/recipes/recipe.service.ts
+++ b/apps/backend/src/modules/recipes/recipe.service.ts
@@ -6,13 +6,8 @@ import type {
   UpdateRecipeBody,
 } from "@recipes/shared";
 import { withPagination } from "@recipes/shared";
-import { isValidObjectId } from "mongoose";
 import type { CacheService } from "@/common/cache/cache.service.js";
-import {
-  BadRequestError,
-  ForbiddenError,
-  NotFoundError,
-} from "@/common/errors.js";
+import { ForbiddenError, NotFoundError } from "@/common/errors.js";
 import type {
   CreateMethodParams,
   DeleteMethodParams,
@@ -22,6 +17,7 @@ import type {
   UpdateMethodParams,
 } from "@/common/types/methods.js";
 import { toRecipe } from "@/common/utils/mongo.js";
+import { assertExists, assertValidId } from "@/common/utils/validation.js";
 import type {
   CategoryDocument,
   CategoryModelType,
@@ -95,9 +91,7 @@ export function createRecipeService(
     },
 
     findById: async (id, params) => {
-      if (!isValidObjectId(id)) {
-        throw new BadRequestError("Invalid recipe ID");
-      }
+      assertValidId(id, "Recipe");
 
       const isAuthenticated = !!params.initiator.id;
 
@@ -125,22 +119,11 @@ export function createRecipeService(
     },
 
     create: async ({ data, initiator }) => {
-      if (!isValidObjectId(initiator.id)) {
-        throw new BadRequestError("Invalid author ID");
-      }
-      if (!isValidObjectId(data.category)) {
-        throw new BadRequestError("Invalid category ID");
-      }
+      assertValidId(initiator.id, "Author");
+      assertValidId(data.category, "Category");
 
-      const categoryExists = await categoryModel.exists({ _id: data.category });
-      if (!categoryExists) {
-        throw new NotFoundError("Category not found");
-      }
-
-      const authorExists = await userModel.exists({ _id: initiator.id });
-      if (!authorExists) {
-        throw new NotFoundError("Author not found");
-      }
+      await assertExists(categoryModel, data.category);
+      await assertExists(userModel, initiator.id);
 
       const recipe = await recipeModel.create({
         ...data,
@@ -160,9 +143,7 @@ export function createRecipeService(
     },
 
     update: async (id, { data, initiator }) => {
-      if (!isValidObjectId(id)) {
-        throw new BadRequestError("Invalid recipe ID");
-      }
+      assertValidId(id, "Recipe");
       const recipe = await recipeModel.findById(id);
       if (!recipe) {
         throw new NotFoundError("Recipe not found");
@@ -198,9 +179,7 @@ export function createRecipeService(
     },
 
     delete: async (id, { initiator }) => {
-      if (!isValidObjectId(id)) {
-        throw new BadRequestError("Invalid recipe ID");
-      }
+      assertValidId(id, "Recipe");
       const recipe = await recipeModel.findById(id).select("+author");
       if (!recipe) {
         throw new NotFoundError("Recipe not found");


### PR DESCRIPTION
## Related Issues

Closes #56

## PR Type

- [x] Refactoring

## Description

Extract duplicated validation patterns across 4 services into shared utilities in `common/utils/validation.ts`:

- **`assertValidId(id, entity)`** — unified `isObjectIdOrHexString` check with `BadRequestError`. Entity label auto-appends "ID" in error message. Compile-time check prevents passing labels containing "ID" (case-insensitive).
- **`assertExists(model, id)`** — `model.exists()` check with `NotFoundError`, uses `model.modelName` for error message label.

### Before → After

| Service | Before | After |
|---|---|---|
| `recipe.service.ts` | 5 inline `isValidObjectId` + `BadRequestError` | `assertValidId` / `assertExists` |
| `favorite.service.ts` | Local `validateUser`/`validateRecipe` with manual checks | Shared utils |
| `comment.service.ts` | 5 inline `isValidObjectId` + `BadRequestError` | `assertValidId` / `assertExists` |
| `recipe-rating.service.ts` | `isObjectIdOrHexString` (inconsistent with rest) + local validators | Shared utils |

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Added/updated tests for new functionality
- [x] Updated documentation (if needed)