### PR TITLE
refactor: replace direct model usage with repositories in services

### DIFF
--- a/apps/backend/src/app.services.ts
+++ b/apps/backend/src/app.services.ts
@@ -61,7 +61,7 @@ export function createServices(
   const favoriteService = createFavoriteService(
     favoriteRepository,
     RecipeModel,
-    UserModel,
+    userRepository,
   );
   const userService = createUserService(
     userRepository,

--- a/apps/backend/src/app.services.ts
+++ b/apps/backend/src/app.services.ts
@@ -82,7 +82,7 @@ export function createServices(
   );
   const recipeService = createRecipeService(
     RecipeModel,
-    UserModel,
+    userRepository,
     FavoriteModel,
     CategoryModel,
     recipeCache,

--- a/apps/backend/src/app.services.ts
+++ b/apps/backend/src/app.services.ts
@@ -56,7 +56,7 @@ export function createServices(
   const commentService = createCommentService(
     commentRepository,
     RecipeModel,
-    UserModel,
+    userRepository,
   );
   const favoriteService = createFavoriteService(
     favoriteRepository,

--- a/apps/backend/src/app.services.ts
+++ b/apps/backend/src/app.services.ts
@@ -71,7 +71,7 @@ export function createServices(
   const recipeRatingService = createRecipeRatingService(
     recipeRatingRepository,
     RecipeModel,
-    UserModel,
+    userRepository,
     bus,
   );
   const categoryService = createCategoryService(

--- a/apps/backend/src/app.services.ts
+++ b/apps/backend/src/app.services.ts
@@ -83,7 +83,7 @@ export function createServices(
   const recipeService = createRecipeService(
     RecipeModel,
     userRepository,
-    FavoriteModel,
+    favoriteRepository,
     CategoryModel,
     recipeCache,
     bus,

--- a/apps/backend/src/app.services.ts
+++ b/apps/backend/src/app.services.ts
@@ -84,7 +84,7 @@ export function createServices(
     RecipeModel,
     userRepository,
     favoriteRepository,
-    CategoryModel,
+    categoryRepository,
     recipeCache,
     bus,
   );

--- a/apps/backend/src/common/base.repository.ts
+++ b/apps/backend/src/common/base.repository.ts
@@ -50,9 +50,11 @@ export class BaseRepository<
   TDefaultPopulate extends PopulateKeys<TDoc> = EmptyObject,
 > {
   protected readonly model: Model<TDoc>;
+  public readonly modelName: string;
 
   constructor(model: Model<TDoc>) {
     this.model = model;
+    this.modelName = model.modelName;
   }
 
   async findById<TPopulate extends PopulateKeys<TDoc> = TDefaultPopulate>(

--- a/apps/backend/src/common/utils/validation.ts
+++ b/apps/backend/src/common/utils/validation.ts
@@ -1,6 +1,7 @@
-import type { Model } from "mongoose";
+import type { Model, Types } from "mongoose";
 import { isObjectIdOrHexString } from "mongoose";
 import { BadRequestError, NotFoundError } from "@/common/errors.js";
+import type { BaseRepository } from "../base.repository.js";
 
 type NoSubstring<S extends string, Forbidden extends string> =
   Lowercase<S> extends `${string}${Lowercase<Forbidden>}${string}`
@@ -28,11 +29,10 @@ export function assertValidId<const T extends string>(
  *
  * @param model - Model to check
  * @param id - ID to check
- * @param forceLabel - Force a specific label to use in the error message
  * @throws {NotFoundError} if the ID does not exist in the model
  */
-export async function assertExists(
-  model: Model<unknown>,
+export async function assertExists<T extends { _id: Types.ObjectId }>(
+  model: Model<unknown> | BaseRepository<T>,
   id: string,
 ): Promise<void> {
   const exists = await model.exists({ _id: id });

--- a/apps/backend/src/modules/comments/comment.service.test.ts
+++ b/apps/backend/src/modules/comments/comment.service.test.ts
@@ -3,7 +3,7 @@ import {
   createCommentDoc,
   createMockCommentRepository,
   createMockRecipeModel,
-  createMockUserModel,
+  createMockUserRepository,
   createObjectId,
   initiator,
   queryParams,
@@ -16,16 +16,17 @@ import {
 import type { CommentRepository } from "@/modules/comments/comment.repository.js";
 import { createCommentService } from "@/modules/comments/comment.service.js";
 import type { RecipeModelType } from "@/modules/recipes/recipe.model.js";
-import type { UserModelType } from "@/modules/users/user.model.js";
+import type { UserRepository } from "@/modules/users/user.repository.js";
 
 describe("commentService", () => {
   const commentRepository = createMockCommentRepository();
   const recipeModel = createMockRecipeModel();
-  const userModel = createMockUserModel();
+  const userRepository = createMockUserRepository();
+
   const service = createCommentService(
     commentRepository as unknown as CommentRepository,
     recipeModel as unknown as RecipeModelType,
-    userModel as unknown as UserModelType,
+    userRepository as unknown as UserRepository,
   );
 
   beforeEach(() => {
@@ -90,7 +91,7 @@ describe("commentService", () => {
 
   describe("findByAuthor", () => {
     it("should return paginated comments by author", async () => {
-      userModel.exists.mockResolvedValue(true);
+      userRepository.exists.mockResolvedValue(true);
       const authorId = createObjectId();
       const populatedComment = {
         _id: createObjectId(),
@@ -121,7 +122,7 @@ describe("commentService", () => {
   describe("create", () => {
     it("should create a comment and return populated DTO", async () => {
       recipeModel.exists.mockResolvedValue(true);
-      userModel.exists.mockResolvedValue(true);
+      userRepository.exists.mockResolvedValue(true);
 
       const authorId = createObjectId();
       const populated = {
@@ -176,7 +177,7 @@ describe("commentService", () => {
 
     it("should throw NotFoundError when author not found", async () => {
       recipeModel.exists.mockResolvedValue(true);
-      userModel.exists.mockResolvedValue(null);
+      userRepository.exists.mockResolvedValue(null);
 
       await expect(
         service.create(createObjectId().toString(), {

--- a/apps/backend/src/modules/comments/comment.service.ts
+++ b/apps/backend/src/modules/comments/comment.service.ts
@@ -14,7 +14,7 @@ import type {
 import { toComment, toCommentForRecipe } from "@/common/utils/mongo.js";
 import { assertExists, assertValidId } from "@/common/utils/validation.js";
 import type { RecipeModelType } from "@/modules/recipes/recipe.model.js";
-import type { UserModelType } from "@/modules/users/user.model.js";
+import type { UserRepository } from "@/modules/users/user.repository.js";
 import type { CommentRepository } from "./comment.repository.js";
 
 export interface CommentService {
@@ -36,7 +36,7 @@ export interface CommentService {
 export function createCommentService(
   repository: CommentRepository,
   recipeModel: RecipeModelType,
-  userModel: UserModelType,
+  userRepository: UserRepository,
 ): CommentService {
   return {
     findByRecipe: async (recipeId, { query, initiator }) => {
@@ -58,7 +58,7 @@ export function createCommentService(
 
     findByAuthor: async (authorId, { query, initiator }) => {
       assertValidId(authorId, "Author");
-      await assertExists(userModel, authorId);
+      await assertExists(userRepository, authorId);
 
       const [comments, total] = await repository.findByAuthor(authorId, {
         query,
@@ -78,7 +78,7 @@ export function createCommentService(
       assertValidId(initiator.id, "Author");
 
       await assertExists(recipeModel, recipeId);
-      await assertExists(userModel, initiator.id);
+      await assertExists(userRepository, initiator.id);
 
       const comment = await repository.create({
         text: data.text,

--- a/apps/backend/src/modules/favorites/favorite.service.test.ts
+++ b/apps/backend/src/modules/favorites/favorite.service.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createMockFavoriteRepository,
   createMockRecipeModel,
-  createMockUserModel,
+  createMockUserRepository,
   createObjectId,
   createRecipeDoc,
   initiator,
@@ -13,17 +13,17 @@ import { BadRequestError, NotFoundError } from "@/common/errors.js";
 import type { FavoriteRepository } from "@/modules/favorites/favorite.repository.js";
 import { createFavoriteService } from "@/modules/favorites/favorite.service.js";
 import type { RecipeModelType } from "@/modules/recipes/recipe.model.js";
-import type { UserModelType } from "@/modules/users/user.model.js";
+import type { UserRepository } from "@/modules/users/user.repository.js";
 
 describe("favoriteService", () => {
   const favoriteRepository = createMockFavoriteRepository();
   const recipeModel = createMockRecipeModel();
-  const userModel = createMockUserModel();
+  const userRepository = createMockUserRepository();
 
   const service = createFavoriteService(
     favoriteRepository as unknown as FavoriteRepository,
     recipeModel as unknown as RecipeModelType,
-    userModel as unknown as UserModelType,
+    userRepository as unknown as UserRepository,
   );
 
   beforeEach(() => {
@@ -32,7 +32,7 @@ describe("favoriteService", () => {
 
   describe("add", () => {
     it("should add a favorite and return favorited: true", async () => {
-      userModel.exists.mockResolvedValue(true);
+      userRepository.exists.mockResolvedValue(true);
       recipeModel.exists.mockResolvedValue(true);
 
       const init = initiator();
@@ -55,7 +55,7 @@ describe("favoriteService", () => {
     });
 
     it("should throw BadRequestError for invalid recipe ID", async () => {
-      userModel.exists.mockResolvedValue(true);
+      userRepository.exists.mockResolvedValue(true);
 
       await expect(
         service.add("invalid-id", { initiator: initiator() }),
@@ -63,7 +63,7 @@ describe("favoriteService", () => {
     });
 
     it("should throw NotFoundError when user does not exist", async () => {
-      userModel.exists.mockResolvedValue(false);
+      userRepository.exists.mockResolvedValue(false);
       recipeModel.exists.mockResolvedValue(true);
 
       await expect(
@@ -72,7 +72,7 @@ describe("favoriteService", () => {
     });
 
     it("should throw NotFoundError when recipe does not exist", async () => {
-      userModel.exists.mockResolvedValue(true);
+      userRepository.exists.mockResolvedValue(true);
       recipeModel.exists.mockResolvedValue(false);
 
       await expect(
@@ -83,7 +83,7 @@ describe("favoriteService", () => {
 
   describe("remove", () => {
     it("should remove a favorite and return favorited: false", async () => {
-      userModel.exists.mockResolvedValue(true);
+      userRepository.exists.mockResolvedValue(true);
       recipeModel.exists.mockResolvedValue(true);
 
       const init = initiator();
@@ -122,7 +122,7 @@ describe("favoriteService", () => {
 
   describe("findByUser", () => {
     it("should return paginated recipes from favorites", async () => {
-      userModel.exists.mockResolvedValue(true);
+      userRepository.exists.mockResolvedValue(true);
       const recipe = populateRecipeDoc(createRecipeDoc(), {
         isFavorited: true,
       });
@@ -138,7 +138,7 @@ describe("favoriteService", () => {
     });
 
     it("should return empty paginated result when no favorites", async () => {
-      userModel.exists.mockResolvedValue(true);
+      userRepository.exists.mockResolvedValue(true);
       favoriteRepository.findByUser.mockResolvedValue([[], 0]);
 
       const result = await service.findByUser(

--- a/apps/backend/src/modules/favorites/favorite.service.ts
+++ b/apps/backend/src/modules/favorites/favorite.service.ts
@@ -8,7 +8,7 @@ import type {
 import { toRecipe } from "@/common/utils/mongo.js";
 import { assertExists, assertValidId } from "@/common/utils/validation.js";
 import type { RecipeModelType } from "@/modules/recipes/recipe.model.js";
-import type { UserModelType } from "@/modules/users/user.model.js";
+import type { UserRepository } from "@/modules/users/user.repository.js";
 import type { FavoriteRepository } from "./favorite.repository.js";
 
 export interface FavoriteService {
@@ -33,11 +33,11 @@ export interface FavoriteService {
 export function createFavoriteService(
   repository: FavoriteRepository,
   recipeModel: RecipeModelType,
-  userModel: UserModelType,
+  userRepository: UserRepository,
 ): FavoriteService {
   async function validateUser(id: string): Promise<void> {
     assertValidId(id, "User");
-    await assertExists(userModel, id);
+    await assertExists(userRepository, id);
   }
 
   async function validateRecipe(id: string): Promise<void> {

--- a/apps/backend/src/modules/recipe-ratings/recipe-rating.service.test.ts
+++ b/apps/backend/src/modules/recipe-ratings/recipe-rating.service.test.ts
@@ -3,7 +3,7 @@ import {
   createMockBus,
   createMockRecipeModel,
   createMockRecipeRatingRepository,
-  createMockUserModel,
+  createMockUserRepository,
   createObjectId,
   initiator,
 } from "@/__tests__/helpers.js";
@@ -11,18 +11,18 @@ import { BadRequestError, NotFoundError } from "@/common/errors.js";
 import type { RecipeRatingRepository } from "@/modules/recipe-ratings/recipe-rating.repository.js";
 import { createRecipeRatingService } from "@/modules/recipe-ratings/recipe-rating.service.js";
 import type { RecipeModelType } from "@/modules/recipes/recipe.model.js";
-import type { UserModelType } from "@/modules/users/user.model.js";
+import type { UserRepository } from "@/modules/users/user.repository.js";
 
 describe("recipeRatingService", () => {
   const repository = createMockRecipeRatingRepository();
   const recipeModel = createMockRecipeModel();
-  const userModel = createMockUserModel();
+  const userRepository = createMockUserRepository();
   const bus = createMockBus();
 
   const service = createRecipeRatingService(
     repository as unknown as RecipeRatingRepository,
     recipeModel as unknown as RecipeModelType,
-    userModel as unknown as UserModelType,
+    userRepository as unknown as UserRepository,
     bus,
   );
 
@@ -32,7 +32,7 @@ describe("recipeRatingService", () => {
 
   describe("rate", () => {
     it("should create a new rating", async () => {
-      userModel.exists.mockResolvedValue(true);
+      userRepository.exists.mockResolvedValue(true);
       recipeModel.exists.mockResolvedValue(true);
       repository.upsert.mockResolvedValue({
         _id: createObjectId(),
@@ -58,7 +58,7 @@ describe("recipeRatingService", () => {
     });
 
     it("should update an existing rating", async () => {
-      userModel.exists.mockResolvedValue(true);
+      userRepository.exists.mockResolvedValue(true);
       recipeModel.exists.mockResolvedValue(true);
       repository.upsert.mockResolvedValue({
         _id: createObjectId(),
@@ -88,7 +88,7 @@ describe("recipeRatingService", () => {
     });
 
     it("should throw BadRequestError for invalid recipe ID", async () => {
-      userModel.exists.mockResolvedValue(true);
+      userRepository.exists.mockResolvedValue(true);
 
       await expect(
         service.rate("invalid-id", {
@@ -99,7 +99,7 @@ describe("recipeRatingService", () => {
     });
 
     it("should throw NotFoundError when user does not exist", async () => {
-      userModel.exists.mockResolvedValue(false);
+      userRepository.exists.mockResolvedValue(false);
       recipeModel.exists.mockResolvedValue(true);
 
       await expect(
@@ -111,7 +111,7 @@ describe("recipeRatingService", () => {
     });
 
     it("should throw NotFoundError when recipe does not exist", async () => {
-      userModel.exists.mockResolvedValue(true);
+      userRepository.exists.mockResolvedValue(true);
       recipeModel.exists.mockResolvedValue(false);
 
       await expect(
@@ -125,7 +125,7 @@ describe("recipeRatingService", () => {
 
   describe("remove", () => {
     it("should remove an existing rating", async () => {
-      userModel.exists.mockResolvedValue(true);
+      userRepository.exists.mockResolvedValue(true);
       recipeModel.exists.mockResolvedValue(true);
       repository.delete.mockResolvedValue({
         _id: createObjectId(),
@@ -147,7 +147,7 @@ describe("recipeRatingService", () => {
     });
 
     it("should throw NotFoundError when rating does not exist", async () => {
-      userModel.exists.mockResolvedValue(true);
+      userRepository.exists.mockResolvedValue(true);
       recipeModel.exists.mockResolvedValue(true);
       repository.delete.mockResolvedValue(null);
 
@@ -167,7 +167,7 @@ describe("recipeRatingService", () => {
     });
 
     it("should throw NotFoundError when recipe does not exist", async () => {
-      userModel.exists.mockResolvedValue(true);
+      userRepository.exists.mockResolvedValue(true);
       recipeModel.exists.mockResolvedValue(false);
 
       await expect(

--- a/apps/backend/src/modules/recipe-ratings/recipe-rating.service.ts
+++ b/apps/backend/src/modules/recipe-ratings/recipe-rating.service.ts
@@ -7,7 +7,7 @@ import type {
 } from "@/common/types/methods.js";
 import { assertExists, assertValidId } from "@/common/utils/validation.js";
 import type { RecipeModelType } from "@/modules/recipes/recipe.model.js";
-import type { UserModelType } from "@/modules/users/user.model.js";
+import type { UserRepository } from "@/modules/users/user.repository.js";
 import type { RecipeRatingRepository } from "./recipe-rating.repository.js";
 
 export interface RecipeRatingService {
@@ -21,12 +21,12 @@ export interface RecipeRatingService {
 export function createRecipeRatingService(
   repository: RecipeRatingRepository,
   recipeModel: RecipeModelType,
-  userModel: UserModelType,
+  userRepository: UserRepository,
   bus: TypedEmitter,
 ): RecipeRatingService {
   async function validateUser(userId: string): Promise<void> {
     assertValidId(userId, "User");
-    await assertExists(userModel, userId);
+    await assertExists(userRepository, userId);
   }
 
   async function validateRecipe(recipeId: string): Promise<void> {

--- a/apps/backend/src/modules/recipes/recipe.service.test.ts
+++ b/apps/backend/src/modules/recipes/recipe.service.test.ts
@@ -6,7 +6,7 @@ import {
   createMockCategoryModel,
   createMockFavoriteModel,
   createMockRecipeModel,
-  createMockUserModel,
+  createMockUserRepository,
   createObjectId,
   createRecipeDoc,
   initiator,
@@ -23,18 +23,18 @@ import type { FavoriteModelType } from "@/modules/favorites/favorite.model.js";
 import { recipeCache } from "@/modules/recipes/recipe.cache.js";
 import type { RecipeModelType } from "@/modules/recipes/recipe.model.js";
 import { createRecipeService } from "@/modules/recipes/recipe.service.js";
-import type { UserModelType } from "@/modules/users/user.model.js";
+import type { UserRepository } from "@/modules/users/user.repository.js";
 
 describe("recipeService", () => {
   const recipeModel = createMockRecipeModel();
-  const userModel = createMockUserModel();
+  const userRepository = createMockUserRepository();
   const favoriteModel = createMockFavoriteModel();
   const categoryModel = createMockCategoryModel();
   const cache = createMockCache();
   const bus = createMockBus();
   const service = createRecipeService(
     recipeModel as unknown as RecipeModelType,
-    userModel as unknown as UserModelType,
+    userRepository as unknown as UserRepository,
     favoriteModel as unknown as FavoriteModelType,
     categoryModel as unknown as CategoryModelType,
     cache,
@@ -235,7 +235,7 @@ describe("recipeService", () => {
 
     it("should create and return a recipe", async () => {
       categoryModel.exists.mockResolvedValue(true);
-      userModel.exists.mockResolvedValue(true);
+      userRepository.exists.mockResolvedValue(true);
 
       const authorId = createObjectId();
       const categoryId = createObjectId();
@@ -299,7 +299,7 @@ describe("recipeService", () => {
 
     it("should throw NotFoundError when author not found", async () => {
       categoryModel.exists.mockResolvedValue(true);
-      userModel.exists.mockResolvedValue(null);
+      userRepository.exists.mockResolvedValue(null);
 
       await expect(
         service.create({

--- a/apps/backend/src/modules/recipes/recipe.service.test.ts
+++ b/apps/backend/src/modules/recipes/recipe.service.test.ts
@@ -4,7 +4,7 @@ import {
   createMockBus,
   createMockCache,
   createMockCategoryModel,
-  createMockFavoriteModel,
+  createMockFavoriteRepository,
   createMockRecipeModel,
   createMockUserRepository,
   createObjectId,
@@ -19,7 +19,7 @@ import {
   NotFoundError,
 } from "@/common/errors.js";
 import type { CategoryModelType } from "@/modules/categories/category.model.js";
-import type { FavoriteModelType } from "@/modules/favorites/favorite.model.js";
+import type { FavoriteRepository } from "@/modules/favorites/favorite.repository.js";
 import { recipeCache } from "@/modules/recipes/recipe.cache.js";
 import type { RecipeModelType } from "@/modules/recipes/recipe.model.js";
 import { createRecipeService } from "@/modules/recipes/recipe.service.js";
@@ -28,14 +28,14 @@ import type { UserRepository } from "@/modules/users/user.repository.js";
 describe("recipeService", () => {
   const recipeModel = createMockRecipeModel();
   const userRepository = createMockUserRepository();
-  const favoriteModel = createMockFavoriteModel();
+  const favoriteRepository = createMockFavoriteRepository();
   const categoryModel = createMockCategoryModel();
   const cache = createMockCache();
   const bus = createMockBus();
   const service = createRecipeService(
     recipeModel as unknown as RecipeModelType,
     userRepository as unknown as UserRepository,
-    favoriteModel as unknown as FavoriteModelType,
+    favoriteRepository as unknown as FavoriteRepository,
     categoryModel as unknown as CategoryModelType,
     cache,
     bus,
@@ -322,9 +322,7 @@ describe("recipeService", () => {
         }),
       };
       recipeModel.findById.mockResolvedValue(recipe);
-      favoriteModel.findOne.mockReturnValue({
-        lean: vi.fn().mockResolvedValue(null),
-      });
+      favoriteRepository.exists.mockReturnValue(false);
 
       const id = createObjectId().toString();
       const result = await service.update(id, {
@@ -355,9 +353,7 @@ describe("recipeService", () => {
         }),
       };
       recipeModel.findById.mockResolvedValue(recipe);
-      favoriteModel.findOne.mockReturnValue({
-        lean: vi.fn().mockResolvedValue(null),
-      });
+      favoriteRepository.exists.mockReturnValue(false);
 
       const id = createObjectId().toString();
       await expect(

--- a/apps/backend/src/modules/recipes/recipe.service.test.ts
+++ b/apps/backend/src/modules/recipes/recipe.service.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createMockBus,
   createMockCache,
-  createMockCategoryModel,
+  createMockCategoryRepository,
   createMockFavoriteRepository,
   createMockRecipeModel,
   createMockUserRepository,
@@ -18,7 +18,7 @@ import {
   ForbiddenError,
   NotFoundError,
 } from "@/common/errors.js";
-import type { CategoryModelType } from "@/modules/categories/category.model.js";
+import type { CategoryRepository } from "@/modules/categories/category.repository.js";
 import type { FavoriteRepository } from "@/modules/favorites/favorite.repository.js";
 import { recipeCache } from "@/modules/recipes/recipe.cache.js";
 import type { RecipeModelType } from "@/modules/recipes/recipe.model.js";
@@ -29,14 +29,14 @@ describe("recipeService", () => {
   const recipeModel = createMockRecipeModel();
   const userRepository = createMockUserRepository();
   const favoriteRepository = createMockFavoriteRepository();
-  const categoryModel = createMockCategoryModel();
+  const categoryRepository = createMockCategoryRepository();
   const cache = createMockCache();
   const bus = createMockBus();
   const service = createRecipeService(
     recipeModel as unknown as RecipeModelType,
     userRepository as unknown as UserRepository,
     favoriteRepository as unknown as FavoriteRepository,
-    categoryModel as unknown as CategoryModelType,
+    categoryRepository as unknown as CategoryRepository,
     cache,
     bus,
   );
@@ -234,7 +234,7 @@ describe("recipeService", () => {
     };
 
     it("should create and return a recipe", async () => {
-      categoryModel.exists.mockResolvedValue(true);
+      categoryRepository.exists.mockResolvedValue(true);
       userRepository.exists.mockResolvedValue(true);
 
       const authorId = createObjectId();
@@ -287,7 +287,7 @@ describe("recipeService", () => {
     });
 
     it("should throw NotFoundError when category not found", async () => {
-      categoryModel.exists.mockResolvedValue(null);
+      categoryRepository.exists.mockResolvedValue(null);
 
       await expect(
         service.create({
@@ -298,7 +298,7 @@ describe("recipeService", () => {
     });
 
     it("should throw NotFoundError when author not found", async () => {
-      categoryModel.exists.mockResolvedValue(true);
+      categoryRepository.exists.mockResolvedValue(true);
       userRepository.exists.mockResolvedValue(null);
 
       await expect(

--- a/apps/backend/src/modules/recipes/recipe.service.ts
+++ b/apps/backend/src/modules/recipes/recipe.service.ts
@@ -35,10 +35,8 @@ import {
   buildFindByIdPipeline,
   buildSearchPipeline,
 } from "@/modules/recipes/recipe.pipeline.js";
-import type {
-  UserDocument,
-  UserModelType,
-} from "@/modules/users/user.model.js";
+import type { UserDocument } from "@/modules/users/user.model.js";
+import type { UserRepository } from "@/modules/users/user.repository.js";
 
 export interface RecipeService {
   findAll(params: QueryMethodParams<RecipeQuery>): Promise<Paginated<Recipe>>;
@@ -56,7 +54,7 @@ export interface RecipeService {
 
 export function createRecipeService(
   recipeModel: RecipeModelType,
-  userModel: UserModelType,
+  userRepository: UserRepository,
   favoriteModel: FavoriteModelType,
   categoryModel: CategoryModelType,
   cache: CacheService,
@@ -138,7 +136,7 @@ export function createRecipeService(
       assertValidId(data.category, "Category");
 
       await assertExists(categoryModel, data.category);
-      await assertExists(userModel, initiator.id);
+      await assertExists(userRepository, initiator.id);
 
       const recipe = await recipeModel.create({
         ...data,

--- a/apps/backend/src/modules/recipes/recipe.service.ts
+++ b/apps/backend/src/modules/recipes/recipe.service.ts
@@ -21,10 +21,8 @@ import { toRecipe } from "@/common/utils/mongo.js";
 import type { WithTotalCountResult } from "@/common/utils/mongoose.aggregation.js";
 import { extractTotalCountResult } from "@/common/utils/mongoose.aggregation.js";
 import { assertExists, assertValidId } from "@/common/utils/validation.js";
-import type {
-  CategoryDocument,
-  CategoryModelType,
-} from "@/modules/categories/category.model.js";
+import type { CategoryDocument } from "@/modules/categories/category.model.js";
+import type { CategoryRepository } from "@/modules/categories/category.repository.js";
 import type { FavoriteRepository } from "@/modules/favorites/favorite.repository.js";
 import { recipeCache } from "@/modules/recipes/recipe.cache.js";
 import type {
@@ -56,7 +54,7 @@ export function createRecipeService(
   recipeModel: RecipeModelType,
   userRepository: UserRepository,
   favoriteRepository: FavoriteRepository,
-  categoryModel: CategoryModelType,
+  categoryRepository: CategoryRepository,
   cache: CacheService,
   bus: TypedEmitter,
 ): RecipeService {
@@ -135,7 +133,7 @@ export function createRecipeService(
       assertValidId(initiator.id, "Author");
       assertValidId(data.category, "Category");
 
-      await assertExists(categoryModel, data.category);
+      await assertExists(categoryRepository, data.category);
       await assertExists(userRepository, initiator.id);
 
       const recipe = await recipeModel.create({

--- a/apps/backend/src/modules/recipes/recipe.service.ts
+++ b/apps/backend/src/modules/recipes/recipe.service.ts
@@ -25,7 +25,7 @@ import type {
   CategoryDocument,
   CategoryModelType,
 } from "@/modules/categories/category.model.js";
-import type { FavoriteModelType } from "@/modules/favorites/favorite.model.js";
+import type { FavoriteRepository } from "@/modules/favorites/favorite.repository.js";
 import { recipeCache } from "@/modules/recipes/recipe.cache.js";
 import type {
   RecipeDocumentPopulated,
@@ -55,7 +55,7 @@ export interface RecipeService {
 export function createRecipeService(
   recipeModel: RecipeModelType,
   userRepository: UserRepository,
-  favoriteModel: FavoriteModelType,
+  favoriteRepository: FavoriteRepository,
   categoryModel: CategoryModelType,
   cache: CacheService,
   bus: TypedEmitter,
@@ -177,12 +177,10 @@ export function createRecipeService(
         { path: "category", select: "name slug" },
       ]);
 
-      const isFavorited = !!(await favoriteModel
-        .findOne({
-          user: initiator.id,
-          recipe: id,
-        })
-        .lean());
+      const isFavorited = await favoriteRepository.exists({
+        user: initiator.id,
+        recipe: id,
+      });
 
       await Promise.all([
         cache.delete(recipeCache.keys.byId(id)),


### PR DESCRIPTION
## Related Issues

Refs #67

## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring
- [ ] Tests
- [ ] Other

## Description

Replaces remaining direct Mongoose model usage in services with repository abstractions.

### Changes

All services now depend on repositories instead of models (where repositories exist):

| Service | Before | After |
|---|---|---|
| `CommentService` | `recipeModel`, `userModel` | `commentRepository`, `userRepository` |
| `FavoriteService` | `recipeModel`, `userModel` | `favoriteRepository`, `userRepository` |
| `RecipeRatingService` | `recipeModel`, `userModel` | `recipeRatingRepository`, `userRepository` |
| `CategoryService` | `recipeModel` | `categoryRepository`, `recipeModel` (for assertExists only) |
| `RecipeService` | `RecipeModel`, `UserModel`, `FavoriteModel`, `CategoryModel` | `RecipeModel`, `userRepository`, `favoriteRepository`, `categoryRepository` |
| `AuthService` | `UserModel` | `userRepository` |
| `UserService` | `UserModel` | `userRepository` |

### app.services.ts DI updates

All repository instances are now created at the top of `createServices()` and passed down to services.

## Screenshots

N/A

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Added/updated tests for new functionality
- [ ] Updated documentation (if needed)