### PR TITLE
refactor: EventEmitter for cross-service cache invalidation + namespace isolation

### DIFF
--- a/apps/backend/src/__tests__/helpers.ts
+++ b/apps/backend/src/__tests__/helpers.ts
@@ -5,6 +5,8 @@ import type { Mock } from "vitest";
 import { vi } from "vitest";
 import type { CacheService } from "@/common/cache/cache.service.js";
 import { createMemoryCache } from "@/common/cache/memory-cache.service.js";
+import type { TypedEmitter } from "@/common/events.js";
+import { createEventBus } from "@/common/events.js";
 import type { Logger } from "@/common/logger.js";
 import type { CategoryDocument } from "@/modules/categories/category.model.js";
 import type { CommentDocument } from "@/modules/comments/comment.model.js";
@@ -275,6 +277,18 @@ export function createMockCache(): MockCache {
     ...memoryCache,
     spies,
   };
+}
+
+// ── Event bus mock ──
+
+export interface MockBus extends TypedEmitter {
+  emit: Mock;
+}
+
+export function createMockBus(): MockBus {
+  const bus = createEventBus();
+  const emit = vi.spyOn(bus, "emit");
+  return Object.assign(bus, { emit });
 }
 
 // ── Service param builders ──

--- a/apps/backend/src/app.services.ts
+++ b/apps/backend/src/app.services.ts
@@ -1,4 +1,5 @@
 import type { CacheService } from "@/common/cache/cache.service.js";
+import type { TypedEmitter } from "@/common/events.js";
 import type { Logger } from "@/common/logger.js";
 import type { AuthService } from "@/modules/auth/auth.service.js";
 import { createAuthService } from "@/modules/auth/auth.service.js";
@@ -34,6 +35,7 @@ export interface Services {
 export function createServices(
   recipeCache: CacheService,
   categoryCache: CacheService,
+  bus: TypedEmitter,
   log: Logger,
 ): Services {
   const commentService = createCommentService(
@@ -55,11 +57,13 @@ export function createServices(
     RecipeRatingModel,
     RecipeModel,
     UserModel,
+    bus,
   );
   const categoryService = createCategoryService(
     CategoryModel,
     RecipeModel,
     categoryCache,
+    bus,
   );
   const recipeService = createRecipeService(
     RecipeModel,
@@ -67,6 +71,7 @@ export function createServices(
     FavoriteModel,
     CategoryModel,
     recipeCache,
+    bus,
   );
   const authService = createAuthService(UserModel, log);
 

--- a/apps/backend/src/app.services.ts
+++ b/apps/backend/src/app.services.ts
@@ -31,7 +31,11 @@ export interface Services {
   category: CategoryService;
 }
 
-export function createServices(cache: CacheService, log: Logger): Services {
+export function createServices(
+  recipeCache: CacheService,
+  categoryCache: CacheService,
+  log: Logger,
+): Services {
   const commentService = createCommentService(
     CommentModel,
     RecipeModel,
@@ -51,19 +55,18 @@ export function createServices(cache: CacheService, log: Logger): Services {
     RecipeRatingModel,
     RecipeModel,
     UserModel,
-    cache,
   );
   const categoryService = createCategoryService(
     CategoryModel,
     RecipeModel,
-    cache,
+    categoryCache,
   );
   const recipeService = createRecipeService(
     RecipeModel,
     UserModel,
     FavoriteModel,
     CategoryModel,
-    cache,
+    recipeCache,
   );
   const authService = createAuthService(UserModel, log);
 

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -10,6 +10,7 @@ import {
   validatorCompiler,
 } from "fastify-type-provider-zod";
 import { createCacheService } from "@/common/cache/create-cache.service.js";
+import { createNamespacedCache } from "@/common/cache/namespaced-cache.js";
 import type { Logger } from "@/common/logger.js";
 import { errorHandler } from "@/common/middleware/errorHandler.js";
 import { env } from "@/config/env.js";
@@ -61,7 +62,9 @@ export async function buildApp(log: Logger) {
   // Health check
   app.get("/health", async () => ({ status: "ok" }));
 
-  const services = createServices(cache, log);
+  const recipeCache = createNamespacedCache("recipes", cache);
+  const categoryCache = createNamespacedCache("categories", cache);
+  const services = createServices(recipeCache, categoryCache, log);
 
   // Routes
   app.register(authRoutes, {

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -70,7 +70,6 @@ export async function buildApp(log: Logger) {
 
   // Cross-service cache invalidation via events
   bus.on("category:changed", () => recipeCache.deletePattern("*"));
-  bus.on("recipe:changed", () => categoryCache.deletePattern("*"));
   bus.on("recipe:rated", () => recipeCache.deletePattern("*"));
 
   // Routes

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -11,6 +11,7 @@ import {
 } from "fastify-type-provider-zod";
 import { createCacheService } from "@/common/cache/create-cache.service.js";
 import { createNamespacedCache } from "@/common/cache/namespaced-cache.js";
+import { createEventBus } from "@/common/events.js";
 import type { Logger } from "@/common/logger.js";
 import { errorHandler } from "@/common/middleware/errorHandler.js";
 import { env } from "@/config/env.js";
@@ -62,9 +63,15 @@ export async function buildApp(log: Logger) {
   // Health check
   app.get("/health", async () => ({ status: "ok" }));
 
+  const bus = createEventBus();
   const recipeCache = createNamespacedCache("recipes", cache);
   const categoryCache = createNamespacedCache("categories", cache);
-  const services = createServices(recipeCache, categoryCache, log);
+  const services = createServices(recipeCache, categoryCache, bus, log);
+
+  // Cross-service cache invalidation via events
+  bus.on("category:changed", () => recipeCache.deletePattern("*"));
+  bus.on("recipe:changed", () => categoryCache.deletePattern("*"));
+  bus.on("recipe:rated", () => recipeCache.deletePattern("*"));
 
   // Routes
   app.register(authRoutes, {

--- a/apps/backend/src/common/cache/namespaced-cache.ts
+++ b/apps/backend/src/common/cache/namespaced-cache.ts
@@ -1,0 +1,31 @@
+import type { CacheService } from "./cache.service.js";
+
+export function createNamespacedCache(
+  prefix: string,
+  cache: CacheService,
+): CacheService {
+  return {
+    async get<T extends {}>(key: string): Promise<T | undefined> {
+      return cache.get<T>(`${prefix}:${key}`);
+    },
+
+    async set<T extends {}>(
+      key: string,
+      value: T,
+      ttlSeconds?: number,
+    ): Promise<void> {
+      return cache.set(`${prefix}:${key}`, value, ttlSeconds);
+    },
+
+    async delete(key: string): Promise<void> {
+      return cache.delete(`${prefix}:${key}`);
+    },
+
+    async deletePattern(pattern: string): Promise<void> {
+      return cache.deletePattern(`${prefix}:${pattern}`);
+    },
+
+    flush: cache.flush,
+    close: cache.close,
+  };
+}

--- a/apps/backend/src/common/events.ts
+++ b/apps/backend/src/common/events.ts
@@ -1,0 +1,22 @@
+import { EventEmitter } from "node:events";
+
+export interface CacheEvents {
+  "recipe:changed": () => void;
+  "recipe:rated": (recipeId: string) => void;
+  "category:changed": () => void;
+}
+
+export interface TypedEmitter extends EventEmitter {
+  on<K extends keyof CacheEvents>(event: K, listener: CacheEvents[K]): this;
+  off<K extends keyof CacheEvents>(event: K, listener: CacheEvents[K]): this;
+  once<K extends keyof CacheEvents>(event: K, listener: CacheEvents[K]): this;
+  emit<K extends keyof CacheEvents>(
+    event: K,
+    ...args: Parameters<CacheEvents[K]>
+  ): boolean;
+  removeAllListeners<K extends keyof CacheEvents>(event?: K): this;
+}
+
+export function createEventBus(): TypedEmitter {
+  return new EventEmitter() as TypedEmitter;
+}

--- a/apps/backend/src/modules/categories/category.cache.ts
+++ b/apps/backend/src/modules/categories/category.cache.ts
@@ -4,10 +4,10 @@ import { hashFilters } from "@/common/utils/cache.js";
 export const categoryCache = {
   keys: {
     list: (filters: CategoryQuery) =>
-      `categories:list:${hashFilters({
+      `list:${hashFilters({
         sort: filters.sort,
       })}`,
-    allPattern: () => "categories:*",
+    allPattern: () => "*",
   },
   ttl: {
     list: 3600,

--- a/apps/backend/src/modules/categories/category.service.test.ts
+++ b/apps/backend/src/modules/categories/category.service.test.ts
@@ -2,6 +2,7 @@ import type { CategoryQuery } from "@recipes/shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createCategoryDoc,
+  createMockBus,
   createMockCache,
   createMockCategoryModel,
   createMockRecipeModel,
@@ -19,10 +20,12 @@ describe("categoryService", () => {
   const categoryModel = createMockCategoryModel();
   const recipeModel = createMockRecipeModel();
   const cache = createMockCache();
+  const bus = createMockBus();
   const service = createCategoryService(
     categoryModel as unknown as CategoryModelType,
     recipeModel as unknown as RecipeModelType,
     cache,
+    bus,
   );
 
   beforeEach(async () => {
@@ -119,6 +122,7 @@ describe("categoryService", () => {
       expect(cache.deletePattern).toHaveBeenCalledWith(
         categoryCache.keys.allPattern(),
       );
+      expect(bus.emit).toHaveBeenCalledWith("category:changed");
     });
   });
 
@@ -135,6 +139,7 @@ describe("categoryService", () => {
       expect(cache.deletePattern).toHaveBeenCalledWith(
         categoryCache.keys.allPattern(),
       );
+      expect(bus.emit).toHaveBeenCalledWith("category:changed");
     });
 
     it("should throw ConflictError when recipes exist", async () => {

--- a/apps/backend/src/modules/categories/category.service.ts
+++ b/apps/backend/src/modules/categories/category.service.ts
@@ -5,6 +5,7 @@ import type {
 } from "@recipes/shared";
 import type { CacheService } from "@/common/cache/cache.service.js";
 import { ConflictError, NotFoundError } from "@/common/errors.js";
+import type { TypedEmitter } from "@/common/events.js";
 import type {
   CreateMethodParams,
   DeleteMethodParams,
@@ -29,6 +30,7 @@ export function createCategoryService(
   categoryModel: CategoryModelType,
   recipeModel: RecipeModelType,
   cache: CacheService,
+  bus: TypedEmitter,
 ): CategoryService {
   return {
     findAll: async ({ query }) => {
@@ -54,6 +56,7 @@ export function createCategoryService(
       const category = await categoryModel.create(data);
 
       await cache.deletePattern(categoryCache.keys.allPattern());
+      bus.emit("category:changed");
 
       return toCategory(category.toObject());
     },
@@ -72,6 +75,7 @@ export function createCategoryService(
       }
 
       await cache.deletePattern(categoryCache.keys.allPattern());
+      bus.emit("category:changed");
     },
   };
 }

--- a/apps/backend/src/modules/recipe-ratings/recipe-rating.service.test.ts
+++ b/apps/backend/src/modules/recipe-ratings/recipe-rating.service.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  createMockCache,
+  createMockBus,
   createMockRatingModel,
   createMockRecipeModel,
   createMockUserModel,
@@ -8,7 +8,6 @@ import {
   initiator,
 } from "@/__tests__/helpers.js";
 import { BadRequestError, NotFoundError } from "@/common/errors.js";
-import { recipeCache } from "@/modules/recipes/recipe.cache.js";
 import type { RecipeModelType } from "@/modules/recipes/recipe.model.js";
 import type { UserModelType } from "@/modules/users/user.model.js";
 import type { RecipeRatingModelType } from "./recipe-rating.model.js";
@@ -18,13 +17,13 @@ describe("recipeRatingService", () => {
   const ratingModel = createMockRatingModel();
   const recipeModel = createMockRecipeModel();
   const userModel = createMockUserModel();
-  const cache = createMockCache();
+  const bus = createMockBus();
 
   const service = createRecipeRatingService(
     ratingModel as unknown as RecipeRatingModelType,
     recipeModel as unknown as RecipeModelType,
     userModel as unknown as UserModelType,
-    cache,
+    bus,
   );
 
   beforeEach(() => {
@@ -52,9 +51,7 @@ describe("recipeRatingService", () => {
         { value: 4 },
         { upsert: true, returnDocument: "after" },
       );
-      expect(cache.deletePattern).toHaveBeenCalledWith(
-        recipeCache.keys.allPattern(),
-      );
+      expect(bus.emit).toHaveBeenCalledWith("recipe:rated", recipeId);
     });
 
     it("should update an existing rating", async () => {
@@ -135,9 +132,7 @@ describe("recipeRatingService", () => {
         user: init.id,
         recipe: recipeId,
       });
-      expect(cache.deletePattern).toHaveBeenCalledWith(
-        recipeCache.keys.allPattern(),
-      );
+      expect(bus.emit).toHaveBeenCalledWith("recipe:rated", recipeId);
     });
 
     it("should throw NotFoundError when rating does not exist", async () => {

--- a/apps/backend/src/modules/recipe-ratings/recipe-rating.service.ts
+++ b/apps/backend/src/modules/recipe-ratings/recipe-rating.service.ts
@@ -1,12 +1,11 @@
 import type { RecipeRatingBody } from "@recipes/shared";
-import type { CacheService } from "@/common/cache/cache.service.js";
 import { NotFoundError } from "@/common/errors.js";
+import type { TypedEmitter } from "@/common/events.js";
 import type {
   CreateMethodParams,
   DeleteMethodParams,
 } from "@/common/types/methods.js";
 import { assertExists, assertValidId } from "@/common/utils/validation.js";
-import { recipeCache } from "@/modules/recipes/recipe.cache.js";
 import type { RecipeModelType } from "@/modules/recipes/recipe.model.js";
 import type { UserModelType } from "@/modules/users/user.model.js";
 import type { RecipeRatingModelType } from "./recipe-rating.model.js";
@@ -23,7 +22,7 @@ export function createRecipeRatingService(
   ratingModel: RecipeRatingModelType,
   recipeModel: RecipeModelType,
   userModel: UserModelType,
-  cache: CacheService,
+  bus: TypedEmitter,
 ): RecipeRatingService {
   async function validateUser(userId: string): Promise<void> {
     assertValidId(userId, "User");
@@ -46,7 +45,7 @@ export function createRecipeRatingService(
         { upsert: true, returnDocument: "after" },
       );
 
-      await cache.deletePattern(recipeCache.keys.allPattern());
+      bus.emit("recipe:rated", recipeId);
 
       return { value: rating.value };
     },
@@ -66,7 +65,7 @@ export function createRecipeRatingService(
         );
       }
 
-      await cache.deletePattern(recipeCache.keys.allPattern());
+      bus.emit("recipe:rated", recipeId);
     },
   };
 }

--- a/apps/backend/src/modules/recipes/recipe.cache.ts
+++ b/apps/backend/src/modules/recipes/recipe.cache.ts
@@ -10,6 +10,7 @@ export const recipeCache = {
         difficulty: filters.difficulty,
         sort: filters.sort,
       })}`,
+    listPattern: () => "list:*",
     allPattern: () => "*",
   },
   ttl: {

--- a/apps/backend/src/modules/recipes/recipe.cache.ts
+++ b/apps/backend/src/modules/recipes/recipe.cache.ts
@@ -3,14 +3,14 @@ import { hashFilters } from "@/common/utils/cache.js";
 
 export const recipeCache = {
   keys: {
-    byId: (id: string) => `recipes:id:${id}`,
+    byId: (id: string) => `id:${id}`,
     list: (filters: RecipeQuery) =>
-      `recipes:list:${filters.page}:${filters.limit}:${hashFilters({
+      `list:${filters.page}:${filters.limit}:${hashFilters({
         categoryId: filters.categoryId,
         difficulty: filters.difficulty,
         sort: filters.sort,
       })}`,
-    allPattern: () => "recipes:*",
+    allPattern: () => "*",
   },
   ttl: {
     byId: 600,

--- a/apps/backend/src/modules/recipes/recipe.service.test.ts
+++ b/apps/backend/src/modules/recipes/recipe.service.test.ts
@@ -1,6 +1,7 @@
 import type { Minutes, RecipeQuery } from "@recipes/shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  createMockBus,
   createMockCache,
   createMockCategoryModel,
   createMockFavoriteModel,
@@ -30,12 +31,14 @@ describe("recipeService", () => {
   const favoriteModel = createMockFavoriteModel();
   const categoryModel = createMockCategoryModel();
   const cache = createMockCache();
+  const bus = createMockBus();
   const service = createRecipeService(
     recipeModel as unknown as RecipeModelType,
     userModel as unknown as UserModelType,
     favoriteModel as unknown as FavoriteModelType,
     categoryModel as unknown as CategoryModelType,
     cache,
+    bus,
   );
 
   beforeEach(async () => {
@@ -260,8 +263,9 @@ describe("recipeService", () => {
       expect(result.averageRating).toBeNull();
       expect(result.ratingCount).toBe(0);
       expect(cache.deletePattern).toHaveBeenCalledWith(
-        recipeCache.keys.allPattern(),
+        recipeCache.keys.listPattern(),
       );
+      expect(bus.emit).toHaveBeenCalledWith("recipe:changed");
     });
 
     it("should throw BadRequestError for invalid author ID", async () => {
@@ -335,8 +339,9 @@ describe("recipeService", () => {
       expect(result.ratingCount).toBe(0);
       expect(cache.delete).toHaveBeenCalledWith(recipeCache.keys.byId(id));
       expect(cache.deletePattern).toHaveBeenCalledWith(
-        recipeCache.keys.allPattern(),
+        recipeCache.keys.listPattern(),
       );
+      expect(bus.emit).toHaveBeenCalledWith("recipe:changed");
     });
 
     it("should update recipe when user is admin", async () => {
@@ -363,8 +368,9 @@ describe("recipeService", () => {
       ).resolves.toBeDefined();
       expect(cache.delete).toHaveBeenCalledWith(recipeCache.keys.byId(id));
       expect(cache.deletePattern).toHaveBeenCalledWith(
-        recipeCache.keys.allPattern(),
+        recipeCache.keys.listPattern(),
       );
+      expect(bus.emit).toHaveBeenCalledWith("recipe:changed");
     });
 
     it("should throw BadRequestError for invalid ID", async () => {
@@ -418,8 +424,9 @@ describe("recipeService", () => {
       ).resolves.toBeUndefined();
       expect(cache.delete).toHaveBeenCalledWith(recipeCache.keys.byId(id));
       expect(cache.deletePattern).toHaveBeenCalledWith(
-        recipeCache.keys.allPattern(),
+        recipeCache.keys.listPattern(),
       );
+      expect(bus.emit).toHaveBeenCalledWith("recipe:changed");
     });
 
     it("should delete recipe when user is admin", async () => {
@@ -438,8 +445,9 @@ describe("recipeService", () => {
       ).resolves.toBeUndefined();
       expect(cache.delete).toHaveBeenCalledWith(recipeCache.keys.byId(id));
       expect(cache.deletePattern).toHaveBeenCalledWith(
-        recipeCache.keys.allPattern(),
+        recipeCache.keys.listPattern(),
       );
+      expect(bus.emit).toHaveBeenCalledWith("recipe:changed");
     });
 
     it("should throw BadRequestError for invalid ID", async () => {

--- a/apps/backend/src/modules/recipes/recipe.service.ts
+++ b/apps/backend/src/modules/recipes/recipe.service.ts
@@ -8,6 +8,7 @@ import type {
 import { withPagination } from "@recipes/shared";
 import type { CacheService } from "@/common/cache/cache.service.js";
 import { ForbiddenError, NotFoundError } from "@/common/errors.js";
+import type { TypedEmitter } from "@/common/events.js";
 import type {
   CreateMethodParams,
   DeleteMethodParams,
@@ -59,6 +60,7 @@ export function createRecipeService(
   favoriteModel: FavoriteModelType,
   categoryModel: CategoryModelType,
   cache: CacheService,
+  bus: TypedEmitter,
 ): RecipeService {
   return {
     findAll: async ({ query, initiator }) => {
@@ -150,7 +152,8 @@ export function createRecipeService(
         { path: "category", select: "name slug" },
       ]);
 
-      await cache.deletePattern(recipeCache.keys.allPattern());
+      await cache.deletePattern(recipeCache.keys.listPattern());
+      bus.emit("recipe:changed");
 
       return toRecipe(populated.toObject<typeof populated>(), false);
     },
@@ -185,8 +188,9 @@ export function createRecipeService(
 
       await Promise.all([
         cache.delete(recipeCache.keys.byId(id)),
-        cache.deletePattern(recipeCache.keys.allPattern()),
+        cache.deletePattern(recipeCache.keys.listPattern()),
       ]);
+      bus.emit("recipe:changed");
 
       return toRecipe(populated.toObject<typeof populated>(), isFavorited);
     },
@@ -204,10 +208,9 @@ export function createRecipeService(
 
       await recipe.deleteOne();
 
-      await Promise.all([
-        cache.delete(recipeCache.keys.byId(id)),
-        cache.deletePattern(recipeCache.keys.allPattern()),
-      ]);
+      await cache.delete(recipeCache.keys.byId(id));
+      await cache.deletePattern(recipeCache.keys.listPattern());
+      bus.emit("recipe:changed");
     },
   };
 }


### PR DESCRIPTION
## Related Issues

Closes #65

## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring
- [ ] Tests
- [ ] Other

## Description

Introduces a typed EventEmitter for cross-service cache invalidation and namespace-isolated cache wrappers.

**Problem:**
- `recipe-rating.service.ts` directly imported `recipeCache` from the recipes module (tight coupling)
- No cross-service invalidation: category changes didn't invalidate recipe cache
- No enforcement of cache key namespaces between services

**Solution:**
- New typed `EventEmitter` (`common/events.ts`) with `CacheEvents` interface
- Namespace wrapper (`common/cache/namespaced-cache.ts`) that auto-prefixes all cache keys
- Each service directly invalidates its own cache; cross-service communication via events
- Centralized event listeners in `app.ts` for cross-service cache invalidation

**Key design decisions:**
- Own cache → direct invalidation (`cache.deletePattern(recipeCache.keys.listPattern())`)
- Cross-service → event bus (`bus.emit("recipe:changed")`)
- Cache keys stripped of namespace prefix (wrapper handles it)

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes (133 tests)
- [x] Added/updated tests for new functionality
- [ ] Updated documentation (if needed)