### PR TITLE
feat: extract password hashing into dedicated PasswordService

### DIFF
--- a/apps/backend/src/__tests__/helpers.ts
+++ b/apps/backend/src/__tests__/helpers.ts
@@ -122,7 +122,6 @@ export function createUserDoc(
     role: "user",
     createdAt: new Date("2024-01-01"),
     updatedAt: new Date("2024-01-01"),
-    comparePassword: vi.fn().mockResolvedValue(true),
     ...overrides,
   };
 }
@@ -234,6 +233,16 @@ export function createMockUserModel(overrides: Record<string, Mock> = {}) {
     findOne: viFn().mockReturnValue(chainable),
     exists: viFn(),
     create: viFn(),
+    ...overrides,
+  };
+}
+
+export function createMockPasswordService(
+  overrides: Record<string, Mock> = {},
+) {
+  return {
+    hash: viFn().mockResolvedValue("hashed-password"),
+    verify: viFn().mockResolvedValue(true),
     ...overrides,
   };
 }

--- a/apps/backend/src/app.services.ts
+++ b/apps/backend/src/app.services.ts
@@ -1,6 +1,8 @@
 import type { CacheService } from "@/common/cache/cache.service.js";
 import type { TypedEmitter } from "@/common/events.js";
 import type { Logger } from "@/common/logger.js";
+import { createBcryptPasswordService } from "@/common/passwords/bcrypt.service.js";
+import { env } from "@/config/env.js";
 import type { AuthService } from "@/modules/auth/auth.service.js";
 import { createAuthService } from "@/modules/auth/auth.service.js";
 import { CategoryModel } from "@/modules/categories/category.model.js";
@@ -25,7 +27,6 @@ import { createRecipeService } from "@/modules/recipes/recipe.service.js";
 import { UserModel } from "@/modules/users/user.model.js";
 import type { UserService } from "@/modules/users/user.service.js";
 import { createUserService } from "@/modules/users/user.service.js";
-import { createBcryptPasswordService } from "./common/passwords/bcrypt.service.js";
 
 export interface Services {
   auth: AuthService;
@@ -48,7 +49,7 @@ export function createServices(
   const favoriteRepository = new FavoriteRepository(FavoriteModel);
   const recipeRatingRepository = new RecipeRatingRepository(RecipeRatingModel);
 
-  const passwordService = createBcryptPasswordService(10);
+  const passwordService = createBcryptPasswordService(env.BCRYPT_SALT_ROUNDS);
 
   const commentService = createCommentService(
     commentRepository,

--- a/apps/backend/src/app.services.ts
+++ b/apps/backend/src/app.services.ts
@@ -25,6 +25,7 @@ import { createRecipeService } from "@/modules/recipes/recipe.service.js";
 import { UserModel } from "@/modules/users/user.model.js";
 import type { UserService } from "@/modules/users/user.service.js";
 import { createUserService } from "@/modules/users/user.service.js";
+import { createBcryptPasswordService } from "./common/passwords/bcrypt.service.js";
 
 export interface Services {
   auth: AuthService;
@@ -46,6 +47,8 @@ export function createServices(
   const categoryRepository = new CategoryRepository(CategoryModel);
   const favoriteRepository = new FavoriteRepository(FavoriteModel);
   const recipeRatingRepository = new RecipeRatingRepository(RecipeRatingModel);
+
+  const passwordService = createBcryptPasswordService(10);
 
   const commentService = createCommentService(
     commentRepository,
@@ -82,7 +85,7 @@ export function createServices(
     recipeCache,
     bus,
   );
-  const authService = createAuthService(UserModel, log);
+  const authService = createAuthService(UserModel, passwordService, log);
 
   return {
     auth: authService,

--- a/apps/backend/src/common/passwords/bcrypt.service.ts
+++ b/apps/backend/src/common/passwords/bcrypt.service.ts
@@ -1,0 +1,14 @@
+import bcrypt from "bcryptjs";
+import type { PasswordService } from "./password.service.js";
+
+export function createBcryptPasswordService(rounds: number): PasswordService {
+  return {
+    async hash(password: string) {
+      return bcrypt.hash(password, rounds);
+    },
+
+    async verify(password: string, hash: string) {
+      return bcrypt.compare(password, hash);
+    },
+  };
+}

--- a/apps/backend/src/common/passwords/password.service.ts
+++ b/apps/backend/src/common/passwords/password.service.ts
@@ -1,0 +1,22 @@
+/**
+ * Password service interface.
+ *
+ * Password service is responsible for hashing and verifying passwords.
+ */
+export interface PasswordService {
+  /**
+   * Hashes a password.
+   *
+   * @param password - The password to hash.
+   * @returns The hashed password.
+   */
+  hash(password: string): Promise<string>;
+  /**
+   * Verifies a password.
+   *
+   * @param password - The password to verify.
+   * @param hash - The hashed password.
+   * @returns True if the password is correct, false otherwise.
+   */
+  verify(password: string, hash: string): Promise<boolean>;
+}

--- a/apps/backend/src/modules/auth/auth.service.test.ts
+++ b/apps/backend/src/modules/auth/auth.service.test.ts
@@ -1,10 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createMockLogger,
+  createMockPasswordService,
   createMockUserModel,
   createUserDoc,
 } from "@/__tests__/helpers.js";
 import { ConflictError, UnauthorizedError } from "@/common/errors.js";
+import type { PasswordService } from "@/common/passwords/password.service.js";
 import type { UserModelType } from "@/modules/users/user.model.js";
 import { createAuthService } from "./auth.service.js";
 
@@ -16,8 +18,13 @@ vi.mock("@/common/utils/jwt.js", () => ({ signToken }));
 
 describe("authService", () => {
   const userModel = createMockUserModel();
+  const passwordService = createMockPasswordService();
   const log = createMockLogger();
-  const service = createAuthService(userModel as unknown as UserModelType, log);
+  const service = createAuthService(
+    userModel as unknown as UserModelType,
+    passwordService as unknown as PasswordService,
+    log,
+  );
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -36,7 +43,12 @@ describe("authService", () => {
       });
 
       expect(userModel.exists).toHaveBeenCalledWith({ email: "new@test.com" });
-      expect(userModel.create).toHaveBeenCalled();
+      expect(passwordService.hash).toHaveBeenCalledWith("Password123!");
+      expect(userModel.create).toHaveBeenCalledWith({
+        email: "new@test.com",
+        password: "hashed-password",
+        name: "New User",
+      });
       expect(signToken).toHaveBeenCalled();
       expect(result.user.email).toBe("new@test.com");
       expect(result.token).toBe("mock-jwt-token");
@@ -80,6 +92,10 @@ describe("authService", () => {
       expect(userModel.findOne).toHaveBeenCalledWith({
         email: "user@test.com",
       });
+      expect(passwordService.verify).toHaveBeenCalledWith(
+        "correct-password",
+        "hashedPassword",
+      );
       expect(result.user.email).toBe("user@test.com");
       expect(result.token).toBe("mock-jwt-token");
     });
@@ -98,16 +114,14 @@ describe("authService", () => {
     });
 
     it("should throw UnauthorizedError when password is wrong", async () => {
-      const doc = createUserDoc({
-        email: "user@test.com",
-        comparePassword: vi.fn().mockResolvedValue(false),
-      });
+      const doc = createUserDoc({ email: "user@test.com" });
       userModel.findOne.mockReturnValue({
         select: vi.fn().mockResolvedValue({
           ...doc,
           toObject: () => doc,
         }),
       });
+      passwordService.verify.mockResolvedValue(false);
 
       await expect(
         service.login({ email: "user@test.com", password: "wrong" }),

--- a/apps/backend/src/modules/auth/auth.service.ts
+++ b/apps/backend/src/modules/auth/auth.service.ts
@@ -1,6 +1,7 @@
 import type { AuthResponse, LoginBody, RegisterBody } from "@recipes/shared";
 import { ConflictError, UnauthorizedError } from "@/common/errors.js";
 import type { Logger } from "@/common/logger.js";
+import type { PasswordService } from "@/common/passwords/password.service.js";
 import { signToken } from "@/common/utils/jwt.js";
 import { toUser } from "@/common/utils/mongo.js";
 import type { UserModelType } from "@/modules/users/user.model.js";
@@ -12,6 +13,7 @@ export interface AuthService {
 
 export function createAuthService(
   userModel: UserModelType,
+  passwordService: PasswordService,
   log: Logger,
 ): AuthService {
   return {
@@ -25,7 +27,11 @@ export function createAuthService(
         throw new ConflictError("Email already in use");
       }
 
-      const user = await userModel.create(data);
+      const password = await passwordService.hash(data.password);
+      const user = await userModel.create({
+        ...data,
+        password,
+      });
       const token = signToken({
         userId: user.id,
         email: user.email,
@@ -43,7 +49,10 @@ export function createAuthService(
       const user = await userModel
         .findOne({ email: data.email })
         .select("+password");
-      if (!user || !(await user.comparePassword(data.password))) {
+      if (
+        !user ||
+        !(await passwordService.verify(data.password, user.password))
+      ) {
         log.warn({ email: data.email }, "Failed login attempt");
         throw new UnauthorizedError("Invalid email or password");
       }

--- a/apps/backend/src/modules/users/user.model.ts
+++ b/apps/backend/src/modules/users/user.model.ts
@@ -1,16 +1,13 @@
 import type { UserRole } from "@recipes/shared";
-import bcrypt from "bcryptjs";
 import type { Model } from "mongoose";
 import { model, Schema } from "mongoose";
 import type { BaseDocument } from "@/common/types/mongoose.js";
-import { env } from "@/config/env.js";
 
 export interface UserDocument extends BaseDocument {
   email: string;
   password: string;
   name: string;
   role: UserRole;
-  comparePassword(candidate: string): Promise<boolean>;
 }
 
 export interface UserModelType extends Model<UserDocument> {}
@@ -36,17 +33,6 @@ const userSchema = new Schema<UserDocument, UserModelType>(
     timestamps: true,
   },
 );
-
-userSchema.pre("save", async function () {
-  if (!this.isModified("password")) return;
-  this.password = await bcrypt.hash(this.password, env.BCRYPT_SALT_ROUNDS);
-});
-
-userSchema.methods.comparePassword = async function (
-  candidate: string,
-): Promise<boolean> {
-  return bcrypt.compare(candidate, this.password);
-};
 
 export const USER_MODEL_NAME = "User";
 export const UserModel = model<UserDocument, UserModelType>(


### PR DESCRIPTION
## Related Issues

Refs #67

## PR Type

- [ ] Bugfix
- [x] Feature
- [x] Refactoring
- [ ] Tests
- [ ] Other

## Description

Extracts password hashing and verification logic from `UserDocument` model method into a dedicated `PasswordService` abstraction.

### What's new

- **`PasswordService` interface** (`common/passwords/password.service.ts`) — defines `hash(password)` and `verify(password, hash)` contract
- **`createBcryptPasswordService` implementation** (`common/passwords/bcrypt.service.ts`) — bcrypt-based implementation using `env.BCRYPT_SALT_ROUNDS`
- **Removed from `UserDocument` model**:
  - `comparePassword` instance method
  - `userSchema.pre("save")` bcrypt hashing hook
  - `bcryptjs` import from model file

### Refactored services

| Service | Before | After |
|---|---|---|
| `AuthService.register` | `UserModel.create(data)` (auto-hashed by hook) | `passwordService.hash(data.password)` then `UserModel.create({ ...data, password })` |
| `AuthService.login` | `user.comparePassword(data.password)` | `passwordService.verify(data.password, user.password)` |

### Benefits

- `UserDocument` is now a pure data type — works with `.lean()` and `BaseRepository`
- Password algorithm is swappable (e.g., argon2) without touching models
- Easier to test — mock `PasswordService` instead of Mongoose instance methods

## Screenshots

N/A

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Added/updated tests for new functionality
- [ ] Updated documentation (if needed)