### PR TITLE
refactor: remove barrel exports from backend modules

### DIFF
--- a/.github/ISSUE_TEMPLATE/refactor.yml
+++ b/.github/ISSUE_TEMPLATE/refactor.yml
@@ -1,0 +1,43 @@
+name: Refactor
+description: Propose a code improvement or refactoring task
+labels: [refactor]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: A clear and concise description of the refactoring task.
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Why is this refactoring needed? What problems does it solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: Which files, modules, or areas of the codebase are affected?
+    validations:
+      required: true
+
+  - type: textarea
+    id: plan
+    attributes:
+      label: Implementation Plan
+      description: Step-by-step plan for the refactoring.
+    validations:
+      required: false
+
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks / Considerations
+      description: Any potential risks, breaking changes, or things to watch out for?
+    validations:
+      required: false

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -16,36 +16,25 @@ import { errorHandler } from "@/common/middleware/errorHandler.js";
 import { env } from "@/config/env.js";
 import { createRateLimitOptions } from "@/config/rate-limit.js";
 import { swaggerOptions, swaggerUiOptions } from "@/config/swagger.js";
-import { authRoutes, createAuthService } from "@/modules/auth/index.js";
-import {
-  CategoryModel,
-  categoryRoutes,
-  createCategoryService,
-} from "@/modules/categories/index.js";
-import {
-  CommentModel,
-  createCommentService,
-} from "@/modules/comments/index.js";
-import {
-  createFavoriteService,
-  FavoriteModel,
-  favoriteRoutes,
-} from "@/modules/favorites/index.js";
-import {
-  createRecipeRatingService,
-  RecipeRatingModel,
-  recipeRatingRoutes,
-} from "@/modules/recipe-ratings/index.js";
-import {
-  createRecipeService,
-  RecipeModel,
-  recipeRoutes,
-} from "@/modules/recipes/index.js";
-import {
-  createUserService,
-  UserModel,
-  userRoutes,
-} from "@/modules/users/index.js";
+import { authRoutes } from "@/modules/auth/auth.routes.js";
+import { createAuthService } from "@/modules/auth/auth.service.js";
+import { CategoryModel } from "@/modules/categories/category.model.js";
+import { categoryRoutes } from "@/modules/categories/category.routes.js";
+import { createCategoryService } from "@/modules/categories/category.service.js";
+import { CommentModel } from "@/modules/comments/comment.model.js";
+import { createCommentService } from "@/modules/comments/comment.service.js";
+import { FavoriteModel } from "@/modules/favorites/favorite.model.js";
+import { favoriteRoutes } from "@/modules/favorites/favorite.routes.js";
+import { createFavoriteService } from "@/modules/favorites/favorite.service.js";
+import { RecipeRatingModel } from "@/modules/recipe-ratings/recipe-rating.model.js";
+import { recipeRatingRoutes } from "@/modules/recipe-ratings/recipe-rating.routes.js";
+import { createRecipeRatingService } from "@/modules/recipe-ratings/recipe-rating.service.js";
+import { RecipeModel } from "@/modules/recipes/recipe.model.js";
+import { recipeRoutes } from "@/modules/recipes/recipe.routes.js";
+import { createRecipeService } from "@/modules/recipes/recipe.service.js";
+import { UserModel } from "@/modules/users/user.model.js";
+import { userRoutes } from "@/modules/users/user.routes.js";
+import { createUserService } from "@/modules/users/user.service.js";
 
 declare module "fastify" {
   interface FastifyInstance {

--- a/apps/backend/src/modules/auth/auth.routes.ts
+++ b/apps/backend/src/modules/auth/auth.routes.ts
@@ -6,7 +6,7 @@ import {
 import type { FastifyPluginAsync } from "fastify";
 import type { ZodTypeProvider } from "fastify-type-provider-zod";
 import { env } from "@/config/env.js";
-import type { AuthService } from "@/modules/auth/index.js";
+import type { AuthService } from "@/modules/auth/auth.service.js";
 
 export interface AuthModuleOptions {
   service: AuthService;

--- a/apps/backend/src/modules/auth/auth.service.ts
+++ b/apps/backend/src/modules/auth/auth.service.ts
@@ -3,7 +3,7 @@ import { ConflictError, UnauthorizedError } from "@/common/errors.js";
 import type { Logger } from "@/common/logger.js";
 import { signToken } from "@/common/utils/jwt.js";
 import { toUser } from "@/common/utils/mongo.js";
-import type { UserModelType } from "@/modules/users/index.js";
+import type { UserModelType } from "@/modules/users/user.model.js";
 
 export interface AuthService {
   register(data: RegisterBody): Promise<AuthResponse>;

--- a/apps/backend/src/modules/auth/index.ts
+++ b/apps/backend/src/modules/auth/index.ts
@@ -1,2 +1,0 @@
-export * from "./auth.routes.js";
-export * from "./auth.service.js";

--- a/apps/backend/src/modules/categories/category.service.test.ts
+++ b/apps/backend/src/modules/categories/category.service.test.ts
@@ -13,7 +13,7 @@ import { ConflictError, NotFoundError } from "@/common/errors.js";
 import { categoryCache } from "@/modules/categories/category.cache.js";
 import type { CategoryModelType } from "@/modules/categories/category.model.js";
 import { createCategoryService } from "@/modules/categories/category.service.js";
-import type { RecipeModelType } from "@/modules/recipes/index.js";
+import type { RecipeModelType } from "@/modules/recipes/recipe.model.js";
 
 describe("categoryService", () => {
   const categoryModel = createMockCategoryModel();

--- a/apps/backend/src/modules/categories/category.service.ts
+++ b/apps/backend/src/modules/categories/category.service.ts
@@ -12,8 +12,8 @@ import type {
 } from "@/common/types/methods.js";
 import { toCategory } from "@/common/utils/mongo.js";
 import { categoryCache } from "@/modules/categories/category.cache.js";
-import type { CategoryModelType } from "@/modules/categories/index.js";
-import type { RecipeModelType } from "@/modules/recipes/index.js";
+import type { CategoryModelType } from "@/modules/categories/category.model.js";
+import type { RecipeModelType } from "@/modules/recipes/recipe.model.js";
 
 export interface CategoryService {
   findAll(params: QueryMethodParams<CategoryQuery>): Promise<Category[]>;

--- a/apps/backend/src/modules/categories/index.ts
+++ b/apps/backend/src/modules/categories/index.ts
@@ -1,5 +1,0 @@
-export * from "./category.cache.js";
-export * from "./category.model.js";
-export * from "./category.routes.js";
-export * from "./category.schema.js";
-export * from "./category.service.js";

--- a/apps/backend/src/modules/comments/comment.aggregation.ts
+++ b/apps/backend/src/modules/comments/comment.aggregation.ts
@@ -1,9 +1,7 @@
 import type { PipelineStage } from "mongoose";
 import type { OptionalInitiator } from "@/common/types/methods.js";
-import {
-  byVisibility,
-  recipesCollectionName,
-} from "@/modules/recipes/index.js";
+import { byVisibility } from "@/modules/recipes/recipe.aggregation.js";
+import { recipesCollectionName } from "@/modules/recipes/recipe.model.js";
 
 export function withRecipe(
   initiator: OptionalInitiator,

--- a/apps/backend/src/modules/comments/comment.model.ts
+++ b/apps/backend/src/modules/comments/comment.model.ts
@@ -10,9 +10,9 @@ import {
   withSort,
   withTotalCount,
 } from "@/common/utils/mongoose.aggregation.js";
-import type { RecipeDocument } from "@/modules/recipes/index.js";
-import { withAuthor } from "@/modules/recipes/index.js";
-import type { UserDocument } from "@/modules/users/index.js";
+import { withAuthor } from "@/modules/recipes/recipe.aggregation.js";
+import type { RecipeDocument } from "@/modules/recipes/recipe.model.js";
+import type { UserDocument } from "@/modules/users/user.model.js";
 import { withRecipe } from "./comment.aggregation.js";
 
 export interface CommentDocument extends BaseDocument {

--- a/apps/backend/src/modules/comments/comment.service.test.ts
+++ b/apps/backend/src/modules/comments/comment.service.test.ts
@@ -15,8 +15,8 @@ import {
 } from "@/common/errors.js";
 import type { CommentModelType } from "@/modules/comments/comment.model.js";
 import { createCommentService } from "@/modules/comments/comment.service.js";
-import type { RecipeModelType } from "@/modules/recipes/index.js";
-import type { UserModelType } from "@/modules/users/index.js";
+import type { RecipeModelType } from "@/modules/recipes/recipe.model.js";
+import type { UserModelType } from "@/modules/users/user.model.js";
 
 describe("commentService", () => {
   const commentModel = createMockCommentModel();

--- a/apps/backend/src/modules/comments/comment.service.ts
+++ b/apps/backend/src/modules/comments/comment.service.ts
@@ -13,9 +13,12 @@ import type {
 } from "@/common/types/methods.js";
 import { toComment, toCommentForRecipe } from "@/common/utils/mongo.js";
 import { assertExists, assertValidId } from "@/common/utils/validation.js";
-import type { CommentModelType } from "@/modules/comments/index.js";
-import type { RecipeModelType } from "@/modules/recipes/index.js";
-import type { UserDocument, UserModelType } from "@/modules/users/index.js";
+import type { CommentModelType } from "@/modules/comments/comment.model.js";
+import type { RecipeModelType } from "@/modules/recipes/recipe.model.js";
+import type {
+  UserDocument,
+  UserModelType,
+} from "@/modules/users/user.model.js";
 
 export interface CommentService {
   findByRecipe(

--- a/apps/backend/src/modules/comments/index.ts
+++ b/apps/backend/src/modules/comments/index.ts
@@ -1,6 +1,0 @@
-// Routes are registered within recipe.routes.ts, not as a standalone module.
-// This is intentional: comments are a child resource of recipes.
-
-export * from "./comment.model.js";
-export * from "./comment.schema.js";
-export * from "./comment.service.js";

--- a/apps/backend/src/modules/favorites/favorite.model.ts
+++ b/apps/backend/src/modules/favorites/favorite.model.ts
@@ -10,7 +10,7 @@ import {
   withSort,
   withTotalCount,
 } from "@/common/utils/mongoose.aggregation.js";
-import type { RecipeDocumentPopulated } from "@/modules/recipes/index.js";
+import type { RecipeDocumentPopulated } from "@/modules/recipes/recipe.model.js";
 import { withRecipe } from "./favorite.aggregation.js";
 
 export interface FavoriteDocument extends BaseDocumentWithoutUpdate {

--- a/apps/backend/src/modules/favorites/favorite.routes.ts
+++ b/apps/backend/src/modules/favorites/favorite.routes.ts
@@ -5,8 +5,8 @@ import {
   assertAuthenticated,
   authGuard,
 } from "@/common/middleware/auth.guard.js";
-import type { FavoriteService } from "@/modules/favorites/index.js";
-import { recipeParamsSchema } from "@/modules/recipes/index.js";
+import type { FavoriteService } from "@/modules/favorites/favorite.service.js";
+import { recipeParamsSchema } from "@/modules/recipes/recipe.schema.js";
 
 export interface FavoriteModuleOptions {
   service: FavoriteService;

--- a/apps/backend/src/modules/favorites/index.ts
+++ b/apps/backend/src/modules/favorites/index.ts
@@ -1,4 +1,0 @@
-export * from "./favorite.model.js";
-export * from "./favorite.routes.js";
-export * from "./favorite.schema.js";
-export * from "./favorite.service.js";

--- a/apps/backend/src/modules/recipe-ratings/index.ts
+++ b/apps/backend/src/modules/recipe-ratings/index.ts
@@ -1,3 +1,0 @@
-export * from "./recipe-rating.model.js";
-export * from "./recipe-rating.routes.js";
-export * from "./recipe-rating.service.js";

--- a/apps/backend/src/modules/recipe-ratings/recipe-rating.routes.ts
+++ b/apps/backend/src/modules/recipe-ratings/recipe-rating.routes.ts
@@ -6,8 +6,8 @@ import {
   assertAuthenticated,
   authGuard,
 } from "@/common/middleware/auth.guard.js";
-import type { RecipeRatingService } from "@/modules/recipe-ratings/index.js";
-import { recipeParamsSchema } from "@/modules/recipes/index.js";
+import type { RecipeRatingService } from "@/modules/recipe-ratings/recipe-rating.service.js";
+import { recipeParamsSchema } from "@/modules/recipes/recipe.schema.js";
 
 export interface RecipeRatingModuleOptions {
   service: RecipeRatingService;

--- a/apps/backend/src/modules/recipes/index.ts
+++ b/apps/backend/src/modules/recipes/index.ts
@@ -1,6 +1,0 @@
-export * from "./recipe.aggregation.js";
-export * from "./recipe.cache.js";
-export * from "./recipe.model.js";
-export * from "./recipe.routes.js";
-export * from "./recipe.schema.js";
-export * from "./recipe.service.js";

--- a/apps/backend/src/modules/recipes/recipe.model.ts
+++ b/apps/backend/src/modules/recipes/recipe.model.ts
@@ -19,8 +19,8 @@ import {
   withSort,
   withTotalCount,
 } from "@/common/utils/mongoose.aggregation.js";
-import type { CategoryDocument } from "@/modules/categories/index.js";
-import type { UserDocument } from "@/modules/users/index.js";
+import type { CategoryDocument } from "@/modules/categories/category.model.js";
+import type { UserDocument } from "@/modules/users/user.model.js";
 import {
   byVisibility,
   withAuthor,

--- a/apps/backend/src/modules/recipes/recipe.routes.ts
+++ b/apps/backend/src/modules/recipes/recipe.routes.ts
@@ -15,10 +15,10 @@ import {
   authGuard,
   optionalAuth,
 } from "@/common/middleware/auth.guard.js";
-import type { CommentService } from "@/modules/comments/index.js";
-import { commentParamsSchema } from "@/modules/comments/index.js";
-import type { RecipeService } from "@/modules/recipes/index.js";
-import { recipeParamsSchema } from "@/modules/recipes/index.js";
+import { commentParamsSchema } from "@/modules/comments/comment.schema.js";
+import type { CommentService } from "@/modules/comments/comment.service.js";
+import { recipeParamsSchema } from "@/modules/recipes/recipe.schema.js";
+import type { RecipeService } from "@/modules/recipes/recipe.service.js";
 
 export interface RecipeModuleOptions {
   service: RecipeService;

--- a/apps/backend/src/modules/recipes/recipe.service.ts
+++ b/apps/backend/src/modules/recipes/recipe.service.ts
@@ -21,11 +21,14 @@ import { assertExists, assertValidId } from "@/common/utils/validation.js";
 import type {
   CategoryDocument,
   CategoryModelType,
-} from "@/modules/categories/index.js";
-import type { FavoriteModelType } from "@/modules/favorites/index.js";
-import type { RecipeModelType } from "@/modules/recipes/index.js";
+} from "@/modules/categories/category.model.js";
+import type { FavoriteModelType } from "@/modules/favorites/favorite.model.js";
 import { recipeCache } from "@/modules/recipes/recipe.cache.js";
-import type { UserDocument, UserModelType } from "@/modules/users/index.js";
+import type { RecipeModelType } from "@/modules/recipes/recipe.model.js";
+import type {
+  UserDocument,
+  UserModelType,
+} from "@/modules/users/user.model.js";
 
 export interface RecipeService {
   findAll(params: QueryMethodParams<RecipeQuery>): Promise<Paginated<Recipe>>;

--- a/apps/backend/src/modules/users/index.ts
+++ b/apps/backend/src/modules/users/index.ts
@@ -1,3 +1,0 @@
-export * from "./user.model.js";
-export * from "./user.routes.js";
-export * from "./user.service.js";

--- a/apps/backend/src/modules/users/user.routes.ts
+++ b/apps/backend/src/modules/users/user.routes.ts
@@ -12,7 +12,7 @@ import {
   assertAuthenticated,
   authGuard,
 } from "@/common/middleware/auth.guard.js";
-import type { UserService } from "@/modules/users/index.js";
+import type { UserService } from "@/modules/users/user.service.js";
 
 export interface UserPluginOptions {
   service: UserService;

--- a/apps/backend/src/modules/users/user.service.ts
+++ b/apps/backend/src/modules/users/user.service.ts
@@ -11,9 +11,9 @@ import type {
   QueryMethodParams,
 } from "@/common/types/methods.js";
 import { toUser } from "@/common/utils/mongo.js";
-import type { CommentService } from "@/modules/comments/index.js";
+import type { CommentService } from "@/modules/comments/comment.service.js";
 import type { FavoriteService } from "@/modules/favorites/favorite.service.js";
-import type { UserModelType } from "@/modules/users/index.js";
+import type { UserModelType } from "@/modules/users/user.model.js";
 
 export interface UserService {
   getCurrentUser(userId: string): Promise<User>;


### PR DESCRIPTION
## Related Issues

Closes #58

## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring
- [ ] Tests
- [ ] Other

## Description

Removes all 7 `index.ts` barrel export files from backend modules (`auth`, `users`, `recipes`, `categories`, `comments`, `favorites`, `recipe-ratings`) and replaces barrel imports with direct imports to specific files.

**Why:**
- Barrel imports were used inconsistently (~50/50 with direct imports)
- `export *` exposed internal implementation details (aggregations, caches)
- No tree-shaking or bundling benefit in a Node.js backend
- Direct imports are more explicit and easier to trace

**Changes:**
- Deleted 7 `index.ts` barrel files
- Updated 13 files to use direct imports
- Added `.github/ISSUE_TEMPLATE/refactor.yml` template

## Screenshots

N/A

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes (130 tests)
- [x] Added/updated tests for new functionality
- [x] Updated documentation (if needed)