### PR TITLE
refactor: extract service creation into dedicated createServices function

### DIFF
--- a/apps/backend/src/app.create-services.ts
+++ b/apps/backend/src/app.create-services.ts
@@ -1,0 +1,79 @@
+import type { CacheService } from "@/common/cache/cache.service.js";
+import type { Logger } from "@/common/logger.js";
+import type { AuthService } from "@/modules/auth/auth.service.js";
+import { createAuthService } from "@/modules/auth/auth.service.js";
+import { CategoryModel } from "@/modules/categories/category.model.js";
+import type { CategoryService } from "@/modules/categories/category.service.js";
+import { createCategoryService } from "@/modules/categories/category.service.js";
+import { CommentModel } from "@/modules/comments/comment.model.js";
+import type { CommentService } from "@/modules/comments/comment.service.js";
+import { createCommentService } from "@/modules/comments/comment.service.js";
+import { FavoriteModel } from "@/modules/favorites/favorite.model.js";
+import type { FavoriteService } from "@/modules/favorites/favorite.service.js";
+import { createFavoriteService } from "@/modules/favorites/favorite.service.js";
+import { RecipeRatingModel } from "@/modules/recipe-ratings/recipe-rating.model.js";
+import type { RecipeRatingService } from "@/modules/recipe-ratings/recipe-rating.service.js";
+import { createRecipeRatingService } from "@/modules/recipe-ratings/recipe-rating.service.js";
+import { RecipeModel } from "@/modules/recipes/recipe.model.js";
+import type { RecipeService } from "@/modules/recipes/recipe.service.js";
+import { createRecipeService } from "@/modules/recipes/recipe.service.js";
+import { UserModel } from "@/modules/users/user.model.js";
+import type { UserService } from "@/modules/users/user.service.js";
+import { createUserService } from "@/modules/users/user.service.js";
+
+export interface Services {
+  authService: AuthService;
+  userService: UserService;
+  recipeService: RecipeService;
+  commentService: CommentService;
+  favoriteService: FavoriteService;
+  recipeRatingService: RecipeRatingService;
+  categoryService: CategoryService;
+}
+
+export function createServices(cache: CacheService, log: Logger): Services {
+  const commentService = createCommentService(
+    CommentModel,
+    RecipeModel,
+    UserModel,
+  );
+  const favoriteService = createFavoriteService(
+    FavoriteModel,
+    RecipeModel,
+    UserModel,
+  );
+  const userService = createUserService(
+    commentService,
+    favoriteService,
+    UserModel,
+  );
+  const recipeRatingService = createRecipeRatingService(
+    RecipeRatingModel,
+    RecipeModel,
+    UserModel,
+    cache,
+  );
+  const categoryService = createCategoryService(
+    CategoryModel,
+    RecipeModel,
+    cache,
+  );
+  const recipeService = createRecipeService(
+    RecipeModel,
+    UserModel,
+    FavoriteModel,
+    CategoryModel,
+    cache,
+  );
+  const authService = createAuthService(UserModel, log);
+
+  return {
+    authService,
+    userService,
+    recipeService,
+    commentService,
+    favoriteService,
+    recipeRatingService,
+    categoryService,
+  };
+}

--- a/apps/backend/src/app.services.ts
+++ b/apps/backend/src/app.services.ts
@@ -22,13 +22,13 @@ import type { UserService } from "@/modules/users/user.service.js";
 import { createUserService } from "@/modules/users/user.service.js";
 
 export interface Services {
-  authService: AuthService;
-  userService: UserService;
-  recipeService: RecipeService;
-  commentService: CommentService;
-  favoriteService: FavoriteService;
-  recipeRatingService: RecipeRatingService;
-  categoryService: CategoryService;
+  auth: AuthService;
+  user: UserService;
+  recipe: RecipeService;
+  comment: CommentService;
+  favorite: FavoriteService;
+  recipeRating: RecipeRatingService;
+  category: CategoryService;
 }
 
 export function createServices(cache: CacheService, log: Logger): Services {
@@ -68,12 +68,12 @@ export function createServices(cache: CacheService, log: Logger): Services {
   const authService = createAuthService(UserModel, log);
 
   return {
-    authService,
-    userService,
-    recipeService,
-    commentService,
-    favoriteService,
-    recipeRatingService,
-    categoryService,
+    auth: authService,
+    user: userService,
+    recipe: recipeService,
+    comment: commentService,
+    favorite: favoriteService,
+    recipeRating: recipeRatingService,
+    category: categoryService,
   };
 }

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -21,7 +21,7 @@ import { favoriteRoutes } from "@/modules/favorites/favorite.routes.js";
 import { recipeRatingRoutes } from "@/modules/recipe-ratings/recipe-rating.routes.js";
 import { recipeRoutes } from "@/modules/recipes/recipe.routes.js";
 import { userRoutes } from "@/modules/users/user.routes.js";
-import { createServices } from "./app.create-services.js";
+import { createServices } from "./app.services.js";
 
 export async function buildApp(log: Logger) {
   const app = Fastify({
@@ -65,28 +65,28 @@ export async function buildApp(log: Logger) {
 
   // Routes
   app.register(authRoutes, {
-    service: services.authService,
+    service: services.auth,
     prefix: "/api/auth",
   });
   app.register(userRoutes, {
-    service: services.userService,
+    service: services.user,
     prefix: "/api/users",
   });
   app.register(recipeRoutes, {
-    service: services.recipeService,
-    commentService: services.commentService,
+    service: services.recipe,
+    commentService: services.comment,
     prefix: "/api/recipes",
   });
   app.register(favoriteRoutes, {
-    service: services.favoriteService,
+    service: services.favorite,
     prefix: "/api/recipes",
   });
   app.register(recipeRatingRoutes, {
-    service: services.recipeRatingService,
+    service: services.recipeRating,
     prefix: "/api/recipes",
   });
   app.register(categoryRoutes, {
-    service: services.categoryService,
+    service: services.category,
     prefix: "/api/categories",
   });
 

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -16,24 +16,12 @@ import { env } from "@/config/env.js";
 import { createRateLimitOptions } from "@/config/rate-limit.js";
 import { swaggerOptions, swaggerUiOptions } from "@/config/swagger.js";
 import { authRoutes } from "@/modules/auth/auth.routes.js";
-import { createAuthService } from "@/modules/auth/auth.service.js";
-import { CategoryModel } from "@/modules/categories/category.model.js";
 import { categoryRoutes } from "@/modules/categories/category.routes.js";
-import { createCategoryService } from "@/modules/categories/category.service.js";
-import { CommentModel } from "@/modules/comments/comment.model.js";
-import { createCommentService } from "@/modules/comments/comment.service.js";
-import { FavoriteModel } from "@/modules/favorites/favorite.model.js";
 import { favoriteRoutes } from "@/modules/favorites/favorite.routes.js";
-import { createFavoriteService } from "@/modules/favorites/favorite.service.js";
-import { RecipeRatingModel } from "@/modules/recipe-ratings/recipe-rating.model.js";
 import { recipeRatingRoutes } from "@/modules/recipe-ratings/recipe-rating.routes.js";
-import { createRecipeRatingService } from "@/modules/recipe-ratings/recipe-rating.service.js";
-import { RecipeModel } from "@/modules/recipes/recipe.model.js";
 import { recipeRoutes } from "@/modules/recipes/recipe.routes.js";
-import { createRecipeService } from "@/modules/recipes/recipe.service.js";
-import { UserModel } from "@/modules/users/user.model.js";
 import { userRoutes } from "@/modules/users/user.routes.js";
-import { createUserService } from "@/modules/users/user.service.js";
+import { createServices } from "./app.create-services.js";
 
 export async function buildApp(log: Logger) {
   const app = Fastify({
@@ -73,65 +61,32 @@ export async function buildApp(log: Logger) {
   // Health check
   app.get("/health", async () => ({ status: "ok" }));
 
-  const commentService = createCommentService(
-    CommentModel,
-    RecipeModel,
-    UserModel,
-  );
-  const favoriteService = createFavoriteService(
-    FavoriteModel,
-    RecipeModel,
-    UserModel,
-  );
-  const userService = createUserService(
-    commentService,
-    favoriteService,
-    UserModel,
-  );
-  const recipeRatingService = createRecipeRatingService(
-    RecipeRatingModel,
-    RecipeModel,
-    UserModel,
-    cache,
-  );
-  const categoryService = createCategoryService(
-    CategoryModel,
-    RecipeModel,
-    cache,
-  );
-  const recipeService = createRecipeService(
-    RecipeModel,
-    UserModel,
-    FavoriteModel,
-    CategoryModel,
-    cache,
-  );
-  const authService = createAuthService(UserModel, log);
+  const services = createServices(cache, log);
 
   // Routes
   app.register(authRoutes, {
-    service: authService,
+    service: services.authService,
     prefix: "/api/auth",
   });
   app.register(userRoutes, {
-    service: userService,
+    service: services.userService,
     prefix: "/api/users",
   });
   app.register(recipeRoutes, {
-    service: recipeService,
-    commentService,
+    service: services.recipeService,
+    commentService: services.commentService,
     prefix: "/api/recipes",
   });
   app.register(favoriteRoutes, {
-    service: favoriteService,
+    service: services.favoriteService,
     prefix: "/api/recipes",
   });
   app.register(recipeRatingRoutes, {
-    service: recipeRatingService,
+    service: services.recipeRatingService,
     prefix: "/api/recipes",
   });
   app.register(categoryRoutes, {
-    service: categoryService,
+    service: services.categoryService,
     prefix: "/api/categories",
   });
 


### PR DESCRIPTION
## Related Issues

Closes #63

## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring
- [ ] Tests
- [ ] Other

## Description

`app.ts` mixed three concerns: Fastify plugin setup, service instantiation, and route registration. This PR extracts all service creation and dependency wiring into a dedicated `createServices()` function.

**Changes:**
- New file `app.create-services.ts` — contains `createServices(cache, log)` that returns a typed `Services` object with all 7 services
- `app.ts` — reduced from 143 to 98 lines, now only handles Fastify setup (plugins, validators, error handling) and route registration

**Benefits:**
- Dependency graph between services is now explicit in one place
- Adding a new service only requires changes in `app.create-services.ts` + a single route registration in `app.ts`
- `Services` interface provides full type safety for all service references

## Screenshots

N/A

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [ ] Added/updated tests for new functionality
- [ ] Updated documentation (if needed)