### PR TITLE
feat(user): add repository layer and integrate PasswordService

### DIFF
--- a/apps/backend/src/__tests__/helpers.ts
+++ b/apps/backend/src/__tests__/helpers.ts
@@ -237,6 +237,13 @@ export function createMockUserModel(overrides: Record<string, Mock> = {}) {
   };
 }
 
+export function createMockUserRepository(overrides: Record<string, Mock> = {}) {
+  return {
+    ...createMockRepository(overrides),
+    ...overrides,
+  };
+}
+
 export function createMockPasswordService(
   overrides: Record<string, Mock> = {},
 ) {

--- a/apps/backend/src/app.services.ts
+++ b/apps/backend/src/app.services.ts
@@ -88,7 +88,7 @@ export function createServices(
     recipeCache,
     bus,
   );
-  const authService = createAuthService(UserModel, passwordService, log);
+  const authService = createAuthService(userRepository, passwordService, log);
 
   return {
     auth: authService,

--- a/apps/backend/src/app.services.ts
+++ b/apps/backend/src/app.services.ts
@@ -27,6 +27,7 @@ import { createRecipeService } from "@/modules/recipes/recipe.service.js";
 import { UserModel } from "@/modules/users/user.model.js";
 import type { UserService } from "@/modules/users/user.service.js";
 import { createUserService } from "@/modules/users/user.service.js";
+import { UserRepository } from "./modules/users/user.repository.js";
 
 export interface Services {
   auth: AuthService;
@@ -48,6 +49,7 @@ export function createServices(
   const categoryRepository = new CategoryRepository(CategoryModel);
   const favoriteRepository = new FavoriteRepository(FavoriteModel);
   const recipeRatingRepository = new RecipeRatingRepository(RecipeRatingModel);
+  const userRepository = new UserRepository(UserModel);
 
   const passwordService = createBcryptPasswordService(env.BCRYPT_SALT_ROUNDS);
 
@@ -62,9 +64,9 @@ export function createServices(
     UserModel,
   );
   const userService = createUserService(
+    userRepository,
     commentService,
     favoriteService,
-    UserModel,
   );
   const recipeRatingService = createRecipeRatingService(
     recipeRatingRepository,

--- a/apps/backend/src/modules/auth/auth.service.test.ts
+++ b/apps/backend/src/modules/auth/auth.service.test.ts
@@ -2,12 +2,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createMockLogger,
   createMockPasswordService,
-  createMockUserModel,
+  createMockRepository,
   createUserDoc,
 } from "@/__tests__/helpers.js";
 import { ConflictError, UnauthorizedError } from "@/common/errors.js";
 import type { PasswordService } from "@/common/passwords/password.service.js";
-import type { UserModelType } from "@/modules/users/user.model.js";
+import type { UserRepository } from "@/modules/users/user.repository.js";
 import { createAuthService } from "./auth.service.js";
 
 const { signToken } = vi.hoisted(() => ({
@@ -17,11 +17,11 @@ const { signToken } = vi.hoisted(() => ({
 vi.mock("@/common/utils/jwt.js", () => ({ signToken }));
 
 describe("authService", () => {
-  const userModel = createMockUserModel();
+  const userRepository = createMockRepository();
   const passwordService = createMockPasswordService();
   const log = createMockLogger();
   const service = createAuthService(
-    userModel as unknown as UserModelType,
+    userRepository as unknown as UserRepository,
     passwordService as unknown as PasswordService,
     log,
   );
@@ -32,9 +32,9 @@ describe("authService", () => {
 
   describe("register", () => {
     it("should register user and return auth response", async () => {
-      userModel.exists.mockResolvedValue(null);
+      userRepository.exists.mockResolvedValue(false);
       const doc = createUserDoc({ email: "new@test.com", name: "New User" });
-      userModel.create.mockResolvedValue({ ...doc, toObject: () => doc });
+      userRepository.create.mockResolvedValue(doc);
 
       const result = await service.register({
         email: "new@test.com",
@@ -42,9 +42,11 @@ describe("authService", () => {
         name: "New User",
       });
 
-      expect(userModel.exists).toHaveBeenCalledWith({ email: "new@test.com" });
+      expect(userRepository.exists).toHaveBeenCalledWith({
+        email: "new@test.com",
+      });
       expect(passwordService.hash).toHaveBeenCalledWith("Password123!");
-      expect(userModel.create).toHaveBeenCalledWith({
+      expect(userRepository.create).toHaveBeenCalledWith({
         email: "new@test.com",
         password: "hashed-password",
         name: "New User",
@@ -55,7 +57,7 @@ describe("authService", () => {
     });
 
     it("should throw ConflictError when email already in use", async () => {
-      userModel.exists.mockResolvedValue({ _id: "existing-id" });
+      userRepository.exists.mockResolvedValue(true);
 
       await expect(
         service.register({
@@ -77,21 +79,17 @@ describe("authService", () => {
   describe("login", () => {
     it("should login and return auth response", async () => {
       const doc = createUserDoc({ email: "user@test.com" });
-      userModel.findOne.mockReturnValue({
-        select: vi.fn().mockResolvedValue({
-          ...doc,
-          toObject: () => doc,
-        }),
-      });
+      userRepository.findOne.mockResolvedValue(doc);
 
       const result = await service.login({
         email: "user@test.com",
         password: "correct-password",
       });
 
-      expect(userModel.findOne).toHaveBeenCalledWith({
-        email: "user@test.com",
-      });
+      expect(userRepository.findOne).toHaveBeenCalledWith(
+        { email: "user@test.com" },
+        { select: "+password" },
+      );
       expect(passwordService.verify).toHaveBeenCalledWith(
         "correct-password",
         "hashedPassword",
@@ -101,9 +99,7 @@ describe("authService", () => {
     });
 
     it("should throw UnauthorizedError when user not found", async () => {
-      userModel.findOne.mockReturnValue({
-        select: vi.fn().mockResolvedValue(null),
-      });
+      userRepository.findOne.mockResolvedValue(null);
 
       await expect(
         service.login({ email: "nobody@test.com", password: "pass" }),
@@ -115,12 +111,7 @@ describe("authService", () => {
 
     it("should throw UnauthorizedError when password is wrong", async () => {
       const doc = createUserDoc({ email: "user@test.com" });
-      userModel.findOne.mockReturnValue({
-        select: vi.fn().mockResolvedValue({
-          ...doc,
-          toObject: () => doc,
-        }),
-      });
+      userRepository.findOne.mockResolvedValue(doc);
       passwordService.verify.mockResolvedValue(false);
 
       await expect(

--- a/apps/backend/src/modules/auth/auth.service.ts
+++ b/apps/backend/src/modules/auth/auth.service.ts
@@ -4,7 +4,7 @@ import type { Logger } from "@/common/logger.js";
 import type { PasswordService } from "@/common/passwords/password.service.js";
 import { signToken } from "@/common/utils/jwt.js";
 import { toUser } from "@/common/utils/mongo.js";
-import type { UserModelType } from "@/modules/users/user.model.js";
+import type { UserRepository } from "@/modules/users/user.repository.js";
 
 export interface AuthService {
   register(data: RegisterBody): Promise<AuthResponse>;
@@ -12,13 +12,13 @@ export interface AuthService {
 }
 
 export function createAuthService(
-  userModel: UserModelType,
+  userRepository: UserRepository,
   passwordService: PasswordService,
   log: Logger,
 ): AuthService {
   return {
     register: async (data) => {
-      const exists = await userModel.exists({ email: data.email });
+      const exists = await userRepository.exists({ email: data.email });
       if (exists) {
         log.warn(
           { email: data.email },
@@ -28,27 +28,31 @@ export function createAuthService(
       }
 
       const password = await passwordService.hash(data.password);
-      const user = await userModel.create({
+      const user = await userRepository.create({
         ...data,
         password,
       });
       const token = signToken({
-        userId: user.id,
+        userId: user._id.toString(),
         email: user.email,
         role: user.role,
       });
 
-      log.info({ userId: user.id, email: user.email }, "User registered");
+      log.info(
+        { userId: user._id.toString(), email: user.email },
+        "User registered",
+      );
 
       return {
-        user: toUser(user.toObject()),
+        user: toUser(user),
         token,
       };
     },
     login: async (data) => {
-      const user = await userModel
-        .findOne({ email: data.email })
-        .select("+password");
+      const user = await userRepository.findOne(
+        { email: data.email },
+        { select: "+password" },
+      );
       if (
         !user ||
         !(await passwordService.verify(data.password, user.password))
@@ -58,15 +62,18 @@ export function createAuthService(
       }
 
       const token = signToken({
-        userId: user.id,
+        userId: user._id.toString(),
         email: user.email,
         role: user.role,
       });
 
-      log.info({ userId: user.id, email: user.email }, "User logged in");
+      log.info(
+        { userId: user._id.toString(), email: user.email },
+        "User logged in",
+      );
 
       return {
-        user: toUser(user.toObject()),
+        user: toUser(user),
         token,
       };
     },

--- a/apps/backend/src/modules/users/user.repository.ts
+++ b/apps/backend/src/modules/users/user.repository.ts
@@ -1,0 +1,16 @@
+import type { RequireKeys } from "@recipes/shared";
+import type { CreateInput } from "@/common/base.repository.js";
+import { BaseRepository } from "@/common/base.repository.js";
+import type { UserDocument } from "./user.model.js";
+
+export type UserCreateInput = RequireKeys<
+  CreateInput<Omit<UserDocument, "role">>,
+  "email" | "password" | "name"
+>;
+// export type UserUpdateInput = UpdateInput<Omit<UserDocument, "role">>;
+
+export class UserRepository extends BaseRepository<
+  UserDocument,
+  UserCreateInput,
+  never
+> {}

--- a/apps/backend/src/modules/users/user.service.test.ts
+++ b/apps/backend/src/modules/users/user.service.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  createMockUserModel,
+  createMockUserRepository,
   createObjectId,
   createUserDoc,
   queryParams,
@@ -8,11 +8,11 @@ import {
 import { NotFoundError } from "@/common/errors.js";
 import type { CommentService } from "@/modules/comments/comment.service.js";
 import type { FavoriteService } from "@/modules/favorites/favorite.service.js";
-import type { UserModelType } from "@/modules/users/user.model.js";
 import { createUserService } from "@/modules/users/user.service.js";
+import type { UserRepository } from "./user.repository.js";
 
 describe("userService", () => {
-  const userModel = createMockUserModel();
+  const userRepository = createMockUserRepository();
   const commentService = {
     findByAuthor: vi.fn(),
     findByRecipe: vi.fn(),
@@ -26,9 +26,9 @@ describe("userService", () => {
     isFavorited: vi.fn(),
   };
   const service = createUserService(
+    userRepository as unknown as UserRepository,
     commentService as unknown as CommentService,
     favoriteService as unknown as FavoriteService,
-    userModel as unknown as UserModelType,
   );
 
   beforeEach(() => {
@@ -38,8 +38,7 @@ describe("userService", () => {
   describe("getCurrentUser", () => {
     it("should return user by ID", async () => {
       const doc = createUserDoc({ email: "user@test.com", name: "Test" });
-      const lean = vi.fn().mockResolvedValue(doc);
-      userModel.findById.mockReturnValue({ lean });
+      userRepository.findById.mockReturnValue(doc);
 
       const result = await service.getCurrentUser(createObjectId().toString());
 
@@ -49,9 +48,7 @@ describe("userService", () => {
     });
 
     it("should throw NotFoundError when user not found", async () => {
-      userModel.findById.mockReturnValue({
-        lean: vi.fn().mockResolvedValue(null),
-      });
+      userRepository.findById.mockReturnValue(null);
 
       await expect(
         service.getCurrentUser(createObjectId().toString()),

--- a/apps/backend/src/modules/users/user.service.ts
+++ b/apps/backend/src/modules/users/user.service.ts
@@ -13,7 +13,7 @@ import type {
 import { toUser } from "@/common/utils/mongo.js";
 import type { CommentService } from "@/modules/comments/comment.service.js";
 import type { FavoriteService } from "@/modules/favorites/favorite.service.js";
-import type { UserModelType } from "@/modules/users/user.model.js";
+import type { UserRepository } from "./user.repository.js";
 
 export interface UserService {
   getCurrentUser(userId: string): Promise<User>;
@@ -28,13 +28,13 @@ export interface UserService {
 }
 
 export function createUserService(
+  repository: UserRepository,
   commentService: CommentService,
   favoriteService: FavoriteService,
-  userModel: UserModelType,
 ): UserService {
   return {
     getCurrentUser: async (userId) => {
-      const user = await userModel.findById(userId).lean();
+      const user = await repository.findById(userId);
       if (!user) {
         throw new NotFoundError("User not found");
       }


### PR DESCRIPTION
## Related Issues

Refs #67

## PR Type

- [ ] Bugfix
- [x] Feature
- [x] Refactoring
- [ ] Tests
- [ ] Other

## Description

Introduces `UserRepository` extending `BaseRepository` and integrates it into `AuthService` and `UserService`.

### What's new

- **`UserRepository`** extending `BaseRepository<UserDocument, UserCreateInput, never>`
  - `UserCreateInput` — `RequireKeys<CreateInput<UserDocument>, "email" | "password" | "name">`
- **`AuthService`** now depends on `UserRepository` instead of `UserModel`
  - `register`: checks `repository.exists({ email })`, creates via `repository.create({ ...data, password })`
  - `login`: uses `repository.findOne({ email }, { select: "+password" })`
- **`UserService`** now depends on `UserRepository` instead of `UserModel`
  - `getCurrentUser`: uses `repository.findById(userId)`

### Tests

- Added `createMockRepository()` generic helper for base repository mocks
- Updated `auth.service.test.ts` to mock `UserRepository` methods
- Updated `user.service.test.ts` to mock `UserRepository`

## Screenshots

N/A

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Added/updated tests for new functionality
- [ ] Updated documentation (if needed)