### PR TITLE
refactor: replace RecipeModel with RecipeRepository in remaining services

### DIFF
--- a/apps/backend/src/app.services.ts
+++ b/apps/backend/src/app.services.ts
@@ -72,7 +72,7 @@ export function createServices(
   );
   const recipeRatingService = createRecipeRatingService(
     recipeRatingRepository,
-    RecipeModel,
+    recipeRepository,
     userRepository,
     bus,
   );

--- a/apps/backend/src/app.services.ts
+++ b/apps/backend/src/app.services.ts
@@ -57,7 +57,7 @@ export function createServices(
 
   const commentService = createCommentService(
     commentRepository,
-    RecipeModel,
+    recipeRepository,
     userRepository,
   );
   const favoriteService = createFavoriteService(

--- a/apps/backend/src/app.services.ts
+++ b/apps/backend/src/app.services.ts
@@ -62,7 +62,7 @@ export function createServices(
   );
   const favoriteService = createFavoriteService(
     favoriteRepository,
-    RecipeModel,
+    recipeRepository,
     userRepository,
   );
   const userService = createUserService(

--- a/apps/backend/src/app.services.ts
+++ b/apps/backend/src/app.services.ts
@@ -78,7 +78,7 @@ export function createServices(
   );
   const categoryService = createCategoryService(
     categoryRepository,
-    RecipeModel,
+    recipeRepository,
     categoryCache,
     bus,
   );

--- a/apps/backend/src/modules/categories/category.service.test.ts
+++ b/apps/backend/src/modules/categories/category.service.test.ts
@@ -5,7 +5,7 @@ import {
   createMockBus,
   createMockCache,
   createMockCategoryRepository,
-  createMockRecipeModel,
+  createMockRecipeRepository,
   createObjectId,
   initiator,
   noInitiator,
@@ -14,16 +14,16 @@ import { ConflictError, NotFoundError } from "@/common/errors.js";
 import { categoryCache } from "@/modules/categories/category.cache.js";
 import type { CategoryRepository } from "@/modules/categories/category.repository.js";
 import { createCategoryService } from "@/modules/categories/category.service.js";
-import type { RecipeModelType } from "@/modules/recipes/recipe.model.js";
+import type { RecipeRepository } from "@/modules/recipes/recipe.repository.js";
 
 describe("categoryService", () => {
   const categoryRepository = createMockCategoryRepository();
-  const recipeModel = createMockRecipeModel();
+  const recipeRepository = createMockRecipeRepository();
   const cache = createMockCache();
   const bus = createMockBus();
   const service = createCategoryService(
     categoryRepository as unknown as CategoryRepository,
-    recipeModel as unknown as RecipeModelType,
+    recipeRepository as unknown as RecipeRepository,
     cache,
     bus,
   );
@@ -132,13 +132,15 @@ describe("categoryService", () => {
 
   describe("deleteById", () => {
     it("should delete category when no recipes exist", async () => {
-      recipeModel.countDocuments.mockResolvedValue(0);
+      recipeRepository.count.mockResolvedValue(0);
       categoryRepository.delete.mockResolvedValue(createCategoryDoc());
 
       const id = createObjectId().toString();
       await service.deleteById(id, { initiator: initiator() });
 
-      expect(recipeModel.countDocuments).toHaveBeenCalledWith({ category: id });
+      expect(recipeRepository.count).toHaveBeenCalledWith({
+        category: id,
+      });
       expect(categoryRepository.delete).toHaveBeenCalledWith(id);
       expect(cache.deletePattern).toHaveBeenCalledWith(
         categoryCache.keys.allPattern(),
@@ -147,7 +149,7 @@ describe("categoryService", () => {
     });
 
     it("should throw ConflictError when recipes exist", async () => {
-      recipeModel.countDocuments.mockResolvedValue(3);
+      recipeRepository.count.mockResolvedValue(3);
 
       await expect(
         service.deleteById(createObjectId().toString(), {
@@ -157,7 +159,7 @@ describe("categoryService", () => {
     });
 
     it("should throw NotFoundError when category not found", async () => {
-      recipeModel.countDocuments.mockResolvedValue(0);
+      recipeRepository.count.mockResolvedValue(0);
       categoryRepository.delete.mockResolvedValue(null);
 
       await expect(

--- a/apps/backend/src/modules/categories/category.service.ts
+++ b/apps/backend/src/modules/categories/category.service.ts
@@ -14,7 +14,7 @@ import type {
 import { toCategory } from "@/common/utils/mongo.js";
 import { categoryCache } from "@/modules/categories/category.cache.js";
 import type { CategoryRepository } from "@/modules/categories/category.repository.js";
-import type { RecipeModelType } from "@/modules/recipes/recipe.model.js";
+import type { RecipeRepository } from "@/modules/recipes/recipe.repository.js";
 
 export interface CategoryService {
   findAll(params: QueryMethodParams<CategoryQuery>): Promise<Category[]>;
@@ -24,7 +24,7 @@ export interface CategoryService {
 
 export function createCategoryService(
   repository: CategoryRepository,
-  recipeModel: RecipeModelType,
+  recipeRepository: RecipeRepository,
   cache: CacheService,
   bus: TypedEmitter,
 ): CategoryService {
@@ -55,7 +55,7 @@ export function createCategoryService(
     },
 
     deleteById: async (id) => {
-      const recipeCount = await recipeModel.countDocuments({
+      const recipeCount = await recipeRepository.count({
         category: id,
       });
       if (recipeCount > 0) {

--- a/apps/backend/src/modules/comments/comment.service.test.ts
+++ b/apps/backend/src/modules/comments/comment.service.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createCommentDoc,
   createMockCommentRepository,
-  createMockRecipeModel,
+  createMockRecipeRepository,
   createMockUserRepository,
   createObjectId,
   initiator,
@@ -15,17 +15,17 @@ import {
 } from "@/common/errors.js";
 import type { CommentRepository } from "@/modules/comments/comment.repository.js";
 import { createCommentService } from "@/modules/comments/comment.service.js";
-import type { RecipeModelType } from "@/modules/recipes/recipe.model.js";
+import type { RecipeRepository } from "@/modules/recipes/recipe.repository.js";
 import type { UserRepository } from "@/modules/users/user.repository.js";
 
 describe("commentService", () => {
   const commentRepository = createMockCommentRepository();
-  const recipeModel = createMockRecipeModel();
+  const recipeRepository = createMockRecipeRepository();
   const userRepository = createMockUserRepository();
 
   const service = createCommentService(
     commentRepository as unknown as CommentRepository,
-    recipeModel as unknown as RecipeModelType,
+    recipeRepository as unknown as RecipeRepository,
     userRepository as unknown as UserRepository,
   );
 
@@ -39,7 +39,7 @@ describe("commentService", () => {
 
   describe("findByRecipe", () => {
     it("should return paginated comments for recipe", async () => {
-      recipeModel.exists.mockResolvedValue(true);
+      recipeRepository.exists.mockResolvedValue(true);
       const authorId = createObjectId();
       const recipeId = createObjectId();
       const populatedComment = {
@@ -69,7 +69,7 @@ describe("commentService", () => {
     });
 
     it("should throw NotFoundError when recipe not found", async () => {
-      recipeModel.exists.mockResolvedValue(null);
+      recipeRepository.exists.mockResolvedValue(null);
 
       await expect(
         service.findByRecipe(createObjectId().toString(), queryParams()),
@@ -77,7 +77,7 @@ describe("commentService", () => {
     });
 
     it("should return empty result when no comments found", async () => {
-      recipeModel.exists.mockResolvedValue(true);
+      recipeRepository.exists.mockResolvedValue(true);
       commentRepository.findByRecipe.mockResolvedValue([[], 0]);
 
       const result = await service.findByRecipe(
@@ -121,7 +121,7 @@ describe("commentService", () => {
 
   describe("create", () => {
     it("should create a comment and return populated DTO", async () => {
-      recipeModel.exists.mockResolvedValue(true);
+      recipeRepository.exists.mockResolvedValue(true);
       userRepository.exists.mockResolvedValue(true);
 
       const authorId = createObjectId();
@@ -165,7 +165,7 @@ describe("commentService", () => {
     });
 
     it("should throw NotFoundError when recipe not found", async () => {
-      recipeModel.exists.mockResolvedValue(null);
+      recipeRepository.exists.mockResolvedValue(null);
 
       await expect(
         service.create(createObjectId().toString(), {
@@ -176,7 +176,7 @@ describe("commentService", () => {
     });
 
     it("should throw NotFoundError when author not found", async () => {
-      recipeModel.exists.mockResolvedValue(true);
+      recipeRepository.exists.mockResolvedValue(true);
       userRepository.exists.mockResolvedValue(null);
 
       await expect(

--- a/apps/backend/src/modules/comments/comment.service.ts
+++ b/apps/backend/src/modules/comments/comment.service.ts
@@ -13,7 +13,7 @@ import type {
 } from "@/common/types/methods.js";
 import { toComment, toCommentForRecipe } from "@/common/utils/mongo.js";
 import { assertExists, assertValidId } from "@/common/utils/validation.js";
-import type { RecipeModelType } from "@/modules/recipes/recipe.model.js";
+import type { RecipeRepository } from "@/modules/recipes/recipe.repository.js";
 import type { UserRepository } from "@/modules/users/user.repository.js";
 import type { CommentRepository } from "./comment.repository.js";
 
@@ -35,13 +35,13 @@ export interface CommentService {
 
 export function createCommentService(
   repository: CommentRepository,
-  recipeModel: RecipeModelType,
+  recipeRepository: RecipeRepository,
   userRepository: UserRepository,
 ): CommentService {
   return {
     findByRecipe: async (recipeId, { query, initiator }) => {
       assertValidId(recipeId, "Recipe");
-      await assertExists(recipeModel, recipeId);
+      await assertExists(recipeRepository, recipeId);
 
       const [comments, total] = await repository.findByRecipe(recipeId, {
         query,
@@ -77,7 +77,7 @@ export function createCommentService(
       assertValidId(recipeId, "Recipe");
       assertValidId(initiator.id, "Author");
 
-      await assertExists(recipeModel, recipeId);
+      await assertExists(recipeRepository, recipeId);
       await assertExists(userRepository, initiator.id);
 
       const comment = await repository.create({

--- a/apps/backend/src/modules/favorites/favorite.service.test.ts
+++ b/apps/backend/src/modules/favorites/favorite.service.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createMockFavoriteRepository,
-  createMockRecipeModel,
+  createMockRecipeRepository,
   createMockUserRepository,
   createObjectId,
   createRecipeDoc,
@@ -12,17 +12,17 @@ import {
 import { BadRequestError, NotFoundError } from "@/common/errors.js";
 import type { FavoriteRepository } from "@/modules/favorites/favorite.repository.js";
 import { createFavoriteService } from "@/modules/favorites/favorite.service.js";
-import type { RecipeModelType } from "@/modules/recipes/recipe.model.js";
+import type { RecipeRepository } from "@/modules/recipes/recipe.repository.js";
 import type { UserRepository } from "@/modules/users/user.repository.js";
 
 describe("favoriteService", () => {
   const favoriteRepository = createMockFavoriteRepository();
-  const recipeModel = createMockRecipeModel();
+  const recipeRepository = createMockRecipeRepository();
   const userRepository = createMockUserRepository();
 
   const service = createFavoriteService(
     favoriteRepository as unknown as FavoriteRepository,
-    recipeModel as unknown as RecipeModelType,
+    recipeRepository as unknown as RecipeRepository,
     userRepository as unknown as UserRepository,
   );
 
@@ -33,7 +33,7 @@ describe("favoriteService", () => {
   describe("add", () => {
     it("should add a favorite and return favorited: true", async () => {
       userRepository.exists.mockResolvedValue(true);
-      recipeModel.exists.mockResolvedValue(true);
+      recipeRepository.exists.mockResolvedValue(true);
 
       const init = initiator();
       const recipeId = createObjectId().toString();
@@ -64,7 +64,7 @@ describe("favoriteService", () => {
 
     it("should throw NotFoundError when user does not exist", async () => {
       userRepository.exists.mockResolvedValue(false);
-      recipeModel.exists.mockResolvedValue(true);
+      recipeRepository.exists.mockResolvedValue(true);
 
       await expect(
         service.add(createObjectId().toString(), { initiator: initiator() }),
@@ -73,7 +73,7 @@ describe("favoriteService", () => {
 
     it("should throw NotFoundError when recipe does not exist", async () => {
       userRepository.exists.mockResolvedValue(true);
-      recipeModel.exists.mockResolvedValue(false);
+      recipeRepository.exists.mockResolvedValue(false);
 
       await expect(
         service.add(createObjectId().toString(), { initiator: initiator() }),
@@ -84,7 +84,7 @@ describe("favoriteService", () => {
   describe("remove", () => {
     it("should remove a favorite and return favorited: false", async () => {
       userRepository.exists.mockResolvedValue(true);
-      recipeModel.exists.mockResolvedValue(true);
+      recipeRepository.exists.mockResolvedValue(true);
 
       const init = initiator();
       const recipeId = createObjectId().toString();

--- a/apps/backend/src/modules/favorites/favorite.service.ts
+++ b/apps/backend/src/modules/favorites/favorite.service.ts
@@ -7,7 +7,7 @@ import type {
 } from "@/common/types/methods.js";
 import { toRecipe } from "@/common/utils/mongo.js";
 import { assertExists, assertValidId } from "@/common/utils/validation.js";
-import type { RecipeModelType } from "@/modules/recipes/recipe.model.js";
+import type { RecipeRepository } from "@/modules/recipes/recipe.repository.js";
 import type { UserRepository } from "@/modules/users/user.repository.js";
 import type { FavoriteRepository } from "./favorite.repository.js";
 
@@ -32,7 +32,7 @@ export interface FavoriteService {
 
 export function createFavoriteService(
   repository: FavoriteRepository,
-  recipeModel: RecipeModelType,
+  recipeRepository: RecipeRepository,
   userRepository: UserRepository,
 ): FavoriteService {
   async function validateUser(id: string): Promise<void> {
@@ -42,7 +42,7 @@ export function createFavoriteService(
 
   async function validateRecipe(id: string): Promise<void> {
     assertValidId(id, "Recipe");
-    await assertExists(recipeModel, id);
+    await assertExists(recipeRepository, id);
   }
 
   return {

--- a/apps/backend/src/modules/recipe-ratings/recipe-rating.service.test.ts
+++ b/apps/backend/src/modules/recipe-ratings/recipe-rating.service.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createMockBus,
-  createMockRecipeModel,
   createMockRecipeRatingRepository,
+  createMockRecipeRepository,
   createMockUserRepository,
   createObjectId,
   initiator,
@@ -10,18 +10,18 @@ import {
 import { BadRequestError, NotFoundError } from "@/common/errors.js";
 import type { RecipeRatingRepository } from "@/modules/recipe-ratings/recipe-rating.repository.js";
 import { createRecipeRatingService } from "@/modules/recipe-ratings/recipe-rating.service.js";
-import type { RecipeModelType } from "@/modules/recipes/recipe.model.js";
+import type { RecipeRepository } from "@/modules/recipes/recipe.repository.js";
 import type { UserRepository } from "@/modules/users/user.repository.js";
 
 describe("recipeRatingService", () => {
   const repository = createMockRecipeRatingRepository();
-  const recipeModel = createMockRecipeModel();
+  const recipeRepository = createMockRecipeRepository();
   const userRepository = createMockUserRepository();
   const bus = createMockBus();
 
   const service = createRecipeRatingService(
     repository as unknown as RecipeRatingRepository,
-    recipeModel as unknown as RecipeModelType,
+    recipeRepository as unknown as RecipeRepository,
     userRepository as unknown as UserRepository,
     bus,
   );
@@ -33,7 +33,7 @@ describe("recipeRatingService", () => {
   describe("rate", () => {
     it("should create a new rating", async () => {
       userRepository.exists.mockResolvedValue(true);
-      recipeModel.exists.mockResolvedValue(true);
+      recipeRepository.exists.mockResolvedValue(true);
       repository.upsert.mockResolvedValue({
         _id: createObjectId(),
         user: createObjectId(),
@@ -59,7 +59,7 @@ describe("recipeRatingService", () => {
 
     it("should update an existing rating", async () => {
       userRepository.exists.mockResolvedValue(true);
-      recipeModel.exists.mockResolvedValue(true);
+      recipeRepository.exists.mockResolvedValue(true);
       repository.upsert.mockResolvedValue({
         _id: createObjectId(),
         user: createObjectId(),
@@ -100,7 +100,7 @@ describe("recipeRatingService", () => {
 
     it("should throw NotFoundError when user does not exist", async () => {
       userRepository.exists.mockResolvedValue(false);
-      recipeModel.exists.mockResolvedValue(true);
+      recipeRepository.exists.mockResolvedValue(true);
 
       await expect(
         service.rate(createObjectId().toString(), {
@@ -112,7 +112,7 @@ describe("recipeRatingService", () => {
 
     it("should throw NotFoundError when recipe does not exist", async () => {
       userRepository.exists.mockResolvedValue(true);
-      recipeModel.exists.mockResolvedValue(false);
+      recipeRepository.exists.mockResolvedValue(false);
 
       await expect(
         service.rate(createObjectId().toString(), {
@@ -126,7 +126,7 @@ describe("recipeRatingService", () => {
   describe("remove", () => {
     it("should remove an existing rating", async () => {
       userRepository.exists.mockResolvedValue(true);
-      recipeModel.exists.mockResolvedValue(true);
+      recipeRepository.exists.mockResolvedValue(true);
       repository.delete.mockResolvedValue({
         _id: createObjectId(),
         user: createObjectId(),
@@ -148,7 +148,7 @@ describe("recipeRatingService", () => {
 
     it("should throw NotFoundError when rating does not exist", async () => {
       userRepository.exists.mockResolvedValue(true);
-      recipeModel.exists.mockResolvedValue(true);
+      recipeRepository.exists.mockResolvedValue(true);
       repository.delete.mockResolvedValue(null);
 
       await expect(
@@ -168,7 +168,7 @@ describe("recipeRatingService", () => {
 
     it("should throw NotFoundError when recipe does not exist", async () => {
       userRepository.exists.mockResolvedValue(true);
-      recipeModel.exists.mockResolvedValue(false);
+      recipeRepository.exists.mockResolvedValue(false);
 
       await expect(
         service.remove(createObjectId().toString(), {

--- a/apps/backend/src/modules/recipe-ratings/recipe-rating.service.ts
+++ b/apps/backend/src/modules/recipe-ratings/recipe-rating.service.ts
@@ -6,7 +6,7 @@ import type {
   DeleteMethodParams,
 } from "@/common/types/methods.js";
 import { assertExists, assertValidId } from "@/common/utils/validation.js";
-import type { RecipeModelType } from "@/modules/recipes/recipe.model.js";
+import type { RecipeRepository } from "@/modules/recipes/recipe.repository.js";
 import type { UserRepository } from "@/modules/users/user.repository.js";
 import type { RecipeRatingRepository } from "./recipe-rating.repository.js";
 
@@ -20,7 +20,7 @@ export interface RecipeRatingService {
 
 export function createRecipeRatingService(
   repository: RecipeRatingRepository,
-  recipeModel: RecipeModelType,
+  recipeRepository: RecipeRepository,
   userRepository: UserRepository,
   bus: TypedEmitter,
 ): RecipeRatingService {
@@ -31,7 +31,7 @@ export function createRecipeRatingService(
 
   async function validateRecipe(recipeId: string): Promise<void> {
     assertValidId(recipeId, "Recipe");
-    await assertExists(recipeModel, recipeId);
+    await assertExists(recipeRepository, recipeId);
   }
 
   return {


### PR DESCRIPTION
## Related Issues

Closes #67

## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring
- [ ] Tests
- [ ] Other

## Description

Replaces remaining direct `RecipeModel` usage with `RecipeRepository` in services that validate recipe existence.

### Changes

| Service | Before | After |
|---|---|---|
| `CommentService` | `recipeModel: RecipeModelType` | `recipeRepository: RecipeRepository` |
| `FavoriteService` | `recipeModel: RecipeModelType` | `recipeRepository: RecipeRepository` |
| `RecipeRatingService` | `recipeModel: RecipeModelType` | `recipeRepository: RecipeRepository` |
| `CategoryService` | `recipeModel: RecipeModelType` | `recipeRepository: RecipeRepository` |

### app.services.ts

All services now receive `recipeRepository` instead of `RecipeModel`.

## Screenshots

N/A

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Added/updated tests for new functionality
- [ ] Updated documentation (if needed)