### PR TITLE
refactor: standardize API response format

### DIFF
--- a/apps/backend/src/common/middleware/errorHandler.test.ts
+++ b/apps/backend/src/common/middleware/errorHandler.test.ts
@@ -30,28 +30,44 @@ describe("errorHandler", () => {
       errorHandler(new AppError("Not found", 404), request, reply);
 
       expect(reply.status).toHaveBeenCalledWith(404);
-      expect(reply.send).toHaveBeenCalledWith({ error: "Not found" });
+      expect(reply.send).toHaveBeenCalledWith({
+        error: "Not found",
+        code: "INTERNAL_SERVER",
+        status: 404,
+      });
     });
 
     it("should handle AppError with 403", () => {
       errorHandler(new AppError("Forbidden", 403), request, reply);
 
       expect(reply.status).toHaveBeenCalledWith(403);
-      expect(reply.send).toHaveBeenCalledWith({ error: "Forbidden" });
+      expect(reply.send).toHaveBeenCalledWith({
+        error: "Forbidden",
+        code: "INTERNAL_SERVER",
+        status: 403,
+      });
     });
 
     it("should handle BadRequestError", () => {
       errorHandler(new BadRequestError("Invalid recipe ID"), request, reply);
 
       expect(reply.status).toHaveBeenCalledWith(400);
-      expect(reply.send).toHaveBeenCalledWith({ error: "Invalid recipe ID" });
+      expect(reply.send).toHaveBeenCalledWith({
+        error: "Invalid recipe ID",
+        code: "BAD_REQUEST",
+        status: 400,
+      });
     });
 
     it("should handle UnauthorizedError", () => {
       errorHandler(new UnauthorizedError("Not authorized"), request, reply);
 
       expect(reply.status).toHaveBeenCalledWith(401);
-      expect(reply.send).toHaveBeenCalledWith({ error: "Not authorized" });
+      expect(reply.send).toHaveBeenCalledWith({
+        error: "Not authorized",
+        code: "UNAUTHORIZED",
+        status: 401,
+      });
     });
 
     it("should handle ForbiddenError", () => {
@@ -64,6 +80,8 @@ describe("errorHandler", () => {
       expect(reply.status).toHaveBeenCalledWith(403);
       expect(reply.send).toHaveBeenCalledWith({
         error: "Not authorized to delete this recipe",
+        code: "FORBIDDEN",
+        status: 403,
       });
     });
 
@@ -71,7 +89,11 @@ describe("errorHandler", () => {
       errorHandler(new NotFoundError("Recipe not found"), request, reply);
 
       expect(reply.status).toHaveBeenCalledWith(404);
-      expect(reply.send).toHaveBeenCalledWith({ error: "Recipe not found" });
+      expect(reply.send).toHaveBeenCalledWith({
+        error: "Recipe not found",
+        code: "NOT_FOUND",
+        status: 404,
+      });
     });
 
     it("should handle ConflictError", () => {
@@ -80,6 +102,8 @@ describe("errorHandler", () => {
       expect(reply.status).toHaveBeenCalledWith(409);
       expect(reply.send).toHaveBeenCalledWith({
         error: "Email already in use",
+        code: "CONFLICT",
+        status: 409,
       });
     });
   });
@@ -102,7 +126,9 @@ describe("errorHandler", () => {
       expect(reply.status).toHaveBeenCalledWith(400);
       expect(reply.send).toHaveBeenCalledWith({
         error: "Validation error",
-        details: error.issues,
+        code: "VALIDATION_ERROR",
+        status: 400,
+        details: { issues: error.issues },
       });
     });
 
@@ -118,6 +144,8 @@ describe("errorHandler", () => {
       expect(reply.status).toHaveBeenCalledWith(400);
       expect(reply.send).toHaveBeenCalledWith({
         error: "Invalid _id: invalid-id",
+        code: "INVALID_FIELD",
+        status: 400,
       });
     });
 
@@ -129,7 +157,11 @@ describe("errorHandler", () => {
       errorHandler(error, request, reply);
 
       expect(reply.status).toHaveBeenCalledWith(409);
-      expect(reply.send).toHaveBeenCalledWith({ error: "Duplicate entry" });
+      expect(reply.send).toHaveBeenCalledWith({
+        error: "Duplicate entry",
+        code: "DUPLICATE_ENTRY",
+        status: 409,
+      });
     });
   });
 
@@ -142,7 +174,11 @@ describe("errorHandler", () => {
       errorHandler(error, request, reply);
 
       expect(reply.status).toHaveBeenCalledWith(400);
-      expect(reply.send).toHaveBeenCalledWith({ error: "Bad request" });
+      expect(reply.send).toHaveBeenCalledWith({
+        error: "Bad request",
+        code: "HTTP_ERROR",
+        status: 400,
+      });
     });
 
     it("should show message and stack in development for 500", () => {
@@ -154,6 +190,8 @@ describe("errorHandler", () => {
       expect(reply.status).toHaveBeenCalledWith(500);
       expect(reply.send).toHaveBeenCalledWith({
         error: "Something broke",
+        code: "INTERNAL_SERVER_ERROR",
+        status: 500,
         stack: error.stack,
       });
     });

--- a/apps/backend/src/common/middleware/errorHandler.ts
+++ b/apps/backend/src/common/middleware/errorHandler.ts
@@ -45,6 +45,31 @@ function isFastifyBodyError(error: unknown): boolean {
   );
 }
 
+interface ErrorResponse {
+  error: string;
+  code: string;
+  status: number;
+  details?: unknown;
+  stack?: string;
+}
+
+function buildErrorResponse(
+  status: number,
+  message: string,
+  code: string,
+  details?: unknown,
+  stack?: string,
+): ErrorResponse {
+  const response: ErrorResponse = { error: message, code, status };
+  if (details !== undefined) {
+    response.details = details;
+  }
+  if (stack !== undefined) {
+    response.stack = stack;
+  }
+  return response;
+}
+
 export function errorHandler(
   error: FastifyError | (Error & { statusCode?: number }),
   request: FastifyRequest,
@@ -65,22 +90,37 @@ export function errorHandler(
   );
 
   if (error instanceof AppError) {
-    reply.status(error.statusCode).send({ error: error.message });
+    reply
+      .status(error.statusCode)
+      .send(
+        buildErrorResponse(
+          error.statusCode,
+          error.message,
+          error.code ?? "INTERNAL_SERVER",
+        ),
+      );
     return;
   }
 
   if (error instanceof ZodError) {
-    reply.status(400).send({
-      error: "Validation error",
-      details: error.issues,
-    });
+    reply.status(400).send(
+      buildErrorResponse(400, "Validation error", "VALIDATION_ERROR", {
+        issues: error.issues,
+      }),
+    );
     return;
   }
 
   if (isMongooseCastError(error)) {
-    reply.status(400).send({
-      error: `Invalid ${error.path}: ${String(error.value)}`,
-    });
+    reply
+      .status(400)
+      .send(
+        buildErrorResponse(
+          400,
+          `Invalid ${error.path}: ${String(error.value)}`,
+          "INVALID_FIELD",
+        ),
+      );
     return;
   }
 
@@ -89,24 +129,30 @@ export function errorHandler(
       field,
       message: err.message,
     }));
-    reply.status(400).send({
-      error: "Validation failed",
-      details,
-    });
+    reply
+      .status(400)
+      .send(
+        buildErrorResponse(
+          400,
+          "Validation failed",
+          "VALIDATION_FAILED",
+          details,
+        ),
+      );
     return;
   }
 
   if (isMongoDuplicateKeyError(error)) {
-    reply.status(409).send({
-      error: "Duplicate entry",
-    });
+    reply
+      .status(409)
+      .send(buildErrorResponse(409, "Duplicate entry", "DUPLICATE_ENTRY"));
     return;
   }
 
   if (isFastifyBodyError(error)) {
-    reply.status(400).send({
-      error: error.message,
-    });
+    reply
+      .status(400)
+      .send(buildErrorResponse(400, error.message, "INVALID_BODY"));
     return;
   }
 
@@ -114,17 +160,30 @@ export function errorHandler(
     ("statusCode" in error ? error.statusCode : undefined) ?? 500;
 
   if (statusCode !== 500) {
-    reply.status(statusCode).send({ error: error.message });
+    reply
+      .status(statusCode)
+      .send(buildErrorResponse(statusCode, error.message, "HTTP_ERROR"));
     return;
   }
 
   if (isDev) {
-    reply.status(500).send({
-      error: error.message,
-      stack: error.stack,
-    });
+    reply
+      .status(500)
+      .send(
+        buildErrorResponse(
+          500,
+          error.message,
+          "INTERNAL_SERVER_ERROR",
+          undefined,
+          error.stack,
+        ),
+      );
     return;
   }
 
-  reply.status(500).send({ error: "Internal server error" });
+  reply
+    .status(500)
+    .send(
+      buildErrorResponse(500, "Internal server error", "INTERNAL_SERVER_ERROR"),
+    );
 }

--- a/apps/backend/src/modules/categories/category.cache.ts
+++ b/apps/backend/src/modules/categories/category.cache.ts
@@ -6,6 +6,8 @@ export const categoryCache = {
     list: (filters: CategoryQuery) =>
       `list:${hashFilters({
         sort: filters.sort,
+        page: filters.page,
+        limit: filters.limit,
       })}`,
     allPattern: () => "*",
   },

--- a/apps/backend/src/modules/categories/category.repository.ts
+++ b/apps/backend/src/modules/categories/category.repository.ts
@@ -5,7 +5,13 @@ import type {
 } from "@recipes/shared";
 import type { CreateInput, UpdateInput } from "@/common/base.repository.js";
 import { BaseRepository } from "@/common/base.repository.js";
-import { withSort } from "@/common/utils/mongoose.aggregation.js";
+import type { WithTotalCountResult } from "@/common/utils/mongoose.aggregation.js";
+import {
+  extractTotalCountResult,
+  withPagination,
+  withSort,
+  withTotalCount,
+} from "@/common/utils/mongoose.aggregation.js";
 import { recipesCollectionName } from "@/modules/recipes/recipe.model.js";
 import type { CategoryDocument } from "./category.model.js";
 
@@ -22,8 +28,10 @@ export class CategoryRepository extends BaseRepository<
 > {
   async findMany(
     query: CategoryQuery,
-  ): Promise<Array<CategoryDocument & CategoryComputed>> {
-    return this.aggregate<CategoryDocument & CategoryComputed>([
+  ): Promise<[Array<CategoryDocument & CategoryComputed>, number]> {
+    const result = await this.aggregate<
+      WithTotalCountResult<CategoryDocument & CategoryComputed>
+    >([
       {
         $lookup: {
           from: recipesCollectionName,
@@ -34,7 +42,12 @@ export class CategoryRepository extends BaseRepository<
       },
       { $addFields: { recipeCount: { $size: "$recipes" } } },
       { $project: { recipes: 0 } },
-      ...withSort(query.sort),
+      ...withTotalCount(
+        ...withSort(query.sort),
+        ...withPagination(query.page, query.limit),
+      ),
     ]);
+
+    return extractTotalCountResult(result);
   }
 }

--- a/apps/backend/src/modules/categories/category.routes.ts
+++ b/apps/backend/src/modules/categories/category.routes.ts
@@ -3,10 +3,10 @@ import {
   categoryQuerySchema,
   categorySchema,
   createCategorySchema,
+  paginatedSchema,
 } from "@recipes/shared";
 import type { FastifyPluginAsync } from "fastify";
 import type { ZodTypeProvider } from "fastify-type-provider-zod";
-import { z } from "zod";
 import {
   assertAuthenticated,
   authGuard,
@@ -31,18 +31,20 @@ export const categoryRoutes: FastifyPluginAsync<CategoryModuleOptions> = async (
         schema: {
           querystring: categoryQuerySchema,
           response: {
-            200: z.array(categorySchema.extend(categoryComputedSchema.shape)),
+            200: paginatedSchema(
+              categorySchema.extend(categoryComputedSchema.shape),
+            ),
           },
           tags: ["Categories"],
           summary: "Get all categories",
         },
       },
       async (request, reply) => {
-        const categories = await service.findAll({
+        const result = await service.findAll({
           query: request.query,
           initiator: { id: request.user?.userId, role: request.user?.role },
         });
-        return reply.send(categories);
+        return reply.send(result);
       },
     )
     .post(

--- a/apps/backend/src/modules/categories/category.service.test.ts
+++ b/apps/backend/src/modules/categories/category.service.test.ts
@@ -1,4 +1,3 @@
-import type { CategoryQuery } from "@recipes/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createCategoryDoc,
@@ -38,7 +37,7 @@ describe("categoryService", () => {
   });
 
   describe("findAll", () => {
-    it("should return all categories sorted by name with recipe count", async () => {
+    it("should return paginated categories sorted by name with recipe count", async () => {
       const docs = [
         {
           ...createCategoryDoc({ name: "Desserts", slug: "desserts" }),
@@ -49,32 +48,34 @@ describe("categoryService", () => {
           recipeCount: 0,
         },
       ];
-      categoryRepository.findMany.mockResolvedValue(docs);
+      categoryRepository.findMany.mockResolvedValue([docs, 2]);
 
-      const query = { sort: "name" } satisfies CategoryQuery;
+      const query = { sort: "name" as const, page: 1, limit: 10 };
       const result = await service.findAll({
         query,
         initiator: noInitiator(),
       });
 
       expect(categoryRepository.findMany).toHaveBeenCalledWith(query);
-      expect(result).toHaveLength(2);
-      expect(result[0]?.name).toBe("Desserts");
-      expect(result[0]?.recipeCount).toBe(5);
-      expect(result[1]?.recipeCount).toBe(0);
+      expect(result.items).toHaveLength(2);
+      expect(result.items[0]?.name).toBe("Desserts");
+      expect(result.items[0]?.recipeCount).toBe(5);
+      expect(result.items[1]?.recipeCount).toBe(0);
+      expect(result.pagination.total).toBe(2);
       expect(cache.get).toHaveBeenCalledWith(categoryCache.keys.list(query));
     });
 
-    it("should return empty array when no categories exist", async () => {
-      categoryRepository.findMany.mockResolvedValue([]);
+    it("should return empty paginated result when no categories exist", async () => {
+      categoryRepository.findMany.mockResolvedValue([[], 0]);
 
-      const query = { sort: "name" } satisfies CategoryQuery;
+      const query = { sort: "name" as const, page: 1, limit: 10 };
       const result = await service.findAll({
         query,
         initiator: noInitiator(),
       });
 
-      expect(result).toEqual([]);
+      expect(result.items).toEqual([]);
+      expect(result.pagination.total).toBe(0);
     });
 
     it("should return cached result on second call", async () => {
@@ -84,9 +85,9 @@ describe("categoryService", () => {
           recipeCount: 3,
         },
       ];
-      categoryRepository.findMany.mockResolvedValue(docs);
+      categoryRepository.findMany.mockResolvedValue([docs, 1]);
 
-      const query = { sort: "name" } satisfies CategoryQuery;
+      const query = { sort: "name" as const, page: 1, limit: 10 };
       await service.findAll({
         query,
         initiator: noInitiator(),
@@ -100,7 +101,8 @@ describe("categoryService", () => {
       });
 
       expect(categoryRepository.findMany).not.toHaveBeenCalled();
-      expect(result).toHaveLength(1);
+      expect(result.items).toHaveLength(1);
+      expect(result.pagination.total).toBe(1);
       expect(cache.get).toHaveBeenCalledWith(categoryCache.keys.list(query));
     });
   });

--- a/apps/backend/src/modules/categories/category.service.ts
+++ b/apps/backend/src/modules/categories/category.service.ts
@@ -3,7 +3,9 @@ import type {
   CategoryQuery,
   CategoryWithComputed,
   CreateCategoryBody,
+  Paginated,
 } from "@recipes/shared";
+import { withPagination } from "@recipes/shared";
 import type { CacheService } from "@/common/cache/cache.service.js";
 import { ConflictError, NotFoundError } from "@/common/errors.js";
 import type { TypedEmitter } from "@/common/events.js";
@@ -20,7 +22,7 @@ import type { RecipeRepository } from "@/modules/recipes/recipe.repository.js";
 export interface CategoryService {
   findAll(
     params: QueryMethodParams<CategoryQuery>,
-  ): Promise<CategoryWithComputed[]>;
+  ): Promise<Paginated<CategoryWithComputed>>;
   create(params: CreateMethodParams<CreateCategoryBody>): Promise<Category>;
   deleteById(id: string, params: DeleteMethodParams): Promise<void>;
 }
@@ -35,13 +37,18 @@ export function createCategoryService(
     findAll: async ({ query }) => {
       const cacheKey = categoryCache.keys.list(query);
 
-      const cached = await cache.get<CategoryWithComputed[]>(cacheKey);
+      const cached = await cache.get<Paginated<CategoryWithComputed>>(cacheKey);
       if (cached !== undefined) {
         return cached;
       }
 
-      const categories = await repository.findMany(query);
-      const result = categories.map(toCategory);
+      const [categories, total] = await repository.findMany(query);
+      const result = withPagination(
+        categories.map(toCategory),
+        total,
+        query.page,
+        query.limit,
+      );
 
       await cache.set(cacheKey, result, categoryCache.ttl.list);
 

--- a/apps/frontend/src/common/api/client.ts
+++ b/apps/frontend/src/common/api/client.ts
@@ -1,12 +1,20 @@
 const TOKEN_KEY = "auth_token";
 
 export class ApiError extends Error {
+  code: string;
+
   constructor(
     public status: number,
     public statusText: string,
-    public body: unknown,
+    public body: {
+      error: string;
+      code: string;
+      status: number;
+      details?: unknown;
+    },
   ) {
-    super(`API Error ${status}: ${statusText}`);
+    super(body.error || `API Error ${status}: ${statusText}`);
+    this.code = body.code || "UNKNOWN_ERROR";
   }
 }
 
@@ -24,12 +32,29 @@ export function removeToken(): void {
 
 async function handleResponse<T>(response: Response): Promise<T> {
   if (!response.ok) {
-    let body: unknown;
+    let raw: unknown;
     try {
-      body = await response.json();
+      raw = await response.json();
     } catch {
-      body = null;
+      raw = null;
     }
+    const body =
+      typeof raw === "object" &&
+      raw !== null &&
+      "error" in raw &&
+      "code" in raw &&
+      "status" in raw
+        ? (raw as {
+            error: string;
+            code: string;
+            status: number;
+            details?: unknown;
+          })
+        : {
+            error: "Unknown error",
+            code: "UNKNOWN_ERROR",
+            status: response.status,
+          };
     throw new ApiError(response.status, response.statusText, body);
   }
 

--- a/apps/frontend/src/features/categories/categories.api.ts
+++ b/apps/frontend/src/features/categories/categories.api.ts
@@ -1,10 +1,14 @@
-import type { CategoryQuery, CategoryWithComputed } from "@recipes/shared";
+import type {
+  CategoryQuery,
+  CategoryWithComputed,
+  Paginated,
+} from "@recipes/shared";
 import { apiClient } from "@/common/api/client";
 
 export function getCategories(
   filters: Partial<CategoryQuery> = {},
-): Promise<CategoryWithComputed[]> {
-  return apiClient<CategoryWithComputed[]>("/api/categories", {
+): Promise<Paginated<CategoryWithComputed>> {
+  return apiClient<Paginated<CategoryWithComputed>>("/api/categories", {
     method: "GET",
     query: filters,
   });

--- a/apps/frontend/src/features/categories/views/CategoriesGrid.vue
+++ b/apps/frontend/src/features/categories/views/CategoriesGrid.vue
@@ -27,7 +27,7 @@ const props = defineProps<{
 
     <template v-else-if="categories">
       <Category
-        v-for="(category, index) in categories.slice(0, 6)"
+        v-for="(category, index) in categories"
         :key="category.id"
         :category
         :style="{ animationDelay: `${index * 80}ms` }"

--- a/apps/frontend/src/pages/Home.vue
+++ b/apps/frontend/src/pages/Home.vue
@@ -20,11 +20,12 @@ onMounted(() => {
   });
 });
 
+const CATEGORIES_LIMIT = 6;
 const {
   data: categories,
   isLoading: isCategoriesLoading,
   error: categoriesError,
-} = useCategories({ sort: "-recipeCount" });
+} = useCategories({ sort: "-recipeCount", limit: CATEGORIES_LIMIT });
 
 const { data: testimonials, isLoading: isTestimonialsLoading } =
   useTestimonials();
@@ -93,7 +94,7 @@ const featuredRecipes = [
         />
 
         <CategoriesGrid
-          :categories
+          :categories="categories?.items"
           :isLoading="isCategoriesLoading"
           :error="categoriesError"
         />

--- a/packages/shared/src/categories/category.schema.ts
+++ b/packages/shared/src/categories/category.schema.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { createSortSchema } from "../query.js";
+import { createSortSchema, paginationQuerySchema } from "../query.js";
 
 export const createCategorySchema = z.object({
   name: z.string().trim().min(2).max(50),
@@ -27,6 +27,8 @@ export const categorySummarySchema = categorySchema.pick({
   slug: true,
 });
 
-export const categoryQuerySchema = z.object({
-  sort: createSortSchema(["name", "recipeCount"]).default("name"),
-});
+export const categoryQuerySchema = z
+  .object({
+    sort: createSortSchema(["name", "recipeCount"]).default("name"),
+  })
+  .extend(paginationQuerySchema.shape);


### PR DESCRIPTION
## Related Issues

<!-- Link related issues: Closes #123, Refs #456 -->

## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring
- [ ] Tests
- [ ] Other

## Description

Standardized API response format across the backend:

### Categories (paginated)
- `GET /api/categories` now returns `Paginated<CategoryWithComputed>` instead of raw array
- Added `page` and `limit` support to `CategoryQuery` schema
- Updated repository aggregation to use `withPagination` and `withTotalCount`
- Frontend `useCategories` and `CategoriesGrid` updated to work with paginated response

### Error responses (standardized)
All error responses now follow a consistent format:
```json
{
  "error": "human readable message",
  "code": "MACHINE_READABLE_CODE",
  "status": 400
}
```

Error codes:
- AppErrors use their internal `code` (e.g. `NOT_FOUND`, `CONFLICT`)
- Zod validation → `VALIDATION_ERROR`
- Mongoose CastError → `INVALID_FIELD`
- Mongoose ValidationError → `VALIDATION_FAILED`
- MongoDB duplicate key → `DUPLICATE_ENTRY`
- Fastify body parse error → `INVALID_BODY`
- Generic non-500 → `HTTP_ERROR`
- 500 → `INTERNAL_SERVER`

### Frontend
- `ApiError` now exposes `code` property from error response body
- Safe fallback when backend returns non-standard error JSON

## Screenshots

<!-- If applicable, add screenshots or recordings of the changes -->

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Added/updated tests for new functionality
- [ ] Updated documentation (if needed)