### PR TITLE
feat(recipe-rating): add repository layer

### DIFF
--- a/apps/backend/src/__tests__/helpers.ts
+++ b/apps/backend/src/__tests__/helpers.ts
@@ -182,6 +182,19 @@ export function createCommentDoc(
 
 // ── Mongoose model mock factories ──
 
+export function createMockRepository(overrides: Record<string, Mock> = {}) {
+  return {
+    findById: viFn(),
+    findOne: viFn(),
+    exists: viFn(),
+    create: viFn(),
+    update: viFn(),
+    delete: viFn(),
+    aggregate: viFn(),
+    ...overrides,
+  };
+}
+
 const chainable = {
   select: viFn().mockReturnThis(),
   sort: viFn().mockReturnThis(),
@@ -290,6 +303,16 @@ export function createMockRatingModel(overrides: Record<string, Mock> = {}) {
     findOneAndUpdate: viFn(),
     findOneAndDelete: viFn(),
     exists: viFn(),
+    ...overrides,
+  };
+}
+
+export function createMockRecipeRatingRepository(
+  overrides: Record<string, Mock> = {},
+) {
+  return {
+    ...createMockRepository(overrides),
+    upsert: viFn(),
     ...overrides,
   };
 }

--- a/apps/backend/src/app.services.ts
+++ b/apps/backend/src/app.services.ts
@@ -16,6 +16,7 @@ import { FavoriteRepository } from "@/modules/favorites/favorite.repository.js";
 import type { FavoriteService } from "@/modules/favorites/favorite.service.js";
 import { createFavoriteService } from "@/modules/favorites/favorite.service.js";
 import { RecipeRatingModel } from "@/modules/recipe-ratings/recipe-rating.model.js";
+import { RecipeRatingRepository } from "@/modules/recipe-ratings/recipe-rating.repository.js";
 import type { RecipeRatingService } from "@/modules/recipe-ratings/recipe-rating.service.js";
 import { createRecipeRatingService } from "@/modules/recipe-ratings/recipe-rating.service.js";
 import { RecipeModel } from "@/modules/recipes/recipe.model.js";
@@ -44,6 +45,7 @@ export function createServices(
   const commentRepository = new CommentRepository(CommentModel);
   const categoryRepository = new CategoryRepository(CategoryModel);
   const favoriteRepository = new FavoriteRepository(FavoriteModel);
+  const recipeRatingRepository = new RecipeRatingRepository(RecipeRatingModel);
 
   const commentService = createCommentService(
     commentRepository,
@@ -61,7 +63,7 @@ export function createServices(
     UserModel,
   );
   const recipeRatingService = createRecipeRatingService(
-    RecipeRatingModel,
+    recipeRatingRepository,
     RecipeModel,
     UserModel,
     bus,

--- a/apps/backend/src/common/base.repository.ts
+++ b/apps/backend/src/common/base.repository.ts
@@ -9,11 +9,18 @@ import type {
 } from "mongoose";
 import type { RefKeys } from "@/common/types/mongoose.js";
 
+// biome-ignore lint/complexity/noBannedTypes: default object value
+type EmptyObject = {};
+
 export type Merge<A, B> = Prettify<Omit<A, keyof B> & B>;
 export type PopulateKeys<T> = Partial<Prettify<Record<RefKeys<T>, unknown>>>;
 
 export type TimestampKeys = "createdAt" | "updatedAt";
 export type AutoFields = "_id" | TimestampKeys;
+
+export type UpdateResult<T, TUpsert extends boolean> = TUpsert extends true
+  ? T
+  : T | null;
 
 export type RepositoryPopulate = PopulateOptions | PopulateOptions[];
 export type RepositoryQueryOptions = Omit<QueryOptions, "populate"> & {
@@ -40,8 +47,7 @@ export class BaseRepository<
   TDoc extends { _id: Types.ObjectId },
   TCreate extends CreateInput<TDoc> = CreateInput<TDoc>,
   TUpdate extends UpdateInput<TDoc> = UpdateInput<TDoc>,
-  // biome-ignore lint/complexity/noBannedTypes: default object value
-  TDefaultPopulate extends PopulateKeys<TDoc> = {},
+  TDefaultPopulate extends PopulateKeys<TDoc> = EmptyObject,
 > {
   protected readonly model: Model<TDoc>;
 
@@ -105,23 +111,38 @@ export class BaseRepository<
     return doc.toObject<Merge<TDoc, TPopulate>>();
   }
 
-  async update<TPopulate extends PopulateKeys<TDoc> = TDefaultPopulate>(
-    id: string,
+  async update<
+    TPopulate extends PopulateKeys<TDoc> = TDefaultPopulate,
+    const TUpsert extends boolean = false,
+  >(
+    filter: string | QueryFilter<TDoc>,
     data: TUpdate,
-    options: RepositoryQueryOptions = {},
-  ): Promise<Merge<TDoc, TPopulate> | null> {
+    options: RepositoryQueryOptions & {
+      upsert?: TUpsert;
+    } = {},
+  ): Promise<UpdateResult<Merge<TDoc, TPopulate>, TUpsert>> {
     const { queryOptions, populate } = this.resolveOptions(options);
-    const query = this.model.findByIdAndUpdate(id, this.castInput(data), {
-      returnDocument: "after",
-      runValidators: true,
-      ...queryOptions,
-    });
+
+    const query =
+      typeof filter === "string"
+        ? this.model.findByIdAndUpdate(filter, this.castInput(data), {
+            returnDocument: "after",
+            runValidators: true,
+            ...queryOptions,
+          })
+        : this.model.findOneAndUpdate(filter, this.castInput(data), {
+            returnDocument: "after",
+            runValidators: true,
+            ...queryOptions,
+          });
 
     if (populate) {
       query.populate<TPopulate>(populate);
     }
 
-    return query.lean<Merge<TDoc, TPopulate>>();
+    return query.lean<Merge<TDoc, TPopulate>>() as Promise<
+      UpdateResult<Merge<TDoc, TPopulate>, TUpsert>
+    >;
   }
 
   /**

--- a/apps/backend/src/modules/recipe-ratings/recipe-rating.repository.ts
+++ b/apps/backend/src/modules/recipe-ratings/recipe-rating.repository.ts
@@ -1,0 +1,24 @@
+import type { RequireKeys } from "@recipes/shared";
+import type { QueryFilter } from "mongoose";
+import type { CreateInput, UpdateInput } from "@/common/base.repository.js";
+import { BaseRepository } from "@/common/base.repository.js";
+import type { RecipeRatingDocument } from "./recipe-rating.model.js";
+
+export type RecipeRatingCreateInput = RequireKeys<
+  CreateInput<RecipeRatingDocument>,
+  "user" | "recipe" | "value"
+>;
+export type RecipeRatingUpdateInput = UpdateInput<RecipeRatingDocument>;
+
+export class RecipeRatingRepository extends BaseRepository<
+  RecipeRatingDocument,
+  RecipeRatingCreateInput,
+  RecipeRatingUpdateInput
+> {
+  async upsert(
+    filter: QueryFilter<RecipeRatingDocument>,
+    value: number,
+  ): Promise<RecipeRatingDocument> {
+    return this.update(filter, { value }, { upsert: true });
+  }
+}

--- a/apps/backend/src/modules/recipe-ratings/recipe-rating.service.test.ts
+++ b/apps/backend/src/modules/recipe-ratings/recipe-rating.service.test.ts
@@ -1,26 +1,26 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createMockBus,
-  createMockRatingModel,
   createMockRecipeModel,
+  createMockRecipeRatingRepository,
   createMockUserModel,
   createObjectId,
   initiator,
 } from "@/__tests__/helpers.js";
 import { BadRequestError, NotFoundError } from "@/common/errors.js";
+import type { RecipeRatingRepository } from "@/modules/recipe-ratings/recipe-rating.repository.js";
+import { createRecipeRatingService } from "@/modules/recipe-ratings/recipe-rating.service.js";
 import type { RecipeModelType } from "@/modules/recipes/recipe.model.js";
 import type { UserModelType } from "@/modules/users/user.model.js";
-import type { RecipeRatingModelType } from "./recipe-rating.model.js";
-import { createRecipeRatingService } from "./recipe-rating.service.js";
 
 describe("recipeRatingService", () => {
-  const ratingModel = createMockRatingModel();
+  const repository = createMockRecipeRatingRepository();
   const recipeModel = createMockRecipeModel();
   const userModel = createMockUserModel();
   const bus = createMockBus();
 
   const service = createRecipeRatingService(
-    ratingModel as unknown as RecipeRatingModelType,
+    repository as unknown as RecipeRatingRepository,
     recipeModel as unknown as RecipeModelType,
     userModel as unknown as UserModelType,
     bus,
@@ -34,8 +34,12 @@ describe("recipeRatingService", () => {
     it("should create a new rating", async () => {
       userModel.exists.mockResolvedValue(true);
       recipeModel.exists.mockResolvedValue(true);
-      ratingModel.findOneAndUpdate.mockResolvedValue({
+      repository.upsert.mockResolvedValue({
+        _id: createObjectId(),
+        user: createObjectId(),
+        recipe: createObjectId(),
         value: 4,
+        createdAt: new Date(),
       });
 
       const init = initiator();
@@ -46,10 +50,9 @@ describe("recipeRatingService", () => {
       });
 
       expect(result).toEqual({ value: 4 });
-      expect(ratingModel.findOneAndUpdate).toHaveBeenCalledWith(
+      expect(repository.upsert).toHaveBeenCalledWith(
         { user: init.id, recipe: recipeId },
-        { value: 4 },
-        { upsert: true, returnDocument: "after" },
+        4,
       );
       expect(bus.emit).toHaveBeenCalledWith("recipe:rated", recipeId);
     });
@@ -57,8 +60,12 @@ describe("recipeRatingService", () => {
     it("should update an existing rating", async () => {
       userModel.exists.mockResolvedValue(true);
       recipeModel.exists.mockResolvedValue(true);
-      ratingModel.findOneAndUpdate.mockResolvedValue({
+      repository.upsert.mockResolvedValue({
+        _id: createObjectId(),
+        user: createObjectId(),
+        recipe: createObjectId(),
         value: 5,
+        createdAt: new Date(),
       });
 
       const init = initiator();
@@ -120,15 +127,19 @@ describe("recipeRatingService", () => {
     it("should remove an existing rating", async () => {
       userModel.exists.mockResolvedValue(true);
       recipeModel.exists.mockResolvedValue(true);
-      ratingModel.findOneAndDelete.mockResolvedValue({
+      repository.delete.mockResolvedValue({
         _id: createObjectId(),
+        user: createObjectId(),
+        recipe: createObjectId(),
+        value: 4,
+        createdAt: new Date(),
       });
 
       const init = initiator();
       const recipeId = createObjectId().toString();
       await service.remove(recipeId, { initiator: init });
 
-      expect(ratingModel.findOneAndDelete).toHaveBeenCalledWith({
+      expect(repository.delete).toHaveBeenCalledWith({
         user: init.id,
         recipe: recipeId,
       });
@@ -138,7 +149,7 @@ describe("recipeRatingService", () => {
     it("should throw NotFoundError when rating does not exist", async () => {
       userModel.exists.mockResolvedValue(true);
       recipeModel.exists.mockResolvedValue(true);
-      ratingModel.findOneAndDelete.mockResolvedValue(null);
+      repository.delete.mockResolvedValue(null);
 
       await expect(
         service.remove(createObjectId().toString(), {

--- a/apps/backend/src/modules/recipe-ratings/recipe-rating.service.ts
+++ b/apps/backend/src/modules/recipe-ratings/recipe-rating.service.ts
@@ -8,7 +8,7 @@ import type {
 import { assertExists, assertValidId } from "@/common/utils/validation.js";
 import type { RecipeModelType } from "@/modules/recipes/recipe.model.js";
 import type { UserModelType } from "@/modules/users/user.model.js";
-import type { RecipeRatingModelType } from "./recipe-rating.model.js";
+import type { RecipeRatingRepository } from "./recipe-rating.repository.js";
 
 export interface RecipeRatingService {
   rate(
@@ -19,7 +19,7 @@ export interface RecipeRatingService {
 }
 
 export function createRecipeRatingService(
-  ratingModel: RecipeRatingModelType,
+  repository: RecipeRatingRepository,
   recipeModel: RecipeModelType,
   userModel: UserModelType,
   bus: TypedEmitter,
@@ -39,10 +39,9 @@ export function createRecipeRatingService(
       await validateUser(initiator.id);
       await validateRecipe(recipeId);
 
-      const rating = await ratingModel.findOneAndUpdate(
+      const rating = await repository.upsert(
         { user: initiator.id, recipe: recipeId },
-        { value: data.value },
-        { upsert: true, returnDocument: "after" },
+        data.value,
       );
 
       bus.emit("recipe:rated", recipeId);
@@ -54,7 +53,7 @@ export function createRecipeRatingService(
       await validateUser(initiator.id);
       await validateRecipe(recipeId);
 
-      const result = await ratingModel.findOneAndDelete({
+      const result = await repository.delete({
         user: initiator.id,
         recipe: recipeId,
       });


### PR DESCRIPTION
## Related Issues

Refs #67

## PR Type

- [ ] Bugfix
- [x] Feature
- [x] Refactoring
- [ ] Tests
- [ ] Other

## Description

Introduces `RecipeRatingRepository` to encapsulate all database access for the recipe ratings module:

- New `RecipeRatingRepository` extending `BaseRepository` with:
  - `RecipeRatingCreateInput` — `RequireKeys<CreateInput<RecipeRatingDocument>, "user" | "recipe" | "value">` (all fields required for junction table)
  - `upsert(userId, recipeId, value)` — `findOneAndUpdate` with `{ upsert: true }`
- `RecipeRatingService` now depends on `RecipeRatingRepository` instead of `RecipeRatingModel` directly
- Added `createMockRecipeRatingRepository()` helper for tests
- Updated `recipe-rating.service.test.ts` to mock repository methods
- Wired repository instantiation in `app.services.ts`

## Screenshots

N/A

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Added/updated tests for new functionality
- [ ] Updated documentation (if needed)