### PR TITLE
feat: BaseRepository with type-safe populate and ref input types

### DIFF
--- a/apps/backend/src/common/base.repository.ts
+++ b/apps/backend/src/common/base.repository.ts
@@ -14,9 +14,11 @@ export type PopulateKeys<T> = Partial<Prettify<Record<RefKeys<T>, unknown>>>;
 
 export type RefsForInput<T> = Prettify<
   Omit<T, RefKeys<T>> & {
-    [K in RefKeys<T>]: T[K] extends Types.ObjectId
-      ? string | Types.ObjectId
-      : T[K];
+    [K in RefKeys<T>]: T[K] extends readonly Types.ObjectId[]
+      ? readonly (Types.ObjectId | string)[]
+      : T[K] extends Types.ObjectId
+        ? Types.ObjectId | string
+        : T[K];
   }
 >;
 export type CreateInput<T extends { _id: Types.ObjectId }> = Partial<

--- a/apps/backend/src/common/base.repository.ts
+++ b/apps/backend/src/common/base.repository.ts
@@ -84,13 +84,26 @@ export class BaseRepository<
     return query.lean<Merge<TDoc, TPopulate>>();
   }
 
+  /**
+   * Deletes a document by id or filter.
+   *
+   * @param filter - The filter to use for finding the document to delete.
+   * @param options - The options to use for the delete operation.
+   * @returns The deleted document, or null if no document was found.
+   */
   // biome-ignore lint/complexity/noBannedTypes: default object value
   async delete<TPopulate extends PopulateKeys<TDoc> = {}>(
-    id: string,
+    filter: string | QueryFilter<TDoc>,
     options: QueryOptions = {},
   ): Promise<Merge<TDoc, TPopulate> | null> {
+    if (typeof filter === "string") {
+      return this.model
+        .findByIdAndDelete(filter, options)
+        .lean<Merge<TDoc, TPopulate>>();
+    }
+
     return this.model
-      .findByIdAndDelete(id, options)
+      .findOneAndDelete(filter, options)
       .lean<Merge<TDoc, TPopulate>>();
   }
 

--- a/apps/backend/src/common/base.repository.ts
+++ b/apps/backend/src/common/base.repository.ts
@@ -22,13 +22,17 @@ export type RefsForInput<T> = Prettify<
   }
 >;
 export type CreateInput<T extends { _id: Types.ObjectId }> = Partial<
-  Omit<RefsForInput<T>, "_id">
+  RefsForInput<T>
 >;
 export type UpdateInput<T extends { _id: Types.ObjectId }> = Partial<
   Omit<RefsForInput<T>, "_id">
 >;
 
-export class BaseRepository<TDoc extends { _id: Types.ObjectId }> {
+export class BaseRepository<
+  TDoc extends { _id: Types.ObjectId },
+  TCreate extends CreateInput<TDoc> = CreateInput<TDoc>,
+  TUpdate extends UpdateInput<TDoc> = UpdateInput<TDoc>,
+> {
   protected readonly model: Model<TDoc>;
 
   constructor(model: Model<TDoc>) {
@@ -69,7 +73,7 @@ export class BaseRepository<TDoc extends { _id: Types.ObjectId }> {
 
   // biome-ignore lint/complexity/noBannedTypes: default object value
   async create<TPopulate extends PopulateKeys<TDoc> = {}>(
-    data: CreateInput<TDoc>,
+    data: TCreate,
     options: PopulateOption = {},
   ): Promise<Merge<TDoc, TPopulate>> {
     const doc = await this.model.create(this.castInput(data));
@@ -84,7 +88,7 @@ export class BaseRepository<TDoc extends { _id: Types.ObjectId }> {
   // biome-ignore lint/complexity/noBannedTypes: default object value
   async update<TPopulate extends PopulateKeys<TDoc> = {}>(
     id: string,
-    data: UpdateInput<TDoc>,
+    data: TUpdate,
     options: QueryOptions = {},
   ): Promise<Merge<TDoc, TPopulate> | null> {
     const query = this.model.findByIdAndUpdate(id, this.castInput(data), {

--- a/apps/backend/src/common/base.repository.ts
+++ b/apps/backend/src/common/base.repository.ts
@@ -1,0 +1,106 @@
+import type { Prettify } from "@recipes/shared";
+import type {
+  Model,
+  PipelineStage,
+  PopulateOption,
+  QueryFilter,
+  QueryOptions,
+  Types,
+} from "mongoose";
+
+type Merge<A, B> = Prettify<Omit<A, keyof B> & B>;
+
+export class BaseRepository<
+  TDoc extends { _id: Types.ObjectId },
+  TCreate extends Partial<TDoc>,
+  TUpdate extends Partial<TDoc> = TCreate,
+> {
+  protected readonly model: Model<TDoc>;
+
+  constructor(model: Model<TDoc>) {
+    this.model = model;
+  }
+
+  // biome-ignore lint/complexity/noBannedTypes: default object value
+  async findById<TPopulate extends Record<string, unknown> = {}>(
+    id: string,
+    options: QueryOptions = {},
+  ): Promise<Merge<TDoc, TPopulate> | null> {
+    const query = this.model.findById(id, null, options);
+
+    return query.lean<Merge<TDoc, TPopulate>>();
+  }
+
+  // biome-ignore lint/complexity/noBannedTypes: default object value
+  async findOne<TPopulate extends Record<string, unknown> = {}>(
+    filter: QueryFilter<TDoc>,
+    options: QueryOptions = {},
+  ): Promise<Merge<TDoc, TPopulate> | null> {
+    const query = this.model.findOne(filter, null, options);
+
+    return query.lean<Merge<TDoc, TPopulate>>();
+  }
+
+  // biome-ignore lint/complexity/noBannedTypes: default object value
+  async findMany<TPopulate extends Record<string, unknown> = {}>(
+    filter: QueryFilter<TDoc> = {},
+    options: QueryOptions = {},
+  ): Promise<Merge<TDoc, TPopulate>[]> {
+    const query = this.model.find(filter, null, options);
+
+    return query.lean<Merge<TDoc, TPopulate>[]>();
+  }
+
+  // biome-ignore lint/complexity/noBannedTypes: default object value
+  async create<TPopulate extends Record<string, unknown> = {}>(
+    data: TCreate,
+    options: PopulateOption = {},
+  ): Promise<Merge<TDoc, TPopulate>> {
+    const doc = await this.model.create(data);
+
+    if (options.populate) {
+      await doc.populate(options.populate);
+    }
+
+    return doc.toObject<Merge<TDoc, TPopulate>>();
+  }
+
+  // biome-ignore lint/complexity/noBannedTypes: default object value
+  async update<TPopulate extends Record<string, unknown> = {}>(
+    id: string,
+    data: TUpdate,
+    options: QueryOptions = {},
+  ): Promise<Merge<TDoc, TPopulate> | null> {
+    const query = this.model.findByIdAndUpdate(id, data, {
+      returnDocument: "after",
+      runValidators: true,
+      ...options,
+    });
+
+    return query.lean<Merge<TDoc, TPopulate>>();
+  }
+
+  // biome-ignore lint/complexity/noBannedTypes: default object value
+  async delete<TPopulate extends Record<string, unknown> = {}>(
+    id: string,
+    options: QueryOptions = {},
+  ): Promise<Merge<TDoc, TPopulate> | null> {
+    return this.model
+      .findByIdAndDelete(id, options)
+      .lean<Merge<TDoc, TPopulate>>();
+  }
+
+  async exists(filter: QueryFilter<TDoc>): Promise<boolean> {
+    return !!(await this.model.exists(filter));
+  }
+
+  async count(filter: QueryFilter<TDoc> = {}): Promise<number> {
+    return this.model.countDocuments(filter);
+  }
+
+  async aggregate<TResult = TDoc>(
+    pipeline: PipelineStage[],
+  ): Promise<TResult[]> {
+    return this.model.aggregate<TResult>(pipeline);
+  }
+}

--- a/apps/backend/src/common/base.repository.ts
+++ b/apps/backend/src/common/base.repository.ts
@@ -7,8 +7,10 @@ import type {
   QueryOptions,
   Types,
 } from "mongoose";
+import type { RefKeys } from "@/common/types/mongoose.js";
 
-type Merge<A, B> = Prettify<Omit<A, keyof B> & B>;
+export type Merge<A, B> = Prettify<Omit<A, keyof B> & B>;
+export type PopulateKeys<T> = Partial<Prettify<Record<RefKeys<T>, unknown>>>;
 
 export class BaseRepository<
   TDoc extends { _id: Types.ObjectId },
@@ -21,8 +23,10 @@ export class BaseRepository<
     this.model = model;
   }
 
-  // biome-ignore lint/complexity/noBannedTypes: default object value
-  async findById<TPopulate extends Record<string, unknown> = {}>(
+  async findById<
+    // biome-ignore lint/complexity/noBannedTypes: default object value
+    TPopulate extends PopulateKeys<TDoc> = {},
+  >(
     id: string,
     options: QueryOptions = {},
   ): Promise<Merge<TDoc, TPopulate> | null> {
@@ -32,7 +36,7 @@ export class BaseRepository<
   }
 
   // biome-ignore lint/complexity/noBannedTypes: default object value
-  async findOne<TPopulate extends Record<string, unknown> = {}>(
+  async findOne<TPopulate extends PopulateKeys<TDoc> = {}>(
     filter: QueryFilter<TDoc>,
     options: QueryOptions = {},
   ): Promise<Merge<TDoc, TPopulate> | null> {
@@ -42,7 +46,7 @@ export class BaseRepository<
   }
 
   // biome-ignore lint/complexity/noBannedTypes: default object value
-  async findMany<TPopulate extends Record<string, unknown> = {}>(
+  async findMany<TPopulate extends PopulateKeys<TDoc> = {}>(
     filter: QueryFilter<TDoc> = {},
     options: QueryOptions = {},
   ): Promise<Merge<TDoc, TPopulate>[]> {
@@ -52,7 +56,7 @@ export class BaseRepository<
   }
 
   // biome-ignore lint/complexity/noBannedTypes: default object value
-  async create<TPopulate extends Record<string, unknown> = {}>(
+  async create<TPopulate extends PopulateKeys<TDoc> = {}>(
     data: TCreate,
     options: PopulateOption = {},
   ): Promise<Merge<TDoc, TPopulate>> {
@@ -66,7 +70,7 @@ export class BaseRepository<
   }
 
   // biome-ignore lint/complexity/noBannedTypes: default object value
-  async update<TPopulate extends Record<string, unknown> = {}>(
+  async update<TPopulate extends PopulateKeys<TDoc> = {}>(
     id: string,
     data: TUpdate,
     options: QueryOptions = {},
@@ -81,7 +85,7 @@ export class BaseRepository<
   }
 
   // biome-ignore lint/complexity/noBannedTypes: default object value
-  async delete<TPopulate extends Record<string, unknown> = {}>(
+  async delete<TPopulate extends PopulateKeys<TDoc> = {}>(
     id: string,
     options: QueryOptions = {},
   ): Promise<Merge<TDoc, TPopulate> | null> {

--- a/apps/backend/src/common/base.repository.ts
+++ b/apps/backend/src/common/base.repository.ts
@@ -2,7 +2,7 @@ import type { Prettify } from "@recipes/shared";
 import type {
   Model,
   PipelineStage,
-  PopulateOption,
+  PopulateOptions,
   QueryFilter,
   QueryOptions,
   Types,
@@ -11,6 +11,14 @@ import type { RefKeys } from "@/common/types/mongoose.js";
 
 export type Merge<A, B> = Prettify<Omit<A, keyof B> & B>;
 export type PopulateKeys<T> = Partial<Prettify<Record<RefKeys<T>, unknown>>>;
+
+export type TimestampKeys = "createdAt" | "updatedAt";
+export type AutoFields = "_id" | TimestampKeys;
+
+export type RepositoryPopulate = PopulateOptions | PopulateOptions[];
+export type RepositoryQueryOptions = Omit<QueryOptions, "populate"> & {
+  populate?: RepositoryPopulate;
+};
 
 export type RefsForInput<T> = Prettify<
   Omit<T, RefKeys<T>> & {
@@ -32,6 +40,8 @@ export class BaseRepository<
   TDoc extends { _id: Types.ObjectId },
   TCreate extends CreateInput<TDoc> = CreateInput<TDoc>,
   TUpdate extends UpdateInput<TDoc> = UpdateInput<TDoc>,
+  // biome-ignore lint/complexity/noBannedTypes: default object value
+  TDefaultPopulate extends PopulateKeys<TDoc> = {},
 > {
   protected readonly model: Model<TDoc>;
 
@@ -39,63 +49,77 @@ export class BaseRepository<
     this.model = model;
   }
 
-  async findById<
-    // biome-ignore lint/complexity/noBannedTypes: default object value
-    TPopulate extends PopulateKeys<TDoc> = {},
-  >(
+  async findById<TPopulate extends PopulateKeys<TDoc> = TDefaultPopulate>(
     id: string,
-    options: QueryOptions = {},
+    options: RepositoryQueryOptions = {},
   ): Promise<Merge<TDoc, TPopulate> | null> {
-    const query = this.model.findById(id, null, options);
+    const { queryOptions, populate } = this.resolveOptions(options);
+    const query = this.model.findById(id, null, queryOptions);
+
+    if (populate) {
+      query.populate<TPopulate>(populate);
+    }
 
     return query.lean<Merge<TDoc, TPopulate>>();
   }
 
-  // biome-ignore lint/complexity/noBannedTypes: default object value
-  async findOne<TPopulate extends PopulateKeys<TDoc> = {}>(
+  async findOne<TPopulate extends PopulateKeys<TDoc> = TDefaultPopulate>(
     filter: QueryFilter<TDoc>,
-    options: QueryOptions = {},
+    options: RepositoryQueryOptions = {},
   ): Promise<Merge<TDoc, TPopulate> | null> {
-    const query = this.model.findOne(filter, null, options);
+    const { queryOptions, populate } = this.resolveOptions(options);
+    const query = this.model.findOne(filter, null, queryOptions);
+
+    if (populate) {
+      query.populate<TPopulate>(populate);
+    }
 
     return query.lean<Merge<TDoc, TPopulate>>();
   }
 
-  // biome-ignore lint/complexity/noBannedTypes: default object value
-  async find<TPopulate extends PopulateKeys<TDoc> = {}>(
+  async find<TPopulate extends PopulateKeys<TDoc> = TDefaultPopulate>(
     filter: QueryFilter<TDoc> = {},
-    options: QueryOptions = {},
+    options: RepositoryQueryOptions = {},
   ): Promise<Merge<TDoc, TPopulate>[]> {
-    const query = this.model.find(filter, null, options);
+    const { queryOptions, populate } = this.resolveOptions(options);
+    const query = this.model.find(filter, null, queryOptions);
+
+    if (populate) {
+      query.populate<TPopulate>(populate);
+    }
 
     return query.lean<Merge<TDoc, TPopulate>[]>();
   }
 
-  // biome-ignore lint/complexity/noBannedTypes: default object value
-  async create<TPopulate extends PopulateKeys<TDoc> = {}>(
+  async create<TPopulate extends PopulateKeys<TDoc> = TDefaultPopulate>(
     data: TCreate,
-    options: PopulateOption = {},
+    options: { populate?: RepositoryPopulate } = {},
   ): Promise<Merge<TDoc, TPopulate>> {
+    const populate = this.mergePopulate(options.populate);
     const doc = await this.model.create(this.castInput(data));
 
-    if (options.populate) {
-      await doc.populate(options.populate);
+    if (populate) {
+      await doc.populate<TPopulate>(populate);
     }
 
     return doc.toObject<Merge<TDoc, TPopulate>>();
   }
 
-  // biome-ignore lint/complexity/noBannedTypes: default object value
-  async update<TPopulate extends PopulateKeys<TDoc> = {}>(
+  async update<TPopulate extends PopulateKeys<TDoc> = TDefaultPopulate>(
     id: string,
     data: TUpdate,
-    options: QueryOptions = {},
+    options: RepositoryQueryOptions = {},
   ): Promise<Merge<TDoc, TPopulate> | null> {
+    const { queryOptions, populate } = this.resolveOptions(options);
     const query = this.model.findByIdAndUpdate(id, this.castInput(data), {
       returnDocument: "after",
       runValidators: true,
-      ...options,
+      ...queryOptions,
     });
+
+    if (populate) {
+      query.populate<TPopulate>(populate);
+    }
 
     return query.lean<Merge<TDoc, TPopulate>>();
   }
@@ -107,20 +131,22 @@ export class BaseRepository<
    * @param options - The options to use for the delete operation.
    * @returns The deleted document, or null if no document was found.
    */
-  // biome-ignore lint/complexity/noBannedTypes: default object value
-  async delete<TPopulate extends PopulateKeys<TDoc> = {}>(
+  async delete<TPopulate extends PopulateKeys<TDoc> = TDefaultPopulate>(
     filter: string | QueryFilter<TDoc>,
-    options: QueryOptions = {},
+    options: RepositoryQueryOptions = {},
   ): Promise<Merge<TDoc, TPopulate> | null> {
-    if (typeof filter === "string") {
-      return this.model
-        .findByIdAndDelete(filter, options)
-        .lean<Merge<TDoc, TPopulate>>();
+    const { queryOptions, populate } = this.resolveOptions(options);
+
+    const query =
+      typeof filter === "string"
+        ? this.model.findByIdAndDelete(filter, queryOptions)
+        : this.model.findOneAndDelete(filter, queryOptions);
+
+    if (populate) {
+      query.populate<TPopulate>(populate);
     }
 
-    return this.model
-      .findOneAndDelete(filter, options)
-      .lean<Merge<TDoc, TPopulate>>();
+    return query.lean<Merge<TDoc, TPopulate>>();
   }
 
   async exists(filter: QueryFilter<TDoc>): Promise<boolean> {
@@ -141,5 +167,27 @@ export class BaseRepository<
     data: TInput,
   ): Partial<TDoc> {
     return this.model.castObject(data) as Partial<TDoc>;
+  }
+
+  protected getDefaultPopulate(): RepositoryPopulate | undefined {
+    return undefined;
+  }
+
+  protected mergePopulate(
+    populate?: RepositoryPopulate,
+  ): RepositoryPopulate | undefined {
+    return populate ?? this.getDefaultPopulate();
+  }
+
+  protected resolveOptions(options: RepositoryQueryOptions = {}): {
+    queryOptions: Omit<RepositoryQueryOptions, "populate">;
+    populate?: RepositoryPopulate;
+  } {
+    const { populate, ...queryOptions } = options;
+
+    return {
+      queryOptions,
+      populate: this.mergePopulate(populate),
+    };
   }
 }

--- a/apps/backend/src/common/base.repository.ts
+++ b/apps/backend/src/common/base.repository.ts
@@ -46,7 +46,7 @@ export class BaseRepository<
   }
 
   // biome-ignore lint/complexity/noBannedTypes: default object value
-  async findMany<TPopulate extends PopulateKeys<TDoc> = {}>(
+  async find<TPopulate extends PopulateKeys<TDoc> = {}>(
     filter: QueryFilter<TDoc> = {},
     options: QueryOptions = {},
   ): Promise<Merge<TDoc, TPopulate>[]> {

--- a/apps/backend/src/common/base.repository.ts
+++ b/apps/backend/src/common/base.repository.ts
@@ -12,11 +12,21 @@ import type { RefKeys } from "@/common/types/mongoose.js";
 export type Merge<A, B> = Prettify<Omit<A, keyof B> & B>;
 export type PopulateKeys<T> = Partial<Prettify<Record<RefKeys<T>, unknown>>>;
 
-export class BaseRepository<
-  TDoc extends { _id: Types.ObjectId },
-  TCreate extends Partial<TDoc>,
-  TUpdate extends Partial<TDoc> = TCreate,
-> {
+export type RefsForInput<T> = Prettify<
+  Omit<T, RefKeys<T>> & {
+    [K in RefKeys<T>]: T[K] extends Types.ObjectId
+      ? string | Types.ObjectId
+      : T[K];
+  }
+>;
+export type CreateInput<T extends { _id: Types.ObjectId }> = Partial<
+  Omit<RefsForInput<T>, "_id">
+>;
+export type UpdateInput<T extends { _id: Types.ObjectId }> = Partial<
+  Omit<RefsForInput<T>, "_id">
+>;
+
+export class BaseRepository<TDoc extends { _id: Types.ObjectId }> {
   protected readonly model: Model<TDoc>;
 
   constructor(model: Model<TDoc>) {
@@ -57,10 +67,10 @@ export class BaseRepository<
 
   // biome-ignore lint/complexity/noBannedTypes: default object value
   async create<TPopulate extends PopulateKeys<TDoc> = {}>(
-    data: TCreate,
+    data: CreateInput<TDoc>,
     options: PopulateOption = {},
   ): Promise<Merge<TDoc, TPopulate>> {
-    const doc = await this.model.create(data);
+    const doc = await this.model.create(this.castInput(data));
 
     if (options.populate) {
       await doc.populate(options.populate);
@@ -72,10 +82,10 @@ export class BaseRepository<
   // biome-ignore lint/complexity/noBannedTypes: default object value
   async update<TPopulate extends PopulateKeys<TDoc> = {}>(
     id: string,
-    data: TUpdate,
+    data: UpdateInput<TDoc>,
     options: QueryOptions = {},
   ): Promise<Merge<TDoc, TPopulate> | null> {
-    const query = this.model.findByIdAndUpdate(id, data, {
+    const query = this.model.findByIdAndUpdate(id, this.castInput(data), {
       returnDocument: "after",
       runValidators: true,
       ...options,
@@ -119,5 +129,11 @@ export class BaseRepository<
     pipeline: PipelineStage[],
   ): Promise<TResult[]> {
     return this.model.aggregate<TResult>(pipeline);
+  }
+
+  protected castInput<TInput extends Record<string, unknown>>(
+    data: TInput,
+  ): Partial<TDoc> {
+    return this.model.castObject(data) as Partial<TDoc>;
   }
 }

--- a/apps/backend/src/common/types/mongoose.ts
+++ b/apps/backend/src/common/types/mongoose.ts
@@ -10,3 +10,21 @@ export interface BaseDocumentWithoutUpdate {
   _id: Types.ObjectId;
   createdAt: Date;
 }
+
+export type RefValue = Types.ObjectId | readonly Types.ObjectId[];
+
+/**
+ * Extracts the keys of a type that are not `_id` and are of type `RefValue`.
+ */
+export type RefKeys<T> = {
+  [K in keyof T]-?: K extends "_id"
+    ? never
+    : NonNullable<T[K]> extends RefValue
+      ? K
+      : never;
+}[keyof T];
+
+/**
+ * Returns a type with only the keys of `T` that are not `_id` and are of type `RefValue`.
+ */
+export type RefsOnly<T> = Pick<T, RefKeys<T>>;

--- a/apps/backend/src/modules/categories/category.repository.ts
+++ b/apps/backend/src/modules/categories/category.repository.ts
@@ -1,22 +1,21 @@
 import type { CategoryQuery, CreateCategoryBody } from "@recipes/shared";
-import type { PipelineStage, QueryFilter } from "mongoose";
+import { BaseRepository } from "@/common/base.repository.js";
 import { withSort } from "@/common/utils/mongoose.aggregation.js";
 import { recipesCollectionName } from "@/modules/recipes/recipe.model.js";
-import type {
+import type { CategoryDocument } from "./category.model.js";
+
+export type RecipeCount = {
+  recipeCount: number;
+};
+
+export class CategoryRepository extends BaseRepository<
   CategoryDocument,
-  CategoryDocumentWithCount,
-  CategoryModelType,
-} from "./category.model.js";
-
-export class CategoryRepository {
-  private model: CategoryModelType;
-
-  constructor(model: CategoryModelType) {
-    this.model = model;
-  }
-
-  async findMany(query: CategoryQuery): Promise<CategoryDocumentWithCount[]> {
-    return this.aggregate<CategoryDocumentWithCount>([
+  CreateCategoryBody
+> {
+  async findMany(
+    query: CategoryQuery,
+  ): Promise<(CategoryDocument & RecipeCount)[]> {
+    return this.aggregate<CategoryDocument & RecipeCount>([
       {
         $lookup: {
           from: recipesCollectionName,
@@ -29,32 +28,5 @@ export class CategoryRepository {
       { $project: { recipes: 0 } },
       ...withSort(query.sort),
     ]);
-  }
-
-  async findById(id: string): Promise<CategoryDocument | null> {
-    return this.model.findById(id).lean();
-  }
-
-  async findOne(
-    filter: QueryFilter<CategoryDocument>,
-  ): Promise<CategoryDocument | null> {
-    return this.model.findOne(filter).lean();
-  }
-
-  async exists(id: string): Promise<boolean> {
-    return !!(await this.model.exists({ _id: id }));
-  }
-
-  async create(data: CreateCategoryBody): Promise<CategoryDocument> {
-    const doc = await this.model.create(data);
-    return doc.toObject();
-  }
-
-  async delete(id: string): Promise<CategoryDocument | null> {
-    return this.model.findByIdAndDelete(id).lean();
-  }
-
-  async aggregate<T>(pipeline: PipelineStage[]): Promise<T[]> {
-    return this.model.aggregate<T>(pipeline);
   }
 }

--- a/apps/backend/src/modules/categories/category.repository.ts
+++ b/apps/backend/src/modules/categories/category.repository.ts
@@ -1,4 +1,5 @@
-import type { CategoryQuery } from "@recipes/shared";
+import type { CategoryQuery, RequireKeys } from "@recipes/shared";
+import type { CreateInput, UpdateInput } from "@/common/base.repository.js";
 import { BaseRepository } from "@/common/base.repository.js";
 import { withSort } from "@/common/utils/mongoose.aggregation.js";
 import { recipesCollectionName } from "@/modules/recipes/recipe.model.js";
@@ -8,7 +9,17 @@ export type RecipeCount = {
   recipeCount: number;
 };
 
-export class CategoryRepository extends BaseRepository<CategoryDocument> {
+export type CategoryCreateInput = RequireKeys<
+  CreateInput<CategoryDocument>,
+  "name"
+>;
+export type CategoryUpdateInput = UpdateInput<CategoryDocument>;
+
+export class CategoryRepository extends BaseRepository<
+  CategoryDocument,
+  CategoryCreateInput,
+  CategoryUpdateInput
+> {
   async findMany(
     query: CategoryQuery,
   ): Promise<(CategoryDocument & RecipeCount)[]> {

--- a/apps/backend/src/modules/categories/category.repository.ts
+++ b/apps/backend/src/modules/categories/category.repository.ts
@@ -1,4 +1,4 @@
-import type { CategoryQuery, CreateCategoryBody } from "@recipes/shared";
+import type { CategoryQuery } from "@recipes/shared";
 import { BaseRepository } from "@/common/base.repository.js";
 import { withSort } from "@/common/utils/mongoose.aggregation.js";
 import { recipesCollectionName } from "@/modules/recipes/recipe.model.js";
@@ -8,10 +8,7 @@ export type RecipeCount = {
   recipeCount: number;
 };
 
-export class CategoryRepository extends BaseRepository<
-  CategoryDocument,
-  CreateCategoryBody
-> {
+export class CategoryRepository extends BaseRepository<CategoryDocument> {
   async findMany(
     query: CategoryQuery,
   ): Promise<(CategoryDocument & RecipeCount)[]> {

--- a/apps/backend/src/modules/comments/comment.repository.ts
+++ b/apps/backend/src/modules/comments/comment.repository.ts
@@ -26,11 +26,7 @@ import type {
   CommentDocumentPopulated,
 } from "./comment.model.js";
 
-export class CommentRepository extends BaseRepository<
-  CommentDocument,
-  CreateCommentBody & { recipe: string; author: string },
-  never
-> {
+export class CommentRepository extends BaseRepository<CommentDocument> {
   async findByRecipe(
     recipeId: string,
     { query, initiator }: QueryMethodParams,

--- a/apps/backend/src/modules/comments/comment.repository.ts
+++ b/apps/backend/src/modules/comments/comment.repository.ts
@@ -1,6 +1,10 @@
-import type { CreateCommentBody } from "@recipes/shared";
+import type { RequireKeys } from "@recipes/shared";
 import type { PipelineStage } from "mongoose";
-import type { PopulateKeys } from "@/common/base.repository.js";
+import type {
+  CreateInput,
+  PopulateKeys,
+  UpdateInput,
+} from "@/common/base.repository.js";
 import { BaseRepository } from "@/common/base.repository.js";
 import type {
   OptionalInitiator,
@@ -25,6 +29,12 @@ import type {
   CommentDocument,
   CommentDocumentPopulated,
 } from "./comment.model.js";
+
+export type CommentCreateInput = RequireKeys<
+  CreateInput<CommentDocument>,
+  "recipe" | "author" | "text"
+>;
+export type CommentUpdateInput = UpdateInput<CommentDocument>;
 
 export class CommentRepository extends BaseRepository<CommentDocument> {
   async findByRecipe(
@@ -80,13 +90,19 @@ export class CommentRepository extends BaseRepository<CommentDocument> {
       author: Pick<UserDocument, "_id" | "name" | "email">;
       recipe: Pick<RecipeDocument, "_id" | "title">;
     },
-  >(
-    data: CreateCommentBody & {
-      recipe: string;
-      author: string;
-    },
-  ) {
-    return super.create<TPopulate>(data);
+  >(data: CommentCreateInput) {
+    return super.create<TPopulate>(data, {
+      populate: [
+        {
+          path: "author recipe",
+          select: "name email",
+        },
+        {
+          path: "recipe",
+          select: "title",
+        },
+      ],
+    });
   }
 }
 

--- a/apps/backend/src/modules/comments/comment.repository.ts
+++ b/apps/backend/src/modules/comments/comment.repository.ts
@@ -1,5 +1,7 @@
 import type { CreateCommentBody } from "@recipes/shared";
-import type { PipelineStage, QueryFilter } from "mongoose";
+import type { PipelineStage } from "mongoose";
+import type { PopulateKeys } from "@/common/base.repository.js";
+import { BaseRepository } from "@/common/base.repository.js";
 import type {
   OptionalInitiator,
   QueryMethodParams,
@@ -16,20 +18,19 @@ import {
   byVisibility,
   withAuthor,
 } from "@/modules/recipes/recipe.aggregation.js";
+import type { RecipeDocument } from "@/modules/recipes/recipe.model.js";
 import { recipesCollectionName } from "@/modules/recipes/recipe.model.js";
+import type { UserDocument } from "@/modules/users/user.model.js";
 import type {
   CommentDocument,
   CommentDocumentPopulated,
-  CommentModelType,
 } from "./comment.model.js";
 
-export class CommentRepository {
-  private model: CommentModelType;
-
-  constructor(model: CommentModelType) {
-    this.model = model;
-  }
-
+export class CommentRepository extends BaseRepository<
+  CommentDocument,
+  CreateCommentBody & { recipe: string; author: string },
+  never
+> {
   async findByRecipe(
     recipeId: string,
     { query, initiator }: QueryMethodParams,
@@ -78,35 +79,18 @@ export class CommentRepository {
     return extractTotalCountResult(result);
   }
 
-  async findById(id: string): Promise<CommentDocument | null> {
-    return this.model.findById(id).lean();
-  }
-
-  async findOne(
-    filter: QueryFilter<CommentDocument>,
-  ): Promise<CommentDocument | null> {
-    return this.model.findOne(filter).lean();
-  }
-
-  async create(
-    data: CreateCommentBody & { recipe: string; author: string },
-  ): Promise<Omit<CommentDocumentPopulated, "recipe">> {
-    const comment = await this.model.create(data);
-
-    return (
-      await comment.populate({
-        path: "author",
-        select: "name email",
-      })
-    ).toObject<Omit<CommentDocumentPopulated, "recipe">>();
-  }
-
-  async delete(id: string): Promise<CommentDocument | null> {
-    return this.model.findByIdAndDelete(id).lean();
-  }
-
-  async aggregate<T>(pipeline: PipelineStage[]): Promise<T[]> {
-    return this.model.aggregate<T>(pipeline);
+  override async create<
+    TPopulate extends PopulateKeys<CommentDocument> = {
+      author: Pick<UserDocument, "_id" | "name" | "email">;
+      recipe: Pick<RecipeDocument, "_id" | "title">;
+    },
+  >(
+    data: CreateCommentBody & {
+      recipe: string;
+      author: string;
+    },
+  ) {
+    return super.create<TPopulate>(data);
   }
 }
 

--- a/apps/backend/src/modules/comments/comment.repository.ts
+++ b/apps/backend/src/modules/comments/comment.repository.ts
@@ -1,10 +1,6 @@
 import type { RequireKeys } from "@recipes/shared";
 import type { PipelineStage } from "mongoose";
-import type {
-  CreateInput,
-  PopulateKeys,
-  UpdateInput,
-} from "@/common/base.repository.js";
+import type { CreateInput, UpdateInput } from "@/common/base.repository.js";
 import { BaseRepository } from "@/common/base.repository.js";
 import type {
   OptionalInitiator,
@@ -35,8 +31,17 @@ export type CommentCreateInput = RequireKeys<
   "recipe" | "author" | "text"
 >;
 export type CommentUpdateInput = UpdateInput<CommentDocument>;
+export type CommentDefaultPopulate = {
+  author: Pick<UserDocument, "_id" | "name" | "email">;
+  recipe: Pick<RecipeDocument, "_id" | "title">;
+};
 
-export class CommentRepository extends BaseRepository<CommentDocument> {
+export class CommentRepository extends BaseRepository<
+  CommentDocument,
+  CommentCreateInput,
+  CommentUpdateInput,
+  CommentDefaultPopulate
+> {
   async findByRecipe(
     recipeId: string,
     { query, initiator }: QueryMethodParams,
@@ -85,24 +90,11 @@ export class CommentRepository extends BaseRepository<CommentDocument> {
     return extractTotalCountResult(result);
   }
 
-  override async create<
-    TPopulate extends PopulateKeys<CommentDocument> = {
-      author: Pick<UserDocument, "_id" | "name" | "email">;
-      recipe: Pick<RecipeDocument, "_id" | "title">;
-    },
-  >(data: CommentCreateInput) {
-    return super.create<TPopulate>(data, {
-      populate: [
-        {
-          path: "author recipe",
-          select: "name email",
-        },
-        {
-          path: "recipe",
-          select: "title",
-        },
-      ],
-    });
+  protected override getDefaultPopulate() {
+    return [
+      { path: "author", select: "_id name email" },
+      { path: "recipe", select: "_id title" },
+    ];
   }
 }
 

--- a/apps/backend/src/modules/comments/comment.service.ts
+++ b/apps/backend/src/modules/comments/comment.service.ts
@@ -97,7 +97,10 @@ export function createCommentService(
         throw new NotFoundError("Comment not found");
       }
 
-      if (!comment.author.equals(initiator.id) && initiator.role !== "admin") {
+      if (
+        !comment.author._id.equals(initiator.id) &&
+        initiator.role !== "admin"
+      ) {
         throw new ForbiddenError("Not authorized to delete this comment");
       }
 

--- a/apps/backend/src/modules/favorites/favorite.repository.ts
+++ b/apps/backend/src/modules/favorites/favorite.repository.ts
@@ -1,4 +1,7 @@
-import type { PipelineStage, QueryFilter } from "mongoose";
+import type { RequireKeys } from "@recipes/shared";
+import type { PipelineStage } from "mongoose";
+import type { CreateInput, UpdateInput } from "@/common/base.repository.js";
+import { BaseRepository } from "@/common/base.repository.js";
 import type {
   OptionalInitiator,
   QueryMethodParams,
@@ -18,20 +21,19 @@ import {
 } from "@/modules/recipes/recipe.aggregation.js";
 import type { RecipeDocumentPopulated } from "@/modules/recipes/recipe.model.js";
 import { recipesCollectionName } from "@/modules/recipes/recipe.model.js";
-import type { FavoriteDocument, FavoriteModelType } from "./favorite.model.js";
+import type { FavoriteDocument } from "./favorite.model.js";
 
-export type CreateFavoriteBody = {
-  user: string;
-  recipe: string;
-};
+export type FavoriteCreateInput = RequireKeys<
+  CreateInput<FavoriteDocument>,
+  "user" | "recipe"
+>;
+export type FavoriteUpdateInput = UpdateInput<FavoriteDocument>;
 
-export class FavoriteRepository {
-  private model: FavoriteModelType;
-
-  constructor(model: FavoriteModelType) {
-    this.model = model;
-  }
-
+export class FavoriteRepository extends BaseRepository<
+  FavoriteDocument,
+  FavoriteCreateInput,
+  FavoriteUpdateInput
+> {
   async findByUser(
     userId: string,
     { query, initiator }: QueryMethodParams,
@@ -58,39 +60,6 @@ export class FavoriteRepository {
       .filter((recipe) => recipe != null);
 
     return [recipes, total];
-  }
-
-  async findOne(
-    filter: QueryFilter<FavoriteDocument>,
-  ): Promise<FavoriteDocument | null> {
-    return this.model.findOne(filter).lean();
-  }
-
-  async create(data: CreateFavoriteBody): Promise<FavoriteDocument> {
-    return this.model.create(data);
-  }
-
-  async delete(
-    userId: string,
-    recipeId: string,
-  ): Promise<FavoriteDocument | null> {
-    return this.model
-      .findOneAndDelete({
-        user: userId,
-        recipe: recipeId,
-      })
-      .lean();
-  }
-
-  async exists(userId: string, recipeId: string): Promise<boolean> {
-    return !!(await this.model.exists({
-      user: userId,
-      recipe: recipeId,
-    }));
-  }
-
-  async aggregate<T>(pipeline: PipelineStage[]): Promise<T[]> {
-    return this.model.aggregate<T>(pipeline);
   }
 }
 

--- a/apps/backend/src/modules/favorites/favorite.service.test.ts
+++ b/apps/backend/src/modules/favorites/favorite.service.test.ts
@@ -91,7 +91,10 @@ describe("favoriteService", () => {
       const result = await service.remove(recipeId, { initiator: init });
 
       expect(result).toEqual({ favorited: false });
-      expect(favoriteRepository.delete).toHaveBeenCalledWith(init.id, recipeId);
+      expect(favoriteRepository.delete).toHaveBeenCalledWith({
+        user: init.id,
+        recipe: recipeId,
+      });
     });
   });
 

--- a/apps/backend/src/modules/favorites/favorite.service.ts
+++ b/apps/backend/src/modules/favorites/favorite.service.ts
@@ -58,7 +58,7 @@ export function createFavoriteService(
       await validateUser(initiator.id);
       await validateRecipe(recipeId);
 
-      await repository.delete(initiator.id, recipeId);
+      await repository.delete({ user: initiator.id, recipe: recipeId });
       return { favorited: false };
     },
 
@@ -76,7 +76,7 @@ export function createFavoriteService(
     },
 
     isFavorited: async (recipeId, { initiator }) => {
-      return repository.exists(initiator.id, recipeId);
+      return repository.exists({ user: initiator.id, recipe: recipeId });
     },
   };
 }

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -8,6 +8,14 @@ export type Replace<T, R extends Record<PropertyKey, unknown>> = Omit<
 > &
   R;
 
+export type PartialKeys<T, K extends keyof T> = Prettify<
+  Omit<T, K> & Partial<Pick<T, K>>
+>;
+
+export type RequireKeys<T, K extends keyof T> = Prettify<
+  Omit<T, K> & Required<Pick<T, K>>
+>;
+
 export type RenameField<
   T extends object,
   K extends keyof T,


### PR DESCRIPTION
## Related Issues

Refs #67

## PR Type

- [ ] Bugfix
- [x] Feature
- [x] Refactoring
- [ ] Tests
- [ ] Other

## Description

Introduces `BaseRepository` — a generic, type-safe base class for all Mongoose repositories, along with refactoring of `Category`, `Comment`, and `Favorite` repositories to extend it.

### What's new

- **`BaseRepository<TDoc, TCreate, TUpdate, TDefaultPopulate>`** — generic base class with:
  - `findById`, `findOne`, `find` — read operations with optional `populate` and type-safe `TPopulate` generic (only ref/ObjectId keys allowed)
  - `create` — with `castInput` (converts strings to ObjectIds via `model.castObject`), optional populate
  - `update` — `findByIdAndUpdate` with `runValidators: true`, optional populate
  - `delete` — by `id` string or `QueryFilter`
  - `exists`, `count`, `aggregate` — standard operations
  - `TDefaultPopulate` — class-level default populate type, overridable via `getDefaultPopulate()`

- **Type utilities**:
  - `RefsForInput<T>` — transforms `ObjectId` fields into `ObjectId | string` for create/update input types
  - `CreateInput<T>` / `UpdateInput<T>` — generated input types based on `RefsForInput`
  - `Merge<A, B>` / `PopulateKeys<T>` — types for merge and populate key constraints

### Refactored repositories

| Repository | Extends BaseRepository | Custom methods |
|---|---|---|
| `CategoryRepository` | ✅ `CategoryDocument`, `CategoryCreateInput`, `CategoryUpdateInput` | `findMany` (aggregation with `recipeCount`) |
| `CommentRepository` | ✅ `CommentDocument`, `CommentCreateInput`, `CommentUpdateInput`, `CommentDefaultPopulate` | `findByRecipe`, `findByAuthor` (aggregations) |
| `FavoriteRepository` | ✅ `FavoriteDocument`, `FavoriteCreateInput`, `FavoriteUpdateInput` | `findByUser` (aggregation with `$lookup` into recipes) |

### Key design decisions

- `castInput()` uses `model.castObject()` for runtime string→ObjectId conversion instead of blind `as` casts
- Default populate per repository via `getDefaultPopulate()` — calling `create(data)` automatically populates based on repository defaults
- Explicit `populate` in options overrides the default

## Screenshots

N/A

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Added/updated tests for new functionality
- [ ] Updated documentation (if needed)