### PR TITLE
test(backend): add integration tests for all HTTP routes

### DIFF
--- a/apps/backend/src/__tests__/build-test-app.ts
+++ b/apps/backend/src/__tests__/build-test-app.ts
@@ -1,0 +1,19 @@
+import Fastify from "fastify";
+import {
+  serializerCompiler,
+  validatorCompiler,
+} from "fastify-type-provider-zod";
+import { errorHandler } from "@/common/middleware/errorHandler.js";
+import type { JwtPayload } from "@/common/utils/jwt.js";
+
+export function createTestApp() {
+  const app = Fastify({ logger: false });
+  app.setValidatorCompiler(validatorCompiler);
+  app.setSerializerCompiler(serializerCompiler);
+  app.setErrorHandler(errorHandler);
+  return app;
+}
+
+export function authHeader(payload: JwtPayload): { authorization: string } {
+  return { authorization: `Bearer fake-token-${payload.userId}` };
+}

--- a/apps/backend/src/common/middleware/errorHandler.ts
+++ b/apps/backend/src/common/middleware/errorHandler.ts
@@ -45,6 +45,26 @@ function isFastifyBodyError(error: unknown): boolean {
   );
 }
 
+export type FastifyValidationError = FastifyError & {
+  validation: {
+    keyword: string;
+    instancePath: string;
+    message: string;
+  }[];
+};
+
+function isFastifyValidationError(
+  error: unknown,
+): error is FastifyValidationError {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    typeof (error as { code: string }).code === "string" &&
+    (error as { code: string }).code.startsWith("FST_ERR_VALIDATION")
+  );
+}
+
 interface ErrorResponse {
   error: string;
   code: string;
@@ -99,6 +119,21 @@ export function errorHandler(
           error.code ?? "INTERNAL_SERVER",
         ),
       );
+    return;
+  }
+
+  if (isFastifyValidationError(error)) {
+    reply.status(400).send(
+      buildErrorResponse(
+        400,
+        "Validation error",
+        "VALIDATION_ERROR",
+        error.validation.map(({ message, instancePath }) => ({
+          message,
+          field: instancePath.split("/").pop(),
+        })),
+      ),
+    );
     return;
   }
 

--- a/apps/backend/src/modules/auth/auth.routes.test.ts
+++ b/apps/backend/src/modules/auth/auth.routes.test.ts
@@ -1,3 +1,4 @@
+import type { FastifyInstance } from "fastify";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createTestApp } from "@/__tests__/build-test-app.js";
 import { authRoutes } from "@/modules/auth/auth.routes.js";
@@ -14,19 +15,19 @@ describe("authRoutes", () => {
     login: vi.fn(),
   };
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
+  let app: FastifyInstance;
 
-  function buildApp() {
-    const app = createTestApp();
-    app.register(authRoutes, { service: mockAuthService, prefix: "/api/auth" });
-    return app;
-  }
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = createTestApp();
+    await app.register(authRoutes, {
+      service: mockAuthService,
+      prefix: "/api/auth",
+    });
+  });
 
   describe("POST /api/auth/register", () => {
     it("should register a new user and return 201", async () => {
-      const app = buildApp();
       const payload = {
         email: "new@test.com",
         password: "Password123!",
@@ -57,7 +58,6 @@ describe("authRoutes", () => {
     });
 
     it("should return 400 for invalid email", async () => {
-      const app = buildApp();
       const response = await app.inject({
         method: "POST",
         url: "/api/auth/register",
@@ -70,7 +70,6 @@ describe("authRoutes", () => {
     });
 
     it("should return 400 for short password", async () => {
-      const app = buildApp();
       const response = await app.inject({
         method: "POST",
         url: "/api/auth/register",
@@ -87,7 +86,6 @@ describe("authRoutes", () => {
     });
 
     it("should return 409 when email already exists", async () => {
-      const app = buildApp();
       mockAuthService.register.mockRejectedValue(
         Object.assign(new Error("Email already in use"), {
           statusCode: 409,
@@ -111,7 +109,6 @@ describe("authRoutes", () => {
 
   describe("POST /api/auth/login", () => {
     it("should login and return 200 with token", async () => {
-      const app = buildApp();
       mockAuthService.login.mockResolvedValue({
         user: {
           id: "507f1f77bcf86cd799439011",
@@ -140,7 +137,6 @@ describe("authRoutes", () => {
     });
 
     it("should return 400 for invalid email format", async () => {
-      const app = buildApp();
       const response = await app.inject({
         method: "POST",
         url: "/api/auth/login",
@@ -153,7 +149,6 @@ describe("authRoutes", () => {
     });
 
     it("should return 401 when credentials are wrong", async () => {
-      const app = buildApp();
       mockAuthService.login.mockRejectedValue(
         Object.assign(new Error("Invalid email or password"), {
           statusCode: 401,

--- a/apps/backend/src/modules/auth/auth.routes.test.ts
+++ b/apps/backend/src/modules/auth/auth.routes.test.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestApp } from "@/__tests__/build-test-app.js";
+import { authRoutes } from "@/modules/auth/auth.routes.js";
+
+const { verifyToken } = vi.hoisted(() => ({
+  verifyToken: vi.fn(),
+}));
+
+vi.mock("@/common/utils/jwt.js", () => ({ verifyToken }));
+
+describe("authRoutes", () => {
+  const mockAuthService = {
+    register: vi.fn(),
+    login: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function buildApp() {
+    const app = createTestApp();
+    app.register(authRoutes, { service: mockAuthService, prefix: "/api/auth" });
+    return app;
+  }
+
+  describe("POST /api/auth/register", () => {
+    it("should register a new user and return 201", async () => {
+      const app = buildApp();
+      const payload = {
+        email: "new@test.com",
+        password: "Password123!",
+        name: "New User",
+      };
+      mockAuthService.register.mockResolvedValue({
+        user: {
+          id: "507f1f77bcf86cd799439011",
+          email: payload.email,
+          name: payload.name,
+          createdAt: "2024-01-01T00:00:00.000Z",
+          updatedAt: "2024-01-01T00:00:00.000Z",
+        },
+        token: "mock-jwt-token",
+      });
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/auth/register",
+        payload,
+      });
+
+      expect(response.statusCode).toBe(201);
+      expect(mockAuthService.register).toHaveBeenCalledWith(payload);
+      const body = JSON.parse(response.payload);
+      expect(body.user.email).toBe(payload.email);
+      expect(body.token).toBe("mock-jwt-token");
+    });
+
+    it("should return 400 for invalid email", async () => {
+      const app = buildApp();
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/auth/register",
+        payload: { email: "not-an-email", password: "pass", name: "A" },
+      });
+
+      expect(response.statusCode).toBe(400);
+      const body = JSON.parse(response.payload);
+      expect(body.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("should return 400 for short password", async () => {
+      const app = buildApp();
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/auth/register",
+        payload: {
+          email: "test@test.com",
+          password: "123",
+          name: "Test User",
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+      const body = JSON.parse(response.payload);
+      expect(body.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("should return 409 when email already exists", async () => {
+      const app = buildApp();
+      mockAuthService.register.mockRejectedValue(
+        Object.assign(new Error("Email already in use"), {
+          statusCode: 409,
+          code: "CONFLICT",
+        }),
+      );
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/auth/register",
+        payload: {
+          email: "existing@test.com",
+          password: "Password123!",
+          name: "Existing",
+        },
+      });
+
+      expect(response.statusCode).toBe(409);
+    });
+  });
+
+  describe("POST /api/auth/login", () => {
+    it("should login and return 200 with token", async () => {
+      const app = buildApp();
+      mockAuthService.login.mockResolvedValue({
+        user: {
+          id: "507f1f77bcf86cd799439011",
+          email: "user@test.com",
+          name: "User",
+          createdAt: "2024-01-01T00:00:00.000Z",
+          updatedAt: "2024-01-01T00:00:00.000Z",
+        },
+        token: "mock-jwt-token",
+      });
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/auth/login",
+        payload: { email: "user@test.com", password: "correct-password" },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(mockAuthService.login).toHaveBeenCalledWith({
+        email: "user@test.com",
+        password: "correct-password",
+      });
+      const body = JSON.parse(response.payload);
+      expect(body.user.email).toBe("user@test.com");
+      expect(body.token).toBe("mock-jwt-token");
+    });
+
+    it("should return 400 for invalid email format", async () => {
+      const app = buildApp();
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/auth/login",
+        payload: { email: "bad-email", password: "pass" },
+      });
+
+      expect(response.statusCode).toBe(400);
+      const body = JSON.parse(response.payload);
+      expect(body.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("should return 401 when credentials are wrong", async () => {
+      const app = buildApp();
+      mockAuthService.login.mockRejectedValue(
+        Object.assign(new Error("Invalid email or password"), {
+          statusCode: 401,
+          code: "UNAUTHORIZED",
+        }),
+      );
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/auth/login",
+        payload: { email: "wrong@test.com", password: "wrong" },
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+  });
+});

--- a/apps/backend/src/modules/auth/auth.routes.test.ts
+++ b/apps/backend/src/modules/auth/auth.routes.test.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createTestApp } from "@/__tests__/build-test-app.js";
+import { ConflictError, UnauthorizedError } from "@/common/errors.js";
 import { authRoutes } from "@/modules/auth/auth.routes.js";
 
 const { verifyToken } = vi.hoisted(() => ({
@@ -87,10 +88,7 @@ describe("authRoutes", () => {
 
     it("should return 409 when email already exists", async () => {
       mockAuthService.register.mockRejectedValue(
-        Object.assign(new Error("Email already in use"), {
-          statusCode: 409,
-          code: "CONFLICT",
-        }),
+        new ConflictError("Email already in use"),
       );
 
       const response = await app.inject({
@@ -150,10 +148,7 @@ describe("authRoutes", () => {
 
     it("should return 401 when credentials are wrong", async () => {
       mockAuthService.login.mockRejectedValue(
-        Object.assign(new Error("Invalid email or password"), {
-          statusCode: 401,
-          code: "UNAUTHORIZED",
-        }),
+        new UnauthorizedError("Invalid email or password"),
       );
 
       const response = await app.inject({

--- a/apps/backend/src/modules/categories/category.routes.test.ts
+++ b/apps/backend/src/modules/categories/category.routes.test.ts
@@ -29,6 +29,18 @@ describe("categoryRoutes", () => {
     updatedAt: "2024-01-01T00:00:00.000Z",
   };
 
+  const testJwtPayload = {
+    userId,
+    email: "user@test.com",
+    role: "user",
+  } as const;
+
+  const testAdminJwtPayload = {
+    userId: adminId,
+    email: "admin@test.com",
+    role: "admin",
+  } as const;
+
   let app: FastifyInstance;
 
   beforeEach(async () => {
@@ -77,28 +89,23 @@ describe("categoryRoutes", () => {
 
   describe("POST /api/categories", () => {
     it("should create category when admin", async () => {
-      verifyToken.mockReturnValue({
-        userId: adminId,
-        email: "admin@test.com",
-        role: "admin",
-      });
+      verifyToken.mockReturnValue(testAdminJwtPayload);
       mockCategoryService.create.mockResolvedValue(validCategory);
 
       const response = await app.inject({
         method: "POST",
         url: "/api/categories",
         payload: { name: "Desserts" },
-        headers: authHeader({
-          userId: adminId,
-          email: "admin@test.com",
-          role: "admin",
-        }),
+        headers: authHeader(testAdminJwtPayload),
       });
 
       expect(response.statusCode).toBe(201);
       expect(mockCategoryService.create).toHaveBeenCalledWith({
         data: { name: "Desserts" },
-        initiator: { id: adminId, role: "admin" },
+        initiator: {
+          id: testAdminJwtPayload.userId,
+          role: testAdminJwtPayload.role,
+        },
       });
     });
 
@@ -113,38 +120,26 @@ describe("categoryRoutes", () => {
     });
 
     it("should return 403 when not admin", async () => {
-      verifyToken.mockReturnValue({
-        userId,
-        email: "user@test.com",
-        role: "user",
-      });
+      verifyToken.mockReturnValue(testJwtPayload);
 
       const response = await app.inject({
         method: "POST",
         url: "/api/categories",
         payload: { name: "Desserts" },
-        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+        headers: authHeader(testJwtPayload),
       });
 
       expect(response.statusCode).toBe(403);
     });
 
     it("should return 400 for invalid body", async () => {
-      verifyToken.mockReturnValue({
-        userId: adminId,
-        email: "admin@test.com",
-        role: "admin",
-      });
+      verifyToken.mockReturnValue(testAdminJwtPayload);
 
       const response = await app.inject({
         method: "POST",
         url: "/api/categories",
         payload: { name: "" },
-        headers: authHeader({
-          userId: adminId,
-          email: "admin@test.com",
-          role: "admin",
-        }),
+        headers: authHeader(testAdminJwtPayload),
       });
 
       expect(response.statusCode).toBe(400);
@@ -155,26 +150,21 @@ describe("categoryRoutes", () => {
 
   describe("DELETE /api/categories/:id", () => {
     it("should delete category when admin", async () => {
-      verifyToken.mockReturnValue({
-        userId: adminId,
-        email: "admin@test.com",
-        role: "admin",
-      });
+      verifyToken.mockReturnValue(testAdminJwtPayload);
       mockCategoryService.deleteById.mockResolvedValue(undefined);
 
       const response = await app.inject({
         method: "DELETE",
         url: `/api/categories/${categoryId}`,
-        headers: authHeader({
-          userId: adminId,
-          email: "admin@test.com",
-          role: "admin",
-        }),
+        headers: authHeader(testAdminJwtPayload),
       });
 
       expect(response.statusCode).toBe(204);
       expect(mockCategoryService.deleteById).toHaveBeenCalledWith(categoryId, {
-        initiator: { id: adminId, role: "admin" },
+        initiator: {
+          id: testAdminJwtPayload.userId,
+          role: testAdminJwtPayload.role,
+        },
       });
     });
 
@@ -188,36 +178,24 @@ describe("categoryRoutes", () => {
     });
 
     it("should return 403 when not admin", async () => {
-      verifyToken.mockReturnValue({
-        userId,
-        email: "user@test.com",
-        role: "user",
-      });
+      verifyToken.mockReturnValue(testJwtPayload);
 
       const response = await app.inject({
         method: "DELETE",
         url: `/api/categories/${categoryId}`,
-        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+        headers: authHeader(testJwtPayload),
       });
 
       expect(response.statusCode).toBe(403);
     });
 
     it("should return 400 for invalid id", async () => {
-      verifyToken.mockReturnValue({
-        userId: adminId,
-        email: "admin@test.com",
-        role: "admin",
-      });
+      verifyToken.mockReturnValue(testAdminJwtPayload);
 
       const response = await app.inject({
         method: "DELETE",
         url: "/api/categories/bad-id",
-        headers: authHeader({
-          userId: adminId,
-          email: "admin@test.com",
-          role: "admin",
-        }),
+        headers: authHeader(testAdminJwtPayload),
       });
 
       expect(response.statusCode).toBe(400);

--- a/apps/backend/src/modules/categories/category.routes.test.ts
+++ b/apps/backend/src/modules/categories/category.routes.test.ts
@@ -1,5 +1,6 @@
+import type { FastifyInstance } from "fastify";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createTestApp, authHeader } from "@/__tests__/build-test-app.js";
+import { authHeader, createTestApp } from "@/__tests__/build-test-app.js";
 import { categoryRoutes } from "@/modules/categories/category.routes.js";
 
 const { verifyToken } = vi.hoisted(() => ({
@@ -28,22 +29,29 @@ describe("categoryRoutes", () => {
     updatedAt: "2024-01-01T00:00:00.000Z",
   };
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
+  let app: FastifyInstance;
 
-  function buildApp() {
-    const app = createTestApp();
-    app.register(categoryRoutes, { service: mockCategoryService, prefix: "/api/categories" });
-    return app;
-  }
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = createTestApp();
+    await app.register(categoryRoutes, {
+      service: mockCategoryService,
+      prefix: "/api/categories",
+    });
+  });
 
   describe("GET /api/categories", () => {
     it("should return paginated categories", async () => {
-      const app = buildApp();
       mockCategoryService.findAll.mockResolvedValue({
         items: [{ ...validCategory, recipeCount: 5 }],
-        pagination: { page: 1, limit: 10, total: 1, totalPages: 1, hasNext: false, hasPrev: false },
+        pagination: {
+          page: 1,
+          limit: 10,
+          total: 1,
+          totalPages: 1,
+          hasNext: false,
+          hasPrev: false,
+        },
       });
 
       const response = await app.inject({
@@ -58,7 +66,6 @@ describe("categoryRoutes", () => {
     });
 
     it("should return 400 for invalid query", async () => {
-      const app = buildApp();
       const response = await app.inject({
         method: "GET",
         url: "/api/categories?page=abc",
@@ -70,15 +77,22 @@ describe("categoryRoutes", () => {
 
   describe("POST /api/categories", () => {
     it("should create category when admin", async () => {
-      const app = buildApp();
-      verifyToken.mockReturnValue({ userId: adminId, email: "admin@test.com", role: "admin" });
+      verifyToken.mockReturnValue({
+        userId: adminId,
+        email: "admin@test.com",
+        role: "admin",
+      });
       mockCategoryService.create.mockResolvedValue(validCategory);
 
       const response = await app.inject({
         method: "POST",
         url: "/api/categories",
         payload: { name: "Desserts" },
-        headers: authHeader({ userId: adminId, email: "admin@test.com", role: "admin" }),
+        headers: authHeader({
+          userId: adminId,
+          email: "admin@test.com",
+          role: "admin",
+        }),
       });
 
       expect(response.statusCode).toBe(201);
@@ -89,7 +103,6 @@ describe("categoryRoutes", () => {
     });
 
     it("should return 401 when not authenticated", async () => {
-      const app = buildApp();
       const response = await app.inject({
         method: "POST",
         url: "/api/categories",
@@ -100,8 +113,11 @@ describe("categoryRoutes", () => {
     });
 
     it("should return 403 when not admin", async () => {
-      const app = buildApp();
-      verifyToken.mockReturnValue({ userId, email: "user@test.com", role: "user" });
+      verifyToken.mockReturnValue({
+        userId,
+        email: "user@test.com",
+        role: "user",
+      });
 
       const response = await app.inject({
         method: "POST",
@@ -114,14 +130,21 @@ describe("categoryRoutes", () => {
     });
 
     it("should return 400 for invalid body", async () => {
-      const app = buildApp();
-      verifyToken.mockReturnValue({ userId: adminId, email: "admin@test.com", role: "admin" });
+      verifyToken.mockReturnValue({
+        userId: adminId,
+        email: "admin@test.com",
+        role: "admin",
+      });
 
       const response = await app.inject({
         method: "POST",
         url: "/api/categories",
         payload: { name: "" },
-        headers: authHeader({ userId: adminId, email: "admin@test.com", role: "admin" }),
+        headers: authHeader({
+          userId: adminId,
+          email: "admin@test.com",
+          role: "admin",
+        }),
       });
 
       expect(response.statusCode).toBe(400);
@@ -132,14 +155,21 @@ describe("categoryRoutes", () => {
 
   describe("DELETE /api/categories/:id", () => {
     it("should delete category when admin", async () => {
-      const app = buildApp();
-      verifyToken.mockReturnValue({ userId: adminId, email: "admin@test.com", role: "admin" });
+      verifyToken.mockReturnValue({
+        userId: adminId,
+        email: "admin@test.com",
+        role: "admin",
+      });
       mockCategoryService.deleteById.mockResolvedValue(undefined);
 
       const response = await app.inject({
         method: "DELETE",
         url: `/api/categories/${categoryId}`,
-        headers: authHeader({ userId: adminId, email: "admin@test.com", role: "admin" }),
+        headers: authHeader({
+          userId: adminId,
+          email: "admin@test.com",
+          role: "admin",
+        }),
       });
 
       expect(response.statusCode).toBe(204);
@@ -149,7 +179,6 @@ describe("categoryRoutes", () => {
     });
 
     it("should return 401 when not authenticated", async () => {
-      const app = buildApp();
       const response = await app.inject({
         method: "DELETE",
         url: `/api/categories/${categoryId}`,
@@ -159,8 +188,11 @@ describe("categoryRoutes", () => {
     });
 
     it("should return 403 when not admin", async () => {
-      const app = buildApp();
-      verifyToken.mockReturnValue({ userId, email: "user@test.com", role: "user" });
+      verifyToken.mockReturnValue({
+        userId,
+        email: "user@test.com",
+        role: "user",
+      });
 
       const response = await app.inject({
         method: "DELETE",
@@ -172,13 +204,20 @@ describe("categoryRoutes", () => {
     });
 
     it("should return 400 for invalid id", async () => {
-      const app = buildApp();
-      verifyToken.mockReturnValue({ userId: adminId, email: "admin@test.com", role: "admin" });
+      verifyToken.mockReturnValue({
+        userId: adminId,
+        email: "admin@test.com",
+        role: "admin",
+      });
 
       const response = await app.inject({
         method: "DELETE",
         url: "/api/categories/bad-id",
-        headers: authHeader({ userId: adminId, email: "admin@test.com", role: "admin" }),
+        headers: authHeader({
+          userId: adminId,
+          email: "admin@test.com",
+          role: "admin",
+        }),
       });
 
       expect(response.statusCode).toBe(400);

--- a/apps/backend/src/modules/categories/category.routes.test.ts
+++ b/apps/backend/src/modules/categories/category.routes.test.ts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestApp, authHeader } from "@/__tests__/build-test-app.js";
+import { categoryRoutes } from "@/modules/categories/category.routes.js";
+
+const { verifyToken } = vi.hoisted(() => ({
+  verifyToken: vi.fn(),
+}));
+
+vi.mock("@/common/utils/jwt.js", () => ({ verifyToken }));
+
+describe("categoryRoutes", () => {
+  const mockCategoryService = {
+    findAll: vi.fn(),
+    create: vi.fn(),
+    deleteById: vi.fn(),
+  };
+
+  const userId = "507f1f77bcf86cd799439011";
+  const adminId = "507f1f77bcf86cd799439022";
+  const categoryId = "507f1f77bcf86cd799439033";
+
+  const validCategory = {
+    id: categoryId,
+    name: "Desserts",
+    slug: "desserts",
+    description: "Sweet dishes",
+    createdAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-01T00:00:00.000Z",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function buildApp() {
+    const app = createTestApp();
+    app.register(categoryRoutes, { service: mockCategoryService, prefix: "/api/categories" });
+    return app;
+  }
+
+  describe("GET /api/categories", () => {
+    it("should return paginated categories", async () => {
+      const app = buildApp();
+      mockCategoryService.findAll.mockResolvedValue({
+        items: [{ ...validCategory, recipeCount: 5 }],
+        pagination: { page: 1, limit: 10, total: 1, totalPages: 1, hasNext: false, hasPrev: false },
+      });
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/categories?page=1&limit=10",
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.payload);
+      expect(body.items).toHaveLength(1);
+      expect(body.items[0].name).toBe("Desserts");
+    });
+
+    it("should return 400 for invalid query", async () => {
+      const app = buildApp();
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/categories?page=abc",
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+  });
+
+  describe("POST /api/categories", () => {
+    it("should create category when admin", async () => {
+      const app = buildApp();
+      verifyToken.mockReturnValue({ userId: adminId, email: "admin@test.com", role: "admin" });
+      mockCategoryService.create.mockResolvedValue(validCategory);
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/categories",
+        payload: { name: "Desserts" },
+        headers: authHeader({ userId: adminId, email: "admin@test.com", role: "admin" }),
+      });
+
+      expect(response.statusCode).toBe(201);
+      expect(mockCategoryService.create).toHaveBeenCalledWith({
+        data: { name: "Desserts" },
+        initiator: { id: adminId, role: "admin" },
+      });
+    });
+
+    it("should return 401 when not authenticated", async () => {
+      const app = buildApp();
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/categories",
+        payload: { name: "Desserts" },
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+
+    it("should return 403 when not admin", async () => {
+      const app = buildApp();
+      verifyToken.mockReturnValue({ userId, email: "user@test.com", role: "user" });
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/categories",
+        payload: { name: "Desserts" },
+        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+      });
+
+      expect(response.statusCode).toBe(403);
+    });
+
+    it("should return 400 for invalid body", async () => {
+      const app = buildApp();
+      verifyToken.mockReturnValue({ userId: adminId, email: "admin@test.com", role: "admin" });
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/categories",
+        payload: { name: "" },
+        headers: authHeader({ userId: adminId, email: "admin@test.com", role: "admin" }),
+      });
+
+      expect(response.statusCode).toBe(400);
+      const body = JSON.parse(response.payload);
+      expect(body.code).toBe("VALIDATION_ERROR");
+    });
+  });
+
+  describe("DELETE /api/categories/:id", () => {
+    it("should delete category when admin", async () => {
+      const app = buildApp();
+      verifyToken.mockReturnValue({ userId: adminId, email: "admin@test.com", role: "admin" });
+      mockCategoryService.deleteById.mockResolvedValue(undefined);
+
+      const response = await app.inject({
+        method: "DELETE",
+        url: `/api/categories/${categoryId}`,
+        headers: authHeader({ userId: adminId, email: "admin@test.com", role: "admin" }),
+      });
+
+      expect(response.statusCode).toBe(204);
+      expect(mockCategoryService.deleteById).toHaveBeenCalledWith(categoryId, {
+        initiator: { id: adminId, role: "admin" },
+      });
+    });
+
+    it("should return 401 when not authenticated", async () => {
+      const app = buildApp();
+      const response = await app.inject({
+        method: "DELETE",
+        url: `/api/categories/${categoryId}`,
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+
+    it("should return 403 when not admin", async () => {
+      const app = buildApp();
+      verifyToken.mockReturnValue({ userId, email: "user@test.com", role: "user" });
+
+      const response = await app.inject({
+        method: "DELETE",
+        url: `/api/categories/${categoryId}`,
+        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+      });
+
+      expect(response.statusCode).toBe(403);
+    });
+
+    it("should return 400 for invalid id", async () => {
+      const app = buildApp();
+      verifyToken.mockReturnValue({ userId: adminId, email: "admin@test.com", role: "admin" });
+
+      const response = await app.inject({
+        method: "DELETE",
+        url: "/api/categories/bad-id",
+        headers: authHeader({ userId: adminId, email: "admin@test.com", role: "admin" }),
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+  });
+});

--- a/apps/backend/src/modules/favorites/favorite.routes.test.ts
+++ b/apps/backend/src/modules/favorites/favorite.routes.test.ts
@@ -1,5 +1,6 @@
+import type { FastifyInstance } from "fastify";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createTestApp, authHeader } from "@/__tests__/build-test-app.js";
+import { authHeader, createTestApp } from "@/__tests__/build-test-app.js";
 import { favoriteRoutes } from "@/modules/favorites/favorite.routes.js";
 
 const { verifyToken } = vi.hoisted(() => ({
@@ -18,20 +19,24 @@ describe("favoriteRoutes", () => {
   const userId = "507f1f77bcf86cd799439011";
   const recipeId = "507f1f77bcf86cd799439033";
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
+  let app: FastifyInstance;
 
-  function buildApp() {
-    const app = createTestApp();
-    app.register(favoriteRoutes, { service: mockFavoriteService, prefix: "/api/recipes" });
-    return app;
-  }
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = createTestApp();
+    await app.register(favoriteRoutes, {
+      service: mockFavoriteService,
+      prefix: "/api/recipes",
+    });
+  });
 
   describe("GET /api/recipes/:id/favorite", () => {
     it("should return favorited status when authenticated", async () => {
-      const app = buildApp();
-      verifyToken.mockReturnValue({ userId, email: "user@test.com", role: "user" });
+      verifyToken.mockReturnValue({
+        userId,
+        email: "user@test.com",
+        role: "user",
+      });
       mockFavoriteService.isFavorited.mockResolvedValue(true);
 
       const response = await app.inject({
@@ -49,7 +54,6 @@ describe("favoriteRoutes", () => {
     });
 
     it("should return 401 when not authenticated", async () => {
-      const app = buildApp();
       const response = await app.inject({
         method: "GET",
         url: `/api/recipes/${recipeId}/favorite`,
@@ -59,8 +63,11 @@ describe("favoriteRoutes", () => {
     });
 
     it("should return 400 for invalid recipe id", async () => {
-      const app = buildApp();
-      verifyToken.mockReturnValue({ userId, email: "user@test.com", role: "user" });
+      verifyToken.mockReturnValue({
+        userId,
+        email: "user@test.com",
+        role: "user",
+      });
 
       const response = await app.inject({
         method: "GET",
@@ -74,8 +81,11 @@ describe("favoriteRoutes", () => {
 
   describe("POST /api/recipes/:id/favorite", () => {
     it("should add favorite when authenticated", async () => {
-      const app = buildApp();
-      verifyToken.mockReturnValue({ userId, email: "user@test.com", role: "user" });
+      verifyToken.mockReturnValue({
+        userId,
+        email: "user@test.com",
+        role: "user",
+      });
       mockFavoriteService.add.mockResolvedValue({ favorited: true });
 
       const response = await app.inject({
@@ -93,7 +103,6 @@ describe("favoriteRoutes", () => {
     });
 
     it("should return 401 when not authenticated", async () => {
-      const app = buildApp();
       const response = await app.inject({
         method: "POST",
         url: `/api/recipes/${recipeId}/favorite`,
@@ -105,8 +114,11 @@ describe("favoriteRoutes", () => {
 
   describe("DELETE /api/recipes/:id/favorite", () => {
     it("should remove favorite when authenticated", async () => {
-      const app = buildApp();
-      verifyToken.mockReturnValue({ userId, email: "user@test.com", role: "user" });
+      verifyToken.mockReturnValue({
+        userId,
+        email: "user@test.com",
+        role: "user",
+      });
       mockFavoriteService.remove.mockResolvedValue({ favorited: false });
 
       const response = await app.inject({
@@ -124,7 +136,6 @@ describe("favoriteRoutes", () => {
     });
 
     it("should return 401 when not authenticated", async () => {
-      const app = buildApp();
       const response = await app.inject({
         method: "DELETE",
         url: `/api/recipes/${recipeId}/favorite`,

--- a/apps/backend/src/modules/favorites/favorite.routes.test.ts
+++ b/apps/backend/src/modules/favorites/favorite.routes.test.ts
@@ -14,10 +14,17 @@ describe("favoriteRoutes", () => {
     isFavorited: vi.fn(),
     add: vi.fn(),
     remove: vi.fn(),
+    findByUser: vi.fn(),
   };
 
   const userId = "507f1f77bcf86cd799439011";
   const recipeId = "507f1f77bcf86cd799439033";
+
+  const testJwtPayload = {
+    userId,
+    email: "user@test.com",
+    role: "user",
+  } as const;
 
   let app: FastifyInstance;
 
@@ -32,24 +39,20 @@ describe("favoriteRoutes", () => {
 
   describe("GET /api/recipes/:id/favorite", () => {
     it("should return favorited status when authenticated", async () => {
-      verifyToken.mockReturnValue({
-        userId,
-        email: "user@test.com",
-        role: "user",
-      });
+      verifyToken.mockReturnValue(testJwtPayload);
       mockFavoriteService.isFavorited.mockResolvedValue(true);
 
       const response = await app.inject({
         method: "GET",
         url: `/api/recipes/${recipeId}/favorite`,
-        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+        headers: authHeader(testJwtPayload),
       });
 
       expect(response.statusCode).toBe(200);
       const body = JSON.parse(response.payload);
       expect(body.favorited).toBe(true);
       expect(mockFavoriteService.isFavorited).toHaveBeenCalledWith(recipeId, {
-        initiator: { id: userId, role: "user" },
+        initiator: { id: testJwtPayload.userId, role: testJwtPayload.role },
       });
     });
 
@@ -63,16 +66,12 @@ describe("favoriteRoutes", () => {
     });
 
     it("should return 400 for invalid recipe id", async () => {
-      verifyToken.mockReturnValue({
-        userId,
-        email: "user@test.com",
-        role: "user",
-      });
+      verifyToken.mockReturnValue(testJwtPayload);
 
       const response = await app.inject({
         method: "GET",
         url: "/api/recipes/bad-id/favorite",
-        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+        headers: authHeader(testJwtPayload),
       });
 
       expect(response.statusCode).toBe(400);
@@ -81,24 +80,20 @@ describe("favoriteRoutes", () => {
 
   describe("POST /api/recipes/:id/favorite", () => {
     it("should add favorite when authenticated", async () => {
-      verifyToken.mockReturnValue({
-        userId,
-        email: "user@test.com",
-        role: "user",
-      });
+      verifyToken.mockReturnValue(testJwtPayload);
       mockFavoriteService.add.mockResolvedValue({ favorited: true });
 
       const response = await app.inject({
         method: "POST",
         url: `/api/recipes/${recipeId}/favorite`,
-        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+        headers: authHeader(testJwtPayload),
       });
 
       expect(response.statusCode).toBe(200);
       const body = JSON.parse(response.payload);
       expect(body.favorited).toBe(true);
       expect(mockFavoriteService.add).toHaveBeenCalledWith(recipeId, {
-        initiator: { id: userId, role: "user" },
+        initiator: { id: testJwtPayload.userId, role: testJwtPayload.role },
       });
     });
 
@@ -114,24 +109,20 @@ describe("favoriteRoutes", () => {
 
   describe("DELETE /api/recipes/:id/favorite", () => {
     it("should remove favorite when authenticated", async () => {
-      verifyToken.mockReturnValue({
-        userId,
-        email: "user@test.com",
-        role: "user",
-      });
+      verifyToken.mockReturnValue(testJwtPayload);
       mockFavoriteService.remove.mockResolvedValue({ favorited: false });
 
       const response = await app.inject({
         method: "DELETE",
         url: `/api/recipes/${recipeId}/favorite`,
-        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+        headers: authHeader(testJwtPayload),
       });
 
       expect(response.statusCode).toBe(200);
       const body = JSON.parse(response.payload);
       expect(body.favorited).toBe(false);
       expect(mockFavoriteService.remove).toHaveBeenCalledWith(recipeId, {
-        initiator: { id: userId, role: "user" },
+        initiator: { id: testJwtPayload.userId, role: testJwtPayload.role },
       });
     });
 

--- a/apps/backend/src/modules/favorites/favorite.routes.test.ts
+++ b/apps/backend/src/modules/favorites/favorite.routes.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestApp, authHeader } from "@/__tests__/build-test-app.js";
+import { favoriteRoutes } from "@/modules/favorites/favorite.routes.js";
+
+const { verifyToken } = vi.hoisted(() => ({
+  verifyToken: vi.fn(),
+}));
+
+vi.mock("@/common/utils/jwt.js", () => ({ verifyToken }));
+
+describe("favoriteRoutes", () => {
+  const mockFavoriteService = {
+    isFavorited: vi.fn(),
+    add: vi.fn(),
+    remove: vi.fn(),
+  };
+
+  const userId = "507f1f77bcf86cd799439011";
+  const recipeId = "507f1f77bcf86cd799439033";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function buildApp() {
+    const app = createTestApp();
+    app.register(favoriteRoutes, { service: mockFavoriteService, prefix: "/api/recipes" });
+    return app;
+  }
+
+  describe("GET /api/recipes/:id/favorite", () => {
+    it("should return favorited status when authenticated", async () => {
+      const app = buildApp();
+      verifyToken.mockReturnValue({ userId, email: "user@test.com", role: "user" });
+      mockFavoriteService.isFavorited.mockResolvedValue(true);
+
+      const response = await app.inject({
+        method: "GET",
+        url: `/api/recipes/${recipeId}/favorite`,
+        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.payload);
+      expect(body.favorited).toBe(true);
+      expect(mockFavoriteService.isFavorited).toHaveBeenCalledWith(recipeId, {
+        initiator: { id: userId, role: "user" },
+      });
+    });
+
+    it("should return 401 when not authenticated", async () => {
+      const app = buildApp();
+      const response = await app.inject({
+        method: "GET",
+        url: `/api/recipes/${recipeId}/favorite`,
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+
+    it("should return 400 for invalid recipe id", async () => {
+      const app = buildApp();
+      verifyToken.mockReturnValue({ userId, email: "user@test.com", role: "user" });
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/recipes/bad-id/favorite",
+        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+  });
+
+  describe("POST /api/recipes/:id/favorite", () => {
+    it("should add favorite when authenticated", async () => {
+      const app = buildApp();
+      verifyToken.mockReturnValue({ userId, email: "user@test.com", role: "user" });
+      mockFavoriteService.add.mockResolvedValue({ favorited: true });
+
+      const response = await app.inject({
+        method: "POST",
+        url: `/api/recipes/${recipeId}/favorite`,
+        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.payload);
+      expect(body.favorited).toBe(true);
+      expect(mockFavoriteService.add).toHaveBeenCalledWith(recipeId, {
+        initiator: { id: userId, role: "user" },
+      });
+    });
+
+    it("should return 401 when not authenticated", async () => {
+      const app = buildApp();
+      const response = await app.inject({
+        method: "POST",
+        url: `/api/recipes/${recipeId}/favorite`,
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+  });
+
+  describe("DELETE /api/recipes/:id/favorite", () => {
+    it("should remove favorite when authenticated", async () => {
+      const app = buildApp();
+      verifyToken.mockReturnValue({ userId, email: "user@test.com", role: "user" });
+      mockFavoriteService.remove.mockResolvedValue({ favorited: false });
+
+      const response = await app.inject({
+        method: "DELETE",
+        url: `/api/recipes/${recipeId}/favorite`,
+        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.payload);
+      expect(body.favorited).toBe(false);
+      expect(mockFavoriteService.remove).toHaveBeenCalledWith(recipeId, {
+        initiator: { id: userId, role: "user" },
+      });
+    });
+
+    it("should return 401 when not authenticated", async () => {
+      const app = buildApp();
+      const response = await app.inject({
+        method: "DELETE",
+        url: `/api/recipes/${recipeId}/favorite`,
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+  });
+});

--- a/apps/backend/src/modules/recipe-ratings/recipe-rating.routes.test.ts
+++ b/apps/backend/src/modules/recipe-ratings/recipe-rating.routes.test.ts
@@ -18,6 +18,12 @@ describe("recipeRatingRoutes", () => {
   const userId = "507f1f77bcf86cd799439011";
   const recipeId = "507f1f77bcf86cd799439033";
 
+  const testJwtPayload = {
+    userId,
+    email: "user@test.com",
+    role: "user",
+  } as const;
+
   let app: FastifyInstance;
 
   beforeEach(async () => {
@@ -31,18 +37,14 @@ describe("recipeRatingRoutes", () => {
 
   describe("PUT /api/recipes/:id/rating", () => {
     it("should rate recipe when authenticated", async () => {
-      verifyToken.mockReturnValue({
-        userId,
-        email: "user@test.com",
-        role: "user",
-      });
+      verifyToken.mockReturnValue(testJwtPayload);
       mockRecipeRatingService.rate.mockResolvedValue({ value: 5 });
 
       const response = await app.inject({
         method: "PUT",
         url: `/api/recipes/${recipeId}/rating`,
         payload: { value: 5 },
-        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+        headers: authHeader(testJwtPayload),
       });
 
       expect(response.statusCode).toBe(200);
@@ -50,7 +52,7 @@ describe("recipeRatingRoutes", () => {
       expect(body.value).toBe(5);
       expect(mockRecipeRatingService.rate).toHaveBeenCalledWith(recipeId, {
         data: { value: 5 },
-        initiator: { id: userId, role: "user" },
+        initiator: { id: testJwtPayload.userId, role: testJwtPayload.role },
       });
     });
 
@@ -65,17 +67,13 @@ describe("recipeRatingRoutes", () => {
     });
 
     it("should return 400 for invalid rating value", async () => {
-      verifyToken.mockReturnValue({
-        userId,
-        email: "user@test.com",
-        role: "user",
-      });
+      verifyToken.mockReturnValue(testJwtPayload);
 
       const response = await app.inject({
         method: "PUT",
         url: `/api/recipes/${recipeId}/rating`,
         payload: { value: 10 },
-        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+        headers: authHeader(testJwtPayload),
       });
 
       expect(response.statusCode).toBe(400);
@@ -84,17 +82,13 @@ describe("recipeRatingRoutes", () => {
     });
 
     it("should return 400 for invalid recipe id", async () => {
-      verifyToken.mockReturnValue({
-        userId,
-        email: "user@test.com",
-        role: "user",
-      });
+      verifyToken.mockReturnValue(testJwtPayload);
 
       const response = await app.inject({
         method: "PUT",
         url: "/api/recipes/bad-id/rating",
         payload: { value: 5 },
-        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+        headers: authHeader(testJwtPayload),
       });
 
       expect(response.statusCode).toBe(400);
@@ -103,22 +97,18 @@ describe("recipeRatingRoutes", () => {
 
   describe("DELETE /api/recipes/:id/rating", () => {
     it("should remove rating when authenticated", async () => {
-      verifyToken.mockReturnValue({
-        userId,
-        email: "user@test.com",
-        role: "user",
-      });
+      verifyToken.mockReturnValue(testJwtPayload);
       mockRecipeRatingService.remove.mockResolvedValue(undefined);
 
       const response = await app.inject({
         method: "DELETE",
         url: `/api/recipes/${recipeId}/rating`,
-        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+        headers: authHeader(testJwtPayload),
       });
 
       expect(response.statusCode).toBe(204);
       expect(mockRecipeRatingService.remove).toHaveBeenCalledWith(recipeId, {
-        initiator: { id: userId, role: "user" },
+        initiator: { id: testJwtPayload.userId, role: testJwtPayload.role },
       });
     });
 

--- a/apps/backend/src/modules/recipe-ratings/recipe-rating.routes.test.ts
+++ b/apps/backend/src/modules/recipe-ratings/recipe-rating.routes.test.ts
@@ -1,5 +1,6 @@
+import type { FastifyInstance } from "fastify";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createTestApp, authHeader } from "@/__tests__/build-test-app.js";
+import { authHeader, createTestApp } from "@/__tests__/build-test-app.js";
 import { recipeRatingRoutes } from "@/modules/recipe-ratings/recipe-rating.routes.js";
 
 const { verifyToken } = vi.hoisted(() => ({
@@ -17,20 +18,24 @@ describe("recipeRatingRoutes", () => {
   const userId = "507f1f77bcf86cd799439011";
   const recipeId = "507f1f77bcf86cd799439033";
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
+  let app: FastifyInstance;
 
-  function buildApp() {
-    const app = createTestApp();
-    app.register(recipeRatingRoutes, { service: mockRecipeRatingService, prefix: "/api/recipes" });
-    return app;
-  }
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = createTestApp();
+    await app.register(recipeRatingRoutes, {
+      service: mockRecipeRatingService,
+      prefix: "/api/recipes",
+    });
+  });
 
   describe("PUT /api/recipes/:id/rating", () => {
     it("should rate recipe when authenticated", async () => {
-      const app = buildApp();
-      verifyToken.mockReturnValue({ userId, email: "user@test.com", role: "user" });
+      verifyToken.mockReturnValue({
+        userId,
+        email: "user@test.com",
+        role: "user",
+      });
       mockRecipeRatingService.rate.mockResolvedValue({ value: 5 });
 
       const response = await app.inject({
@@ -50,7 +55,6 @@ describe("recipeRatingRoutes", () => {
     });
 
     it("should return 401 when not authenticated", async () => {
-      const app = buildApp();
       const response = await app.inject({
         method: "PUT",
         url: `/api/recipes/${recipeId}/rating`,
@@ -61,8 +65,11 @@ describe("recipeRatingRoutes", () => {
     });
 
     it("should return 400 for invalid rating value", async () => {
-      const app = buildApp();
-      verifyToken.mockReturnValue({ userId, email: "user@test.com", role: "user" });
+      verifyToken.mockReturnValue({
+        userId,
+        email: "user@test.com",
+        role: "user",
+      });
 
       const response = await app.inject({
         method: "PUT",
@@ -77,8 +84,11 @@ describe("recipeRatingRoutes", () => {
     });
 
     it("should return 400 for invalid recipe id", async () => {
-      const app = buildApp();
-      verifyToken.mockReturnValue({ userId, email: "user@test.com", role: "user" });
+      verifyToken.mockReturnValue({
+        userId,
+        email: "user@test.com",
+        role: "user",
+      });
 
       const response = await app.inject({
         method: "PUT",
@@ -93,8 +103,11 @@ describe("recipeRatingRoutes", () => {
 
   describe("DELETE /api/recipes/:id/rating", () => {
     it("should remove rating when authenticated", async () => {
-      const app = buildApp();
-      verifyToken.mockReturnValue({ userId, email: "user@test.com", role: "user" });
+      verifyToken.mockReturnValue({
+        userId,
+        email: "user@test.com",
+        role: "user",
+      });
       mockRecipeRatingService.remove.mockResolvedValue(undefined);
 
       const response = await app.inject({
@@ -110,7 +123,6 @@ describe("recipeRatingRoutes", () => {
     });
 
     it("should return 401 when not authenticated", async () => {
-      const app = buildApp();
       const response = await app.inject({
         method: "DELETE",
         url: `/api/recipes/${recipeId}/rating`,

--- a/apps/backend/src/modules/recipe-ratings/recipe-rating.routes.test.ts
+++ b/apps/backend/src/modules/recipe-ratings/recipe-rating.routes.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestApp, authHeader } from "@/__tests__/build-test-app.js";
+import { recipeRatingRoutes } from "@/modules/recipe-ratings/recipe-rating.routes.js";
+
+const { verifyToken } = vi.hoisted(() => ({
+  verifyToken: vi.fn(),
+}));
+
+vi.mock("@/common/utils/jwt.js", () => ({ verifyToken }));
+
+describe("recipeRatingRoutes", () => {
+  const mockRecipeRatingService = {
+    rate: vi.fn(),
+    remove: vi.fn(),
+  };
+
+  const userId = "507f1f77bcf86cd799439011";
+  const recipeId = "507f1f77bcf86cd799439033";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function buildApp() {
+    const app = createTestApp();
+    app.register(recipeRatingRoutes, { service: mockRecipeRatingService, prefix: "/api/recipes" });
+    return app;
+  }
+
+  describe("PUT /api/recipes/:id/rating", () => {
+    it("should rate recipe when authenticated", async () => {
+      const app = buildApp();
+      verifyToken.mockReturnValue({ userId, email: "user@test.com", role: "user" });
+      mockRecipeRatingService.rate.mockResolvedValue({ value: 5 });
+
+      const response = await app.inject({
+        method: "PUT",
+        url: `/api/recipes/${recipeId}/rating`,
+        payload: { value: 5 },
+        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.payload);
+      expect(body.value).toBe(5);
+      expect(mockRecipeRatingService.rate).toHaveBeenCalledWith(recipeId, {
+        data: { value: 5 },
+        initiator: { id: userId, role: "user" },
+      });
+    });
+
+    it("should return 401 when not authenticated", async () => {
+      const app = buildApp();
+      const response = await app.inject({
+        method: "PUT",
+        url: `/api/recipes/${recipeId}/rating`,
+        payload: { value: 5 },
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+
+    it("should return 400 for invalid rating value", async () => {
+      const app = buildApp();
+      verifyToken.mockReturnValue({ userId, email: "user@test.com", role: "user" });
+
+      const response = await app.inject({
+        method: "PUT",
+        url: `/api/recipes/${recipeId}/rating`,
+        payload: { value: 10 },
+        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+      });
+
+      expect(response.statusCode).toBe(400);
+      const body = JSON.parse(response.payload);
+      expect(body.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("should return 400 for invalid recipe id", async () => {
+      const app = buildApp();
+      verifyToken.mockReturnValue({ userId, email: "user@test.com", role: "user" });
+
+      const response = await app.inject({
+        method: "PUT",
+        url: "/api/recipes/bad-id/rating",
+        payload: { value: 5 },
+        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+  });
+
+  describe("DELETE /api/recipes/:id/rating", () => {
+    it("should remove rating when authenticated", async () => {
+      const app = buildApp();
+      verifyToken.mockReturnValue({ userId, email: "user@test.com", role: "user" });
+      mockRecipeRatingService.remove.mockResolvedValue(undefined);
+
+      const response = await app.inject({
+        method: "DELETE",
+        url: `/api/recipes/${recipeId}/rating`,
+        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+      });
+
+      expect(response.statusCode).toBe(204);
+      expect(mockRecipeRatingService.remove).toHaveBeenCalledWith(recipeId, {
+        initiator: { id: userId, role: "user" },
+      });
+    });
+
+    it("should return 401 when not authenticated", async () => {
+      const app = buildApp();
+      const response = await app.inject({
+        method: "DELETE",
+        url: `/api/recipes/${recipeId}/rating`,
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+  });
+});

--- a/apps/backend/src/modules/recipes/recipe.routes.test.ts
+++ b/apps/backend/src/modules/recipes/recipe.routes.test.ts
@@ -1,0 +1,471 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { authHeader, createTestApp } from "@/__tests__/build-test-app.js";
+import { recipeRoutes } from "@/modules/recipes/recipe.routes.js";
+
+const { verifyToken } = vi.hoisted(() => ({
+  verifyToken: vi.fn(),
+}));
+
+vi.mock("@/common/utils/jwt.js", () => ({ verifyToken }));
+
+describe("recipeRoutes", () => {
+  const mockRecipeService = {
+    findAll: vi.fn(),
+    findById: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  };
+
+  const mockCommentService = {
+    findByRecipe: vi.fn(),
+    findByAuthor: vi.fn(),
+    create: vi.fn(),
+    delete: vi.fn(),
+  };
+
+  const userId = "507f1f77bcf86cd799439011";
+  const adminId = "507f1f77bcf86cd799439022";
+  const recipeId = "507f1f77bcf86cd799439033";
+  const commentId = "507f1f77bcf86cd799439044";
+
+  const validRecipe = {
+    id: recipeId,
+    title: "Test Recipe",
+    description: "A delicious test recipe",
+    ingredients: [{ name: "Flour", quantity: 200, unit: "g" }],
+    instructions: ["Mix ingredients", "Bake it well"],
+    category: {
+      id: "507f1f77bcf86cd799439055",
+      name: "Desserts",
+      slug: "desserts",
+    },
+    author: { id: userId, email: "chef@test.com", name: "Chef" },
+    difficulty: "easy" as const,
+    cookingTime: 30,
+    servings: 4,
+    isPublic: true,
+    createdAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-01T00:00:00.000Z",
+    isFavorited: false,
+    userRating: null,
+    averageRating: null,
+    ratingCount: 0,
+  };
+
+  const paginatedResult = {
+    items: [validRecipe],
+    pagination: {
+      page: 1,
+      limit: 10,
+      total: 1,
+      totalPages: 1,
+      hasNext: false,
+      hasPrev: false,
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function buildApp() {
+    const app = createTestApp();
+    app.register(recipeRoutes, {
+      service: mockRecipeService,
+      commentService: mockCommentService,
+      prefix: "/api/recipes",
+    });
+    return app;
+  }
+
+  describe("GET /api/recipes", () => {
+    it("should return paginated recipes for unauthenticated user", async () => {
+      const app = buildApp();
+      mockRecipeService.findAll.mockResolvedValue(paginatedResult);
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/recipes?page=1&limit=10",
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(mockRecipeService.findAll).toHaveBeenCalledWith({
+        query: expect.objectContaining({ page: 1, limit: 10 }),
+        initiator: { id: undefined, role: undefined },
+      });
+      const body = JSON.parse(response.payload);
+      expect(body.items).toHaveLength(1);
+    });
+
+    it("should return paginated recipes for authenticated user", async () => {
+      const app = buildApp();
+      verifyToken.mockReturnValue({
+        userId,
+        email: "user@test.com",
+        role: "user",
+      });
+      mockRecipeService.findAll.mockResolvedValue(paginatedResult);
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/recipes",
+        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(mockRecipeService.findAll).toHaveBeenCalledWith({
+        query: expect.any(Object),
+        initiator: { id: userId, role: "user" },
+      });
+    });
+
+    it("should return 400 for invalid query params", async () => {
+      const app = buildApp();
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/recipes?page=abc",
+      });
+
+      expect(response.statusCode).toBe(400);
+      const body = JSON.parse(response.payload);
+      expect(body.code).toBe("VALIDATION_ERROR");
+    });
+  });
+
+  describe("GET /api/recipes/:id", () => {
+    it("should return recipe by id", async () => {
+      const app = buildApp();
+      mockRecipeService.findById.mockResolvedValue(validRecipe);
+
+      const response = await app.inject({
+        method: "GET",
+        url: `/api/recipes/${recipeId}`,
+      });
+
+      if (response.statusCode !== 200) {
+        console.log(
+          "GET /api/recipes/:id response:",
+          response.statusCode,
+          JSON.parse(response.payload),
+        );
+      }
+
+      expect(response.statusCode).toBe(200);
+      expect(mockRecipeService.findById).toHaveBeenCalledWith(recipeId, {
+        initiator: { id: undefined, role: undefined },
+      });
+      const body = JSON.parse(response.payload);
+      expect(body.title).toBe("Test Recipe");
+    });
+
+    it("should return 400 for invalid id", async () => {
+      const app = buildApp();
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/recipes/invalid-id",
+      });
+
+      expect(response.statusCode).toBe(400);
+      const body = JSON.parse(response.payload);
+      expect(body.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("should return 404 when recipe not found", async () => {
+      const app = buildApp();
+      mockRecipeService.findById.mockRejectedValue(
+        Object.assign(new Error("Recipe not found"), {
+          statusCode: 404,
+          code: "NOT_FOUND",
+        }),
+      );
+
+      const response = await app.inject({
+        method: "GET",
+        url: `/api/recipes/${recipeId}`,
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+  });
+
+  describe("POST /api/recipes", () => {
+    it("should create recipe when authenticated", async () => {
+      const app = buildApp();
+      verifyToken.mockReturnValue({
+        userId,
+        email: "user@test.com",
+        role: "user",
+      });
+      mockRecipeService.create.mockResolvedValue(validRecipe);
+
+      const payload = {
+        title: "New Recipe",
+        description: "A new recipe description",
+        ingredients: [{ name: "Flour", quantity: 100, unit: "g" }],
+        instructions: ["Mix all ingredients together"],
+        category: "507f1f77bcf86cd799439055",
+        difficulty: "easy",
+        cookingTime: 20,
+        servings: 2,
+        isPublic: true,
+      };
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/recipes",
+        payload,
+        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+      });
+
+      if (response.statusCode !== 201) {
+        console.log(
+          "POST /api/recipes response:",
+          response.statusCode,
+          JSON.parse(response.payload),
+        );
+      }
+
+      expect(response.statusCode).toBe(201);
+      expect(mockRecipeService.create).toHaveBeenCalledWith({
+        data: payload,
+        initiator: { id: userId, role: "user" },
+      });
+    });
+
+    it("should return 401 when not authenticated", async () => {
+      const app = buildApp();
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/recipes",
+        payload: {},
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+
+    it("should return 400 for invalid body", async () => {
+      const app = buildApp();
+      verifyToken.mockReturnValue({
+        userId,
+        email: "user@test.com",
+        role: "user",
+      });
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/recipes",
+        payload: { title: "AB" },
+        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+      });
+
+      expect(response.statusCode).toBe(400);
+      const body = JSON.parse(response.payload);
+      expect(body.code).toBe("VALIDATION_ERROR");
+    });
+  });
+
+  describe("PATCH /api/recipes/:id", () => {
+    it("should update recipe when authenticated", async () => {
+      const app = buildApp();
+      verifyToken.mockReturnValue({
+        userId,
+        email: "user@test.com",
+        role: "user",
+      });
+      mockRecipeService.update.mockResolvedValue({
+        ...validRecipe,
+        title: "Updated",
+      });
+
+      const response = await app.inject({
+        method: "PATCH",
+        url: `/api/recipes/${recipeId}`,
+        payload: { title: "Updated" },
+        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(mockRecipeService.update).toHaveBeenCalledWith(recipeId, {
+        data: { title: "Updated", isPublic: true },
+        initiator: { id: userId, role: "user" },
+      });
+    });
+
+    it("should return 401 when not authenticated", async () => {
+      const app = buildApp();
+      const response = await app.inject({
+        method: "PATCH",
+        url: `/api/recipes/${recipeId}`,
+        payload: {},
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+
+    it("should return 400 for invalid id", async () => {
+      const app = buildApp();
+      verifyToken.mockReturnValue({
+        userId,
+        email: "user@test.com",
+        role: "user",
+      });
+
+      const response = await app.inject({
+        method: "PATCH",
+        url: "/api/recipes/bad-id",
+        payload: {},
+        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+  });
+
+  describe("DELETE /api/recipes/:id", () => {
+    it("should delete recipe when authenticated", async () => {
+      const app = buildApp();
+      verifyToken.mockReturnValue({
+        userId,
+        email: "user@test.com",
+        role: "user",
+      });
+      mockRecipeService.delete.mockResolvedValue(undefined);
+
+      const response = await app.inject({
+        method: "DELETE",
+        url: `/api/recipes/${recipeId}`,
+        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+      });
+
+      expect(response.statusCode).toBe(204);
+      expect(mockRecipeService.delete).toHaveBeenCalledWith(recipeId, {
+        initiator: { id: userId, role: "user" },
+      });
+    });
+
+    it("should return 401 when not authenticated", async () => {
+      const app = buildApp();
+      const response = await app.inject({
+        method: "DELETE",
+        url: `/api/recipes/${recipeId}`,
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+  });
+
+  describe("GET /api/recipes/:id/comments", () => {
+    it("should return comments for recipe", async () => {
+      const app = buildApp();
+      mockCommentService.findByRecipe.mockResolvedValue({
+        items: [],
+        pagination: {
+          page: 1,
+          limit: 10,
+          total: 0,
+          totalPages: 0,
+          hasNext: false,
+          hasPrev: false,
+        },
+      });
+
+      const response = await app.inject({
+        method: "GET",
+        url: `/api/recipes/${recipeId}/comments`,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(mockCommentService.findByRecipe).toHaveBeenCalledWith(recipeId, {
+        query: expect.any(Object),
+        initiator: { id: undefined, role: undefined },
+      });
+    });
+
+    it("should return 400 for invalid recipe id", async () => {
+      const app = buildApp();
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/recipes/bad-id/comments",
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+  });
+
+  describe("POST /api/recipes/:id/comments", () => {
+    it("should create comment when authenticated", async () => {
+      const app = buildApp();
+      verifyToken.mockReturnValue({
+        userId,
+        email: "user@test.com",
+        role: "user",
+      });
+      mockCommentService.create.mockResolvedValue({
+        id: commentId,
+        text: "Great!",
+        recipe: { id: recipeId, title: "Test" },
+        author: { id: userId, email: "user@test.com", name: "User" },
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      });
+
+      const response = await app.inject({
+        method: "POST",
+        url: `/api/recipes/${recipeId}/comments`,
+        payload: { text: "Great!" },
+        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+      });
+
+      expect(response.statusCode).toBe(201);
+      expect(mockCommentService.create).toHaveBeenCalledWith(recipeId, {
+        data: { text: "Great!" },
+        initiator: { id: userId, role: "user" },
+      });
+    });
+
+    it("should return 401 when not authenticated", async () => {
+      const app = buildApp();
+      const response = await app.inject({
+        method: "POST",
+        url: `/api/recipes/${recipeId}/comments`,
+        payload: { text: "Hi" },
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+  });
+
+  describe("DELETE /api/recipes/comments/:id", () => {
+    it("should delete comment when authenticated", async () => {
+      const app = buildApp();
+      verifyToken.mockReturnValue({
+        userId,
+        email: "user@test.com",
+        role: "user",
+      });
+      mockCommentService.delete.mockResolvedValue(undefined);
+
+      const response = await app.inject({
+        method: "DELETE",
+        url: `/api/recipes/comments/${commentId}`,
+        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+      });
+
+      expect(response.statusCode).toBe(204);
+      expect(mockCommentService.delete).toHaveBeenCalledWith(commentId, {
+        initiator: { id: userId, role: "user" },
+      });
+    });
+
+    it("should return 401 when not authenticated", async () => {
+      const app = buildApp();
+      const response = await app.inject({
+        method: "DELETE",
+        url: `/api/recipes/comments/${commentId}`,
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+  });
+});

--- a/apps/backend/src/modules/recipes/recipe.routes.test.ts
+++ b/apps/backend/src/modules/recipes/recipe.routes.test.ts
@@ -1,3 +1,4 @@
+import type { FastifyInstance } from "fastify";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { authHeader, createTestApp } from "@/__tests__/build-test-app.js";
 import { recipeRoutes } from "@/modules/recipes/recipe.routes.js";
@@ -25,7 +26,6 @@ describe("recipeRoutes", () => {
   };
 
   const userId = "507f1f77bcf86cd799439011";
-  const adminId = "507f1f77bcf86cd799439022";
   const recipeId = "507f1f77bcf86cd799439033";
   const commentId = "507f1f77bcf86cd799439044";
 
@@ -65,23 +65,20 @@ describe("recipeRoutes", () => {
     },
   };
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
+  let app: FastifyInstance;
 
-  function buildApp() {
-    const app = createTestApp();
-    app.register(recipeRoutes, {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = createTestApp();
+    await app.register(recipeRoutes, {
       service: mockRecipeService,
       commentService: mockCommentService,
       prefix: "/api/recipes",
     });
-    return app;
-  }
+  });
 
   describe("GET /api/recipes", () => {
     it("should return paginated recipes for unauthenticated user", async () => {
-      const app = buildApp();
       mockRecipeService.findAll.mockResolvedValue(paginatedResult);
 
       const response = await app.inject({
@@ -99,7 +96,6 @@ describe("recipeRoutes", () => {
     });
 
     it("should return paginated recipes for authenticated user", async () => {
-      const app = buildApp();
       verifyToken.mockReturnValue({
         userId,
         email: "user@test.com",
@@ -121,7 +117,6 @@ describe("recipeRoutes", () => {
     });
 
     it("should return 400 for invalid query params", async () => {
-      const app = buildApp();
       const response = await app.inject({
         method: "GET",
         url: "/api/recipes?page=abc",
@@ -135,21 +130,12 @@ describe("recipeRoutes", () => {
 
   describe("GET /api/recipes/:id", () => {
     it("should return recipe by id", async () => {
-      const app = buildApp();
       mockRecipeService.findById.mockResolvedValue(validRecipe);
 
       const response = await app.inject({
         method: "GET",
         url: `/api/recipes/${recipeId}`,
       });
-
-      if (response.statusCode !== 200) {
-        console.log(
-          "GET /api/recipes/:id response:",
-          response.statusCode,
-          JSON.parse(response.payload),
-        );
-      }
 
       expect(response.statusCode).toBe(200);
       expect(mockRecipeService.findById).toHaveBeenCalledWith(recipeId, {
@@ -160,7 +146,6 @@ describe("recipeRoutes", () => {
     });
 
     it("should return 400 for invalid id", async () => {
-      const app = buildApp();
       const response = await app.inject({
         method: "GET",
         url: "/api/recipes/invalid-id",
@@ -172,7 +157,6 @@ describe("recipeRoutes", () => {
     });
 
     it("should return 404 when recipe not found", async () => {
-      const app = buildApp();
       mockRecipeService.findById.mockRejectedValue(
         Object.assign(new Error("Recipe not found"), {
           statusCode: 404,
@@ -191,7 +175,6 @@ describe("recipeRoutes", () => {
 
   describe("POST /api/recipes", () => {
     it("should create recipe when authenticated", async () => {
-      const app = buildApp();
       verifyToken.mockReturnValue({
         userId,
         email: "user@test.com",
@@ -218,14 +201,6 @@ describe("recipeRoutes", () => {
         headers: authHeader({ userId, email: "user@test.com", role: "user" }),
       });
 
-      if (response.statusCode !== 201) {
-        console.log(
-          "POST /api/recipes response:",
-          response.statusCode,
-          JSON.parse(response.payload),
-        );
-      }
-
       expect(response.statusCode).toBe(201);
       expect(mockRecipeService.create).toHaveBeenCalledWith({
         data: payload,
@@ -234,7 +209,6 @@ describe("recipeRoutes", () => {
     });
 
     it("should return 401 when not authenticated", async () => {
-      const app = buildApp();
       const response = await app.inject({
         method: "POST",
         url: "/api/recipes",
@@ -245,7 +219,6 @@ describe("recipeRoutes", () => {
     });
 
     it("should return 400 for invalid body", async () => {
-      const app = buildApp();
       verifyToken.mockReturnValue({
         userId,
         email: "user@test.com",
@@ -267,7 +240,6 @@ describe("recipeRoutes", () => {
 
   describe("PATCH /api/recipes/:id", () => {
     it("should update recipe when authenticated", async () => {
-      const app = buildApp();
       verifyToken.mockReturnValue({
         userId,
         email: "user@test.com",
@@ -293,7 +265,6 @@ describe("recipeRoutes", () => {
     });
 
     it("should return 401 when not authenticated", async () => {
-      const app = buildApp();
       const response = await app.inject({
         method: "PATCH",
         url: `/api/recipes/${recipeId}`,
@@ -304,7 +275,6 @@ describe("recipeRoutes", () => {
     });
 
     it("should return 400 for invalid id", async () => {
-      const app = buildApp();
       verifyToken.mockReturnValue({
         userId,
         email: "user@test.com",
@@ -324,7 +294,6 @@ describe("recipeRoutes", () => {
 
   describe("DELETE /api/recipes/:id", () => {
     it("should delete recipe when authenticated", async () => {
-      const app = buildApp();
       verifyToken.mockReturnValue({
         userId,
         email: "user@test.com",
@@ -345,7 +314,6 @@ describe("recipeRoutes", () => {
     });
 
     it("should return 401 when not authenticated", async () => {
-      const app = buildApp();
       const response = await app.inject({
         method: "DELETE",
         url: `/api/recipes/${recipeId}`,
@@ -357,7 +325,6 @@ describe("recipeRoutes", () => {
 
   describe("GET /api/recipes/:id/comments", () => {
     it("should return comments for recipe", async () => {
-      const app = buildApp();
       mockCommentService.findByRecipe.mockResolvedValue({
         items: [],
         pagination: {
@@ -383,7 +350,6 @@ describe("recipeRoutes", () => {
     });
 
     it("should return 400 for invalid recipe id", async () => {
-      const app = buildApp();
       const response = await app.inject({
         method: "GET",
         url: "/api/recipes/bad-id/comments",
@@ -395,7 +361,6 @@ describe("recipeRoutes", () => {
 
   describe("POST /api/recipes/:id/comments", () => {
     it("should create comment when authenticated", async () => {
-      const app = buildApp();
       verifyToken.mockReturnValue({
         userId,
         email: "user@test.com",
@@ -425,7 +390,6 @@ describe("recipeRoutes", () => {
     });
 
     it("should return 401 when not authenticated", async () => {
-      const app = buildApp();
       const response = await app.inject({
         method: "POST",
         url: `/api/recipes/${recipeId}/comments`,
@@ -438,7 +402,6 @@ describe("recipeRoutes", () => {
 
   describe("DELETE /api/recipes/comments/:id", () => {
     it("should delete comment when authenticated", async () => {
-      const app = buildApp();
       verifyToken.mockReturnValue({
         userId,
         email: "user@test.com",
@@ -459,7 +422,6 @@ describe("recipeRoutes", () => {
     });
 
     it("should return 401 when not authenticated", async () => {
-      const app = buildApp();
       const response = await app.inject({
         method: "DELETE",
         url: `/api/recipes/comments/${commentId}`,

--- a/apps/backend/src/modules/recipes/recipe.routes.test.ts
+++ b/apps/backend/src/modules/recipes/recipe.routes.test.ts
@@ -1,6 +1,8 @@
 import type { FastifyInstance } from "fastify";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { authHeader, createTestApp } from "@/__tests__/build-test-app.js";
+import { noInitiator } from "@/__tests__/helpers.js";
+import { NotFoundError } from "@/common/errors.js";
 import { recipeRoutes } from "@/modules/recipes/recipe.routes.js";
 
 const { verifyToken } = vi.hoisted(() => ({
@@ -65,6 +67,12 @@ describe("recipeRoutes", () => {
     },
   };
 
+  const testJwtPayload = {
+    userId,
+    email: "user@test.com",
+    role: "user",
+  } as const;
+
   let app: FastifyInstance;
 
   beforeEach(async () => {
@@ -81,38 +89,39 @@ describe("recipeRoutes", () => {
     it("should return paginated recipes for unauthenticated user", async () => {
       mockRecipeService.findAll.mockResolvedValue(paginatedResult);
 
+      const page = 1;
+      const limit = 10;
       const response = await app.inject({
         method: "GET",
-        url: "/api/recipes?page=1&limit=10",
+        url: `/api/recipes?page=${page}&limit=${limit}`,
       });
 
       expect(response.statusCode).toBe(200);
       expect(mockRecipeService.findAll).toHaveBeenCalledWith({
-        query: expect.objectContaining({ page: 1, limit: 10 }),
-        initiator: { id: undefined, role: undefined },
+        query: expect.objectContaining({ page, limit }),
+        initiator: noInitiator(),
       });
       const body = JSON.parse(response.payload);
-      expect(body.items).toHaveLength(1);
+      expect(body.items).toHaveLength(paginatedResult.items.length);
     });
 
     it("should return paginated recipes for authenticated user", async () => {
-      verifyToken.mockReturnValue({
-        userId,
-        email: "user@test.com",
-        role: "user",
-      });
+      verifyToken.mockReturnValue(testJwtPayload);
       mockRecipeService.findAll.mockResolvedValue(paginatedResult);
 
       const response = await app.inject({
         method: "GET",
         url: "/api/recipes",
-        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+        headers: authHeader(testJwtPayload),
       });
 
       expect(response.statusCode).toBe(200);
       expect(mockRecipeService.findAll).toHaveBeenCalledWith({
         query: expect.any(Object),
-        initiator: { id: userId, role: "user" },
+        initiator: {
+          id: testJwtPayload.userId,
+          role: testJwtPayload.role,
+        },
       });
     });
 
@@ -139,7 +148,7 @@ describe("recipeRoutes", () => {
 
       expect(response.statusCode).toBe(200);
       expect(mockRecipeService.findById).toHaveBeenCalledWith(recipeId, {
-        initiator: { id: undefined, role: undefined },
+        initiator: noInitiator(),
       });
       const body = JSON.parse(response.payload);
       expect(body.title).toBe("Test Recipe");
@@ -158,10 +167,7 @@ describe("recipeRoutes", () => {
 
     it("should return 404 when recipe not found", async () => {
       mockRecipeService.findById.mockRejectedValue(
-        Object.assign(new Error("Recipe not found"), {
-          statusCode: 404,
-          code: "NOT_FOUND",
-        }),
+        new NotFoundError("Recipe not found"),
       );
 
       const response = await app.inject({
@@ -175,11 +181,7 @@ describe("recipeRoutes", () => {
 
   describe("POST /api/recipes", () => {
     it("should create recipe when authenticated", async () => {
-      verifyToken.mockReturnValue({
-        userId,
-        email: "user@test.com",
-        role: "user",
-      });
+      verifyToken.mockReturnValue(testJwtPayload);
       mockRecipeService.create.mockResolvedValue(validRecipe);
 
       const payload = {
@@ -198,13 +200,16 @@ describe("recipeRoutes", () => {
         method: "POST",
         url: "/api/recipes",
         payload,
-        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+        headers: authHeader(testJwtPayload),
       });
 
       expect(response.statusCode).toBe(201);
       expect(mockRecipeService.create).toHaveBeenCalledWith({
         data: payload,
-        initiator: { id: userId, role: "user" },
+        initiator: {
+          id: testJwtPayload.userId,
+          role: testJwtPayload.role,
+        },
       });
     });
 
@@ -219,17 +224,13 @@ describe("recipeRoutes", () => {
     });
 
     it("should return 400 for invalid body", async () => {
-      verifyToken.mockReturnValue({
-        userId,
-        email: "user@test.com",
-        role: "user",
-      });
+      verifyToken.mockReturnValue(testJwtPayload);
 
       const response = await app.inject({
         method: "POST",
         url: "/api/recipes",
         payload: { title: "AB" },
-        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+        headers: authHeader(testJwtPayload),
       });
 
       expect(response.statusCode).toBe(400);
@@ -240,11 +241,7 @@ describe("recipeRoutes", () => {
 
   describe("PATCH /api/recipes/:id", () => {
     it("should update recipe when authenticated", async () => {
-      verifyToken.mockReturnValue({
-        userId,
-        email: "user@test.com",
-        role: "user",
-      });
+      verifyToken.mockReturnValue(testJwtPayload);
       mockRecipeService.update.mockResolvedValue({
         ...validRecipe,
         title: "Updated",
@@ -254,13 +251,16 @@ describe("recipeRoutes", () => {
         method: "PATCH",
         url: `/api/recipes/${recipeId}`,
         payload: { title: "Updated" },
-        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+        headers: authHeader(testJwtPayload),
       });
 
       expect(response.statusCode).toBe(200);
       expect(mockRecipeService.update).toHaveBeenCalledWith(recipeId, {
         data: { title: "Updated", isPublic: true },
-        initiator: { id: userId, role: "user" },
+        initiator: {
+          id: testJwtPayload.userId,
+          role: testJwtPayload.role,
+        },
       });
     });
 
@@ -275,17 +275,13 @@ describe("recipeRoutes", () => {
     });
 
     it("should return 400 for invalid id", async () => {
-      verifyToken.mockReturnValue({
-        userId,
-        email: "user@test.com",
-        role: "user",
-      });
+      verifyToken.mockReturnValue(testJwtPayload);
 
       const response = await app.inject({
         method: "PATCH",
         url: "/api/recipes/bad-id",
         payload: {},
-        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+        headers: authHeader(testJwtPayload),
       });
 
       expect(response.statusCode).toBe(400);
@@ -294,22 +290,21 @@ describe("recipeRoutes", () => {
 
   describe("DELETE /api/recipes/:id", () => {
     it("should delete recipe when authenticated", async () => {
-      verifyToken.mockReturnValue({
-        userId,
-        email: "user@test.com",
-        role: "user",
-      });
+      verifyToken.mockReturnValue(testJwtPayload);
       mockRecipeService.delete.mockResolvedValue(undefined);
 
       const response = await app.inject({
         method: "DELETE",
         url: `/api/recipes/${recipeId}`,
-        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+        headers: authHeader(testJwtPayload),
       });
 
       expect(response.statusCode).toBe(204);
       expect(mockRecipeService.delete).toHaveBeenCalledWith(recipeId, {
-        initiator: { id: userId, role: "user" },
+        initiator: {
+          id: testJwtPayload.userId,
+          role: testJwtPayload.role,
+        },
       });
     });
 
@@ -345,7 +340,7 @@ describe("recipeRoutes", () => {
       expect(response.statusCode).toBe(200);
       expect(mockCommentService.findByRecipe).toHaveBeenCalledWith(recipeId, {
         query: expect.any(Object),
-        initiator: { id: undefined, role: undefined },
+        initiator: noInitiator(),
       });
     });
 
@@ -361,16 +356,16 @@ describe("recipeRoutes", () => {
 
   describe("POST /api/recipes/:id/comments", () => {
     it("should create comment when authenticated", async () => {
-      verifyToken.mockReturnValue({
-        userId,
-        email: "user@test.com",
-        role: "user",
-      });
+      verifyToken.mockReturnValue(testJwtPayload);
       mockCommentService.create.mockResolvedValue({
         id: commentId,
         text: "Great!",
         recipe: { id: recipeId, title: "Test" },
-        author: { id: userId, email: "user@test.com", name: "User" },
+        author: {
+          id: testJwtPayload.userId,
+          email: testJwtPayload.email,
+          name: "User",
+        },
         createdAt: "2024-01-01T00:00:00.000Z",
         updatedAt: "2024-01-01T00:00:00.000Z",
       });
@@ -379,13 +374,16 @@ describe("recipeRoutes", () => {
         method: "POST",
         url: `/api/recipes/${recipeId}/comments`,
         payload: { text: "Great!" },
-        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+        headers: authHeader(testJwtPayload),
       });
 
       expect(response.statusCode).toBe(201);
       expect(mockCommentService.create).toHaveBeenCalledWith(recipeId, {
         data: { text: "Great!" },
-        initiator: { id: userId, role: "user" },
+        initiator: {
+          id: testJwtPayload.userId,
+          role: testJwtPayload.role,
+        },
       });
     });
 
@@ -402,22 +400,21 @@ describe("recipeRoutes", () => {
 
   describe("DELETE /api/recipes/comments/:id", () => {
     it("should delete comment when authenticated", async () => {
-      verifyToken.mockReturnValue({
-        userId,
-        email: "user@test.com",
-        role: "user",
-      });
+      verifyToken.mockReturnValue(testJwtPayload);
       mockCommentService.delete.mockResolvedValue(undefined);
 
       const response = await app.inject({
         method: "DELETE",
         url: `/api/recipes/comments/${commentId}`,
-        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+        headers: authHeader(testJwtPayload),
       });
 
       expect(response.statusCode).toBe(204);
       expect(mockCommentService.delete).toHaveBeenCalledWith(commentId, {
-        initiator: { id: userId, role: "user" },
+        initiator: {
+          id: testJwtPayload.userId,
+          role: testJwtPayload.role,
+        },
       });
     });
 

--- a/apps/backend/src/modules/reviews/review.routes.test.ts
+++ b/apps/backend/src/modules/reviews/review.routes.test.ts
@@ -1,5 +1,6 @@
+import type { FastifyInstance } from "fastify";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createTestApp, authHeader } from "@/__tests__/build-test-app.js";
+import { authHeader, createTestApp } from "@/__tests__/build-test-app.js";
 import { reviewRoutes } from "@/modules/reviews/review.routes.js";
 
 const { verifyToken } = vi.hoisted(() => ({
@@ -33,19 +34,19 @@ describe("reviewRoutes", () => {
     updatedAt: "2024-01-01T00:00:00.000Z",
   };
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
+  let app: FastifyInstance;
 
-  function buildApp() {
-    const app = createTestApp();
-    app.register(reviewRoutes, { service: mockReviewService, prefix: "/api/reviews" });
-    return app;
-  }
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = createTestApp();
+    await app.register(reviewRoutes, {
+      service: mockReviewService,
+      prefix: "/api/reviews",
+    });
+  });
 
   describe("GET /api/reviews/testimonials", () => {
     it("should return featured testimonials", async () => {
-      const app = buildApp();
       mockReviewService.findFeatured.mockResolvedValue([validReview]);
 
       const response = await app.inject({
@@ -62,7 +63,6 @@ describe("reviewRoutes", () => {
 
   describe("GET /api/reviews/stats", () => {
     it("should return review statistics", async () => {
-      const app = buildApp();
       mockReviewService.getStats.mockResolvedValue({
         totalReviews: 42,
         averageRating: 4.5,
@@ -83,8 +83,11 @@ describe("reviewRoutes", () => {
 
   describe("POST /api/reviews", () => {
     it("should create review when authenticated", async () => {
-      const app = buildApp();
-      verifyToken.mockReturnValue({ userId, email: "user@test.com", role: "user" });
+      verifyToken.mockReturnValue({
+        userId,
+        email: "user@test.com",
+        role: "user",
+      });
       mockReviewService.create.mockResolvedValue(validReview);
 
       const response = await app.inject({
@@ -102,7 +105,6 @@ describe("reviewRoutes", () => {
     });
 
     it("should return 401 when not authenticated", async () => {
-      const app = buildApp();
       const response = await app.inject({
         method: "POST",
         url: "/api/reviews",
@@ -113,8 +115,11 @@ describe("reviewRoutes", () => {
     });
 
     it("should return 400 for invalid body", async () => {
-      const app = buildApp();
-      verifyToken.mockReturnValue({ userId, email: "user@test.com", role: "user" });
+      verifyToken.mockReturnValue({
+        userId,
+        email: "user@test.com",
+        role: "user",
+      });
 
       const response = await app.inject({
         method: "POST",
@@ -131,17 +136,31 @@ describe("reviewRoutes", () => {
 
   describe("GET /api/reviews", () => {
     it("should return paginated reviews when admin", async () => {
-      const app = buildApp();
-      verifyToken.mockReturnValue({ userId: adminId, email: "admin@test.com", role: "admin" });
+      verifyToken.mockReturnValue({
+        userId: adminId,
+        email: "admin@test.com",
+        role: "admin",
+      });
       mockReviewService.findAll.mockResolvedValue({
         items: [validReview],
-        pagination: { page: 1, limit: 10, total: 1, totalPages: 1, hasNext: false, hasPrev: false },
+        pagination: {
+          page: 1,
+          limit: 10,
+          total: 1,
+          totalPages: 1,
+          hasNext: false,
+          hasPrev: false,
+        },
       });
 
       const response = await app.inject({
         method: "GET",
         url: "/api/reviews",
-        headers: authHeader({ userId: adminId, email: "admin@test.com", role: "admin" }),
+        headers: authHeader({
+          userId: adminId,
+          email: "admin@test.com",
+          role: "admin",
+        }),
       });
 
       expect(response.statusCode).toBe(200);
@@ -150,7 +169,6 @@ describe("reviewRoutes", () => {
     });
 
     it("should return 401 when not authenticated", async () => {
-      const app = buildApp();
       const response = await app.inject({
         method: "GET",
         url: "/api/reviews",
@@ -160,8 +178,11 @@ describe("reviewRoutes", () => {
     });
 
     it("should return 403 when not admin", async () => {
-      const app = buildApp();
-      verifyToken.mockReturnValue({ userId, email: "user@test.com", role: "user" });
+      verifyToken.mockReturnValue({
+        userId,
+        email: "user@test.com",
+        role: "user",
+      });
 
       const response = await app.inject({
         method: "GET",
@@ -175,9 +196,15 @@ describe("reviewRoutes", () => {
 
   describe("PATCH /api/reviews/:id", () => {
     it("should update review when authenticated", async () => {
-      const app = buildApp();
-      verifyToken.mockReturnValue({ userId, email: "user@test.com", role: "user" });
-      mockReviewService.update.mockResolvedValue({ ...validReview, text: "Updated" });
+      verifyToken.mockReturnValue({
+        userId,
+        email: "user@test.com",
+        role: "user",
+      });
+      mockReviewService.update.mockResolvedValue({
+        ...validReview,
+        text: "Updated",
+      });
 
       const response = await app.inject({
         method: "PATCH",
@@ -194,7 +221,6 @@ describe("reviewRoutes", () => {
     });
 
     it("should return 401 when not authenticated", async () => {
-      const app = buildApp();
       const response = await app.inject({
         method: "PATCH",
         url: `/api/reviews/${reviewId}`,
@@ -205,8 +231,11 @@ describe("reviewRoutes", () => {
     });
 
     it("should return 400 for invalid id", async () => {
-      const app = buildApp();
-      verifyToken.mockReturnValue({ userId, email: "user@test.com", role: "user" });
+      verifyToken.mockReturnValue({
+        userId,
+        email: "user@test.com",
+        role: "user",
+      });
 
       const response = await app.inject({
         method: "PATCH",
@@ -221,15 +250,25 @@ describe("reviewRoutes", () => {
 
   describe("PATCH /api/reviews/:id/feature", () => {
     it("should feature review when admin", async () => {
-      const app = buildApp();
-      verifyToken.mockReturnValue({ userId: adminId, email: "admin@test.com", role: "admin" });
-      mockReviewService.feature.mockResolvedValue({ ...validReview, isFeatured: true });
+      verifyToken.mockReturnValue({
+        userId: adminId,
+        email: "admin@test.com",
+        role: "admin",
+      });
+      mockReviewService.feature.mockResolvedValue({
+        ...validReview,
+        isFeatured: true,
+      });
 
       const response = await app.inject({
         method: "PATCH",
         url: `/api/reviews/${reviewId}/feature`,
         payload: { isFeatured: true },
-        headers: authHeader({ userId: adminId, email: "admin@test.com", role: "admin" }),
+        headers: authHeader({
+          userId: adminId,
+          email: "admin@test.com",
+          role: "admin",
+        }),
       });
 
       expect(response.statusCode).toBe(200);
@@ -241,7 +280,6 @@ describe("reviewRoutes", () => {
     });
 
     it("should return 401 when not authenticated", async () => {
-      const app = buildApp();
       const response = await app.inject({
         method: "PATCH",
         url: `/api/reviews/${reviewId}/feature`,
@@ -252,8 +290,11 @@ describe("reviewRoutes", () => {
     });
 
     it("should return 403 when not admin", async () => {
-      const app = buildApp();
-      verifyToken.mockReturnValue({ userId, email: "user@test.com", role: "user" });
+      verifyToken.mockReturnValue({
+        userId,
+        email: "user@test.com",
+        role: "user",
+      });
 
       const response = await app.inject({
         method: "PATCH",
@@ -268,8 +309,11 @@ describe("reviewRoutes", () => {
 
   describe("DELETE /api/reviews/:id", () => {
     it("should delete review when authenticated", async () => {
-      const app = buildApp();
-      verifyToken.mockReturnValue({ userId, email: "user@test.com", role: "user" });
+      verifyToken.mockReturnValue({
+        userId,
+        email: "user@test.com",
+        role: "user",
+      });
       mockReviewService.delete.mockResolvedValue(undefined);
 
       const response = await app.inject({
@@ -285,7 +329,6 @@ describe("reviewRoutes", () => {
     });
 
     it("should return 401 when not authenticated", async () => {
-      const app = buildApp();
       const response = await app.inject({
         method: "DELETE",
         url: `/api/reviews/${reviewId}`,
@@ -295,8 +338,11 @@ describe("reviewRoutes", () => {
     });
 
     it("should return 400 for invalid id", async () => {
-      const app = buildApp();
-      verifyToken.mockReturnValue({ userId, email: "user@test.com", role: "user" });
+      verifyToken.mockReturnValue({
+        userId,
+        email: "user@test.com",
+        role: "user",
+      });
 
       const response = await app.inject({
         method: "DELETE",

--- a/apps/backend/src/modules/reviews/review.routes.test.ts
+++ b/apps/backend/src/modules/reviews/review.routes.test.ts
@@ -34,6 +34,12 @@ describe("reviewRoutes", () => {
     updatedAt: "2024-01-01T00:00:00.000Z",
   };
 
+  const testJwtPayload = {
+    userId,
+    email: "user@test.com",
+    role: "user",
+  } as const;
+
   let app: FastifyInstance;
 
   beforeEach(async () => {
@@ -83,24 +89,20 @@ describe("reviewRoutes", () => {
 
   describe("POST /api/reviews", () => {
     it("should create review when authenticated", async () => {
-      verifyToken.mockReturnValue({
-        userId,
-        email: "user@test.com",
-        role: "user",
-      });
+      verifyToken.mockReturnValue(testJwtPayload);
       mockReviewService.create.mockResolvedValue(validReview);
 
       const response = await app.inject({
         method: "POST",
         url: "/api/reviews",
         payload: { text: "Great platform!", rating: 5 },
-        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+        headers: authHeader(testJwtPayload),
       });
 
       expect(response.statusCode).toBe(201);
       expect(mockReviewService.create).toHaveBeenCalledWith({
         data: { text: "Great platform!", rating: 5 },
-        initiator: { id: userId, role: "user" },
+        initiator: { id: testJwtPayload.userId, role: testJwtPayload.role },
       });
     });
 
@@ -115,17 +117,13 @@ describe("reviewRoutes", () => {
     });
 
     it("should return 400 for invalid body", async () => {
-      verifyToken.mockReturnValue({
-        userId,
-        email: "user@test.com",
-        role: "user",
-      });
+      verifyToken.mockReturnValue(testJwtPayload);
 
       const response = await app.inject({
         method: "POST",
         url: "/api/reviews",
         payload: { text: "Hi", rating: 10 },
-        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+        headers: authHeader(testJwtPayload),
       });
 
       expect(response.statusCode).toBe(400);
@@ -178,16 +176,12 @@ describe("reviewRoutes", () => {
     });
 
     it("should return 403 when not admin", async () => {
-      verifyToken.mockReturnValue({
-        userId,
-        email: "user@test.com",
-        role: "user",
-      });
+      verifyToken.mockReturnValue(testJwtPayload);
 
       const response = await app.inject({
         method: "GET",
         url: "/api/reviews",
-        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+        headers: authHeader(testJwtPayload),
       });
 
       expect(response.statusCode).toBe(403);
@@ -196,11 +190,7 @@ describe("reviewRoutes", () => {
 
   describe("PATCH /api/reviews/:id", () => {
     it("should update review when authenticated", async () => {
-      verifyToken.mockReturnValue({
-        userId,
-        email: "user@test.com",
-        role: "user",
-      });
+      verifyToken.mockReturnValue(testJwtPayload);
       mockReviewService.update.mockResolvedValue({
         ...validReview,
         text: "Updated",
@@ -210,13 +200,13 @@ describe("reviewRoutes", () => {
         method: "PATCH",
         url: `/api/reviews/${reviewId}`,
         payload: { text: "Updated" },
-        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+        headers: authHeader(testJwtPayload),
       });
 
       expect(response.statusCode).toBe(200);
       expect(mockReviewService.update).toHaveBeenCalledWith(reviewId, {
         data: { text: "Updated" },
-        initiator: { id: userId, role: "user" },
+        initiator: { id: testJwtPayload.userId, role: testJwtPayload.role },
       });
     });
 
@@ -231,17 +221,13 @@ describe("reviewRoutes", () => {
     });
 
     it("should return 400 for invalid id", async () => {
-      verifyToken.mockReturnValue({
-        userId,
-        email: "user@test.com",
-        role: "user",
-      });
+      verifyToken.mockReturnValue(testJwtPayload);
 
       const response = await app.inject({
         method: "PATCH",
         url: "/api/reviews/bad-id",
         payload: { text: "Updated" },
-        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+        headers: authHeader(testJwtPayload),
       });
 
       expect(response.statusCode).toBe(400);
@@ -290,17 +276,13 @@ describe("reviewRoutes", () => {
     });
 
     it("should return 403 when not admin", async () => {
-      verifyToken.mockReturnValue({
-        userId,
-        email: "user@test.com",
-        role: "user",
-      });
+      verifyToken.mockReturnValue(testJwtPayload);
 
       const response = await app.inject({
         method: "PATCH",
         url: `/api/reviews/${reviewId}/feature`,
         payload: { isFeatured: true },
-        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+        headers: authHeader(testJwtPayload),
       });
 
       expect(response.statusCode).toBe(403);
@@ -309,22 +291,18 @@ describe("reviewRoutes", () => {
 
   describe("DELETE /api/reviews/:id", () => {
     it("should delete review when authenticated", async () => {
-      verifyToken.mockReturnValue({
-        userId,
-        email: "user@test.com",
-        role: "user",
-      });
+      verifyToken.mockReturnValue(testJwtPayload);
       mockReviewService.delete.mockResolvedValue(undefined);
 
       const response = await app.inject({
         method: "DELETE",
         url: `/api/reviews/${reviewId}`,
-        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+        headers: authHeader(testJwtPayload),
       });
 
       expect(response.statusCode).toBe(204);
       expect(mockReviewService.delete).toHaveBeenCalledWith(reviewId, {
-        initiator: { id: userId, role: "user" },
+        initiator: { id: testJwtPayload.userId, role: testJwtPayload.role },
       });
     });
 
@@ -338,16 +316,12 @@ describe("reviewRoutes", () => {
     });
 
     it("should return 400 for invalid id", async () => {
-      verifyToken.mockReturnValue({
-        userId,
-        email: "user@test.com",
-        role: "user",
-      });
+      verifyToken.mockReturnValue(testJwtPayload);
 
       const response = await app.inject({
         method: "DELETE",
         url: "/api/reviews/bad-id",
-        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+        headers: authHeader(testJwtPayload),
       });
 
       expect(response.statusCode).toBe(400);

--- a/apps/backend/src/modules/reviews/review.routes.test.ts
+++ b/apps/backend/src/modules/reviews/review.routes.test.ts
@@ -1,0 +1,310 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestApp, authHeader } from "@/__tests__/build-test-app.js";
+import { reviewRoutes } from "@/modules/reviews/review.routes.js";
+
+const { verifyToken } = vi.hoisted(() => ({
+  verifyToken: vi.fn(),
+}));
+
+vi.mock("@/common/utils/jwt.js", () => ({ verifyToken }));
+
+describe("reviewRoutes", () => {
+  const mockReviewService = {
+    findFeatured: vi.fn(),
+    getStats: vi.fn(),
+    create: vi.fn(),
+    findAll: vi.fn(),
+    update: vi.fn(),
+    feature: vi.fn(),
+    delete: vi.fn(),
+  };
+
+  const userId = "507f1f77bcf86cd799439011";
+  const adminId = "507f1f77bcf86cd799439022";
+  const reviewId = "507f1f77bcf86cd799439033";
+
+  const validReview = {
+    id: reviewId,
+    text: "Great platform!",
+    rating: 5,
+    author: { id: userId, email: "user@test.com", name: "User" },
+    isFeatured: false,
+    createdAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-01T00:00:00.000Z",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function buildApp() {
+    const app = createTestApp();
+    app.register(reviewRoutes, { service: mockReviewService, prefix: "/api/reviews" });
+    return app;
+  }
+
+  describe("GET /api/reviews/testimonials", () => {
+    it("should return featured testimonials", async () => {
+      const app = buildApp();
+      mockReviewService.findFeatured.mockResolvedValue([validReview]);
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/reviews/testimonials",
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.payload);
+      expect(body).toHaveLength(1);
+      expect(body[0].text).toBe("Great platform!");
+    });
+  });
+
+  describe("GET /api/reviews/stats", () => {
+    it("should return review statistics", async () => {
+      const app = buildApp();
+      mockReviewService.getStats.mockResolvedValue({
+        totalReviews: 42,
+        averageRating: 4.5,
+        happyCooksCount: 38,
+      });
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/reviews/stats",
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.payload);
+      expect(body.totalReviews).toBe(42);
+      expect(body.averageRating).toBe(4.5);
+    });
+  });
+
+  describe("POST /api/reviews", () => {
+    it("should create review when authenticated", async () => {
+      const app = buildApp();
+      verifyToken.mockReturnValue({ userId, email: "user@test.com", role: "user" });
+      mockReviewService.create.mockResolvedValue(validReview);
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/reviews",
+        payload: { text: "Great platform!", rating: 5 },
+        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+      });
+
+      expect(response.statusCode).toBe(201);
+      expect(mockReviewService.create).toHaveBeenCalledWith({
+        data: { text: "Great platform!", rating: 5 },
+        initiator: { id: userId, role: "user" },
+      });
+    });
+
+    it("should return 401 when not authenticated", async () => {
+      const app = buildApp();
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/reviews",
+        payload: { text: "Hi", rating: 3 },
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+
+    it("should return 400 for invalid body", async () => {
+      const app = buildApp();
+      verifyToken.mockReturnValue({ userId, email: "user@test.com", role: "user" });
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/reviews",
+        payload: { text: "Hi", rating: 10 },
+        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+      });
+
+      expect(response.statusCode).toBe(400);
+      const body = JSON.parse(response.payload);
+      expect(body.code).toBe("VALIDATION_ERROR");
+    });
+  });
+
+  describe("GET /api/reviews", () => {
+    it("should return paginated reviews when admin", async () => {
+      const app = buildApp();
+      verifyToken.mockReturnValue({ userId: adminId, email: "admin@test.com", role: "admin" });
+      mockReviewService.findAll.mockResolvedValue({
+        items: [validReview],
+        pagination: { page: 1, limit: 10, total: 1, totalPages: 1, hasNext: false, hasPrev: false },
+      });
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/reviews",
+        headers: authHeader({ userId: adminId, email: "admin@test.com", role: "admin" }),
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.payload);
+      expect(body.items).toHaveLength(1);
+    });
+
+    it("should return 401 when not authenticated", async () => {
+      const app = buildApp();
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/reviews",
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+
+    it("should return 403 when not admin", async () => {
+      const app = buildApp();
+      verifyToken.mockReturnValue({ userId, email: "user@test.com", role: "user" });
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/reviews",
+        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+      });
+
+      expect(response.statusCode).toBe(403);
+    });
+  });
+
+  describe("PATCH /api/reviews/:id", () => {
+    it("should update review when authenticated", async () => {
+      const app = buildApp();
+      verifyToken.mockReturnValue({ userId, email: "user@test.com", role: "user" });
+      mockReviewService.update.mockResolvedValue({ ...validReview, text: "Updated" });
+
+      const response = await app.inject({
+        method: "PATCH",
+        url: `/api/reviews/${reviewId}`,
+        payload: { text: "Updated" },
+        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(mockReviewService.update).toHaveBeenCalledWith(reviewId, {
+        data: { text: "Updated" },
+        initiator: { id: userId, role: "user" },
+      });
+    });
+
+    it("should return 401 when not authenticated", async () => {
+      const app = buildApp();
+      const response = await app.inject({
+        method: "PATCH",
+        url: `/api/reviews/${reviewId}`,
+        payload: { text: "Updated" },
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+
+    it("should return 400 for invalid id", async () => {
+      const app = buildApp();
+      verifyToken.mockReturnValue({ userId, email: "user@test.com", role: "user" });
+
+      const response = await app.inject({
+        method: "PATCH",
+        url: "/api/reviews/bad-id",
+        payload: { text: "Updated" },
+        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+  });
+
+  describe("PATCH /api/reviews/:id/feature", () => {
+    it("should feature review when admin", async () => {
+      const app = buildApp();
+      verifyToken.mockReturnValue({ userId: adminId, email: "admin@test.com", role: "admin" });
+      mockReviewService.feature.mockResolvedValue({ ...validReview, isFeatured: true });
+
+      const response = await app.inject({
+        method: "PATCH",
+        url: `/api/reviews/${reviewId}/feature`,
+        payload: { isFeatured: true },
+        headers: authHeader({ userId: adminId, email: "admin@test.com", role: "admin" }),
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(mockReviewService.feature).toHaveBeenCalledWith(
+        reviewId,
+        { initiator: { id: adminId, role: "admin" } },
+        true,
+      );
+    });
+
+    it("should return 401 when not authenticated", async () => {
+      const app = buildApp();
+      const response = await app.inject({
+        method: "PATCH",
+        url: `/api/reviews/${reviewId}/feature`,
+        payload: { isFeatured: true },
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+
+    it("should return 403 when not admin", async () => {
+      const app = buildApp();
+      verifyToken.mockReturnValue({ userId, email: "user@test.com", role: "user" });
+
+      const response = await app.inject({
+        method: "PATCH",
+        url: `/api/reviews/${reviewId}/feature`,
+        payload: { isFeatured: true },
+        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+      });
+
+      expect(response.statusCode).toBe(403);
+    });
+  });
+
+  describe("DELETE /api/reviews/:id", () => {
+    it("should delete review when authenticated", async () => {
+      const app = buildApp();
+      verifyToken.mockReturnValue({ userId, email: "user@test.com", role: "user" });
+      mockReviewService.delete.mockResolvedValue(undefined);
+
+      const response = await app.inject({
+        method: "DELETE",
+        url: `/api/reviews/${reviewId}`,
+        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+      });
+
+      expect(response.statusCode).toBe(204);
+      expect(mockReviewService.delete).toHaveBeenCalledWith(reviewId, {
+        initiator: { id: userId, role: "user" },
+      });
+    });
+
+    it("should return 401 when not authenticated", async () => {
+      const app = buildApp();
+      const response = await app.inject({
+        method: "DELETE",
+        url: `/api/reviews/${reviewId}`,
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+
+    it("should return 400 for invalid id", async () => {
+      const app = buildApp();
+      verifyToken.mockReturnValue({ userId, email: "user@test.com", role: "user" });
+
+      const response = await app.inject({
+        method: "DELETE",
+        url: "/api/reviews/bad-id",
+        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+  });
+});

--- a/apps/backend/src/modules/users/user.routes.test.ts
+++ b/apps/backend/src/modules/users/user.routes.test.ts
@@ -1,5 +1,6 @@
+import type { FastifyInstance } from "fastify";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createTestApp, authHeader } from "@/__tests__/build-test-app.js";
+import { authHeader, createTestApp } from "@/__tests__/build-test-app.js";
 import { userRoutes } from "@/modules/users/user.routes.js";
 
 const { verifyToken } = vi.hoisted(() => ({
@@ -17,20 +18,24 @@ describe("userRoutes", () => {
 
   const userId = "507f1f77bcf86cd799439011";
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
+  let app: FastifyInstance;
 
-  function buildApp() {
-    const app = createTestApp();
-    app.register(userRoutes, { service: mockUserService, prefix: "/api/users" });
-    return app;
-  }
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = createTestApp();
+    await app.register(userRoutes, {
+      service: mockUserService,
+      prefix: "/api/users",
+    });
+  });
 
   describe("GET /api/users/me", () => {
     it("should return current user when authenticated", async () => {
-      const app = buildApp();
-      verifyToken.mockReturnValue({ userId, email: "user@test.com", role: "user" });
+      verifyToken.mockReturnValue({
+        userId,
+        email: "user@test.com",
+        role: "user",
+      });
       mockUserService.getCurrentUser.mockResolvedValue({
         id: userId,
         email: "user@test.com",
@@ -52,7 +57,6 @@ describe("userRoutes", () => {
     });
 
     it("should return 401 when not authenticated", async () => {
-      const app = buildApp();
       const response = await app.inject({
         method: "GET",
         url: "/api/users/me",
@@ -64,11 +68,21 @@ describe("userRoutes", () => {
 
   describe("GET /api/users/me/favorites", () => {
     it("should return favorites when authenticated", async () => {
-      const app = buildApp();
-      verifyToken.mockReturnValue({ userId, email: "user@test.com", role: "user" });
+      verifyToken.mockReturnValue({
+        userId,
+        email: "user@test.com",
+        role: "user",
+      });
       mockUserService.getFavorites.mockResolvedValue({
         items: [],
-        pagination: { page: 1, limit: 10, total: 0, totalPages: 0, hasNext: false, hasPrev: false },
+        pagination: {
+          page: 1,
+          limit: 10,
+          total: 0,
+          totalPages: 0,
+          hasNext: false,
+          hasPrev: false,
+        },
       });
 
       const response = await app.inject({
@@ -88,7 +102,6 @@ describe("userRoutes", () => {
     });
 
     it("should return 401 when not authenticated", async () => {
-      const app = buildApp();
       const response = await app.inject({
         method: "GET",
         url: "/api/users/me/favorites",
@@ -100,11 +113,21 @@ describe("userRoutes", () => {
 
   describe("GET /api/users/me/comments", () => {
     it("should return comments when authenticated", async () => {
-      const app = buildApp();
-      verifyToken.mockReturnValue({ userId, email: "user@test.com", role: "user" });
+      verifyToken.mockReturnValue({
+        userId,
+        email: "user@test.com",
+        role: "user",
+      });
       mockUserService.getComments.mockResolvedValue({
         items: [],
-        pagination: { page: 1, limit: 10, total: 0, totalPages: 0, hasNext: false, hasPrev: false },
+        pagination: {
+          page: 1,
+          limit: 10,
+          total: 0,
+          totalPages: 0,
+          hasNext: false,
+          hasPrev: false,
+        },
       });
 
       const response = await app.inject({
@@ -124,7 +147,6 @@ describe("userRoutes", () => {
     });
 
     it("should return 401 when not authenticated", async () => {
-      const app = buildApp();
       const response = await app.inject({
         method: "GET",
         url: "/api/users/me/comments",

--- a/apps/backend/src/modules/users/user.routes.test.ts
+++ b/apps/backend/src/modules/users/user.routes.test.ts
@@ -18,6 +18,12 @@ describe("userRoutes", () => {
 
   const userId = "507f1f77bcf86cd799439011";
 
+  const testJwtPayload = {
+    userId,
+    email: "user@test.com",
+    role: "user",
+  } as const;
+
   let app: FastifyInstance;
 
   beforeEach(async () => {
@@ -31,14 +37,10 @@ describe("userRoutes", () => {
 
   describe("GET /api/users/me", () => {
     it("should return current user when authenticated", async () => {
-      verifyToken.mockReturnValue({
-        userId,
-        email: "user@test.com",
-        role: "user",
-      });
+      verifyToken.mockReturnValue(testJwtPayload);
       mockUserService.getCurrentUser.mockResolvedValue({
-        id: userId,
-        email: "user@test.com",
+        id: testJwtPayload.userId,
+        email: testJwtPayload.email,
         name: "Test User",
         createdAt: "2024-01-01T00:00:00.000Z",
         updatedAt: "2024-01-01T00:00:00.000Z",
@@ -47,13 +49,15 @@ describe("userRoutes", () => {
       const response = await app.inject({
         method: "GET",
         url: "/api/users/me",
-        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+        headers: authHeader(testJwtPayload),
       });
 
       expect(response.statusCode).toBe(200);
-      expect(mockUserService.getCurrentUser).toHaveBeenCalledWith(userId);
+      expect(mockUserService.getCurrentUser).toHaveBeenCalledWith(
+        testJwtPayload.userId,
+      );
       const body = JSON.parse(response.payload);
-      expect(body.email).toBe("user@test.com");
+      expect(body.email).toBe(testJwtPayload.email);
     });
 
     it("should return 401 when not authenticated", async () => {
@@ -68,11 +72,7 @@ describe("userRoutes", () => {
 
   describe("GET /api/users/me/favorites", () => {
     it("should return favorites when authenticated", async () => {
-      verifyToken.mockReturnValue({
-        userId,
-        email: "user@test.com",
-        role: "user",
-      });
+      verifyToken.mockReturnValue(testJwtPayload);
       mockUserService.getFavorites.mockResolvedValue({
         items: [],
         pagination: {
@@ -88,7 +88,7 @@ describe("userRoutes", () => {
       const response = await app.inject({
         method: "GET",
         url: "/api/users/me/favorites",
-        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+        headers: authHeader(testJwtPayload),
       });
 
       expect(response.statusCode).toBe(200);
@@ -96,7 +96,7 @@ describe("userRoutes", () => {
         userId,
         expect.objectContaining({
           query: expect.any(Object),
-          initiator: { id: userId, role: "user" },
+          initiator: { id: testJwtPayload.userId, role: testJwtPayload.role },
         }),
       );
     });
@@ -113,11 +113,7 @@ describe("userRoutes", () => {
 
   describe("GET /api/users/me/comments", () => {
     it("should return comments when authenticated", async () => {
-      verifyToken.mockReturnValue({
-        userId,
-        email: "user@test.com",
-        role: "user",
-      });
+      verifyToken.mockReturnValue(testJwtPayload);
       mockUserService.getComments.mockResolvedValue({
         items: [],
         pagination: {
@@ -133,7 +129,7 @@ describe("userRoutes", () => {
       const response = await app.inject({
         method: "GET",
         url: "/api/users/me/comments",
-        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+        headers: authHeader(testJwtPayload),
       });
 
       expect(response.statusCode).toBe(200);
@@ -141,7 +137,7 @@ describe("userRoutes", () => {
         userId,
         expect.objectContaining({
           query: expect.any(Object),
-          initiator: { id: userId, role: "user" },
+          initiator: { id: testJwtPayload.userId, role: testJwtPayload.role },
         }),
       );
     });

--- a/apps/backend/src/modules/users/user.routes.test.ts
+++ b/apps/backend/src/modules/users/user.routes.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestApp, authHeader } from "@/__tests__/build-test-app.js";
+import { userRoutes } from "@/modules/users/user.routes.js";
+
+const { verifyToken } = vi.hoisted(() => ({
+  verifyToken: vi.fn(),
+}));
+
+vi.mock("@/common/utils/jwt.js", () => ({ verifyToken }));
+
+describe("userRoutes", () => {
+  const mockUserService = {
+    getCurrentUser: vi.fn(),
+    getFavorites: vi.fn(),
+    getComments: vi.fn(),
+  };
+
+  const userId = "507f1f77bcf86cd799439011";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function buildApp() {
+    const app = createTestApp();
+    app.register(userRoutes, { service: mockUserService, prefix: "/api/users" });
+    return app;
+  }
+
+  describe("GET /api/users/me", () => {
+    it("should return current user when authenticated", async () => {
+      const app = buildApp();
+      verifyToken.mockReturnValue({ userId, email: "user@test.com", role: "user" });
+      mockUserService.getCurrentUser.mockResolvedValue({
+        id: userId,
+        email: "user@test.com",
+        name: "Test User",
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      });
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/users/me",
+        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(mockUserService.getCurrentUser).toHaveBeenCalledWith(userId);
+      const body = JSON.parse(response.payload);
+      expect(body.email).toBe("user@test.com");
+    });
+
+    it("should return 401 when not authenticated", async () => {
+      const app = buildApp();
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/users/me",
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+  });
+
+  describe("GET /api/users/me/favorites", () => {
+    it("should return favorites when authenticated", async () => {
+      const app = buildApp();
+      verifyToken.mockReturnValue({ userId, email: "user@test.com", role: "user" });
+      mockUserService.getFavorites.mockResolvedValue({
+        items: [],
+        pagination: { page: 1, limit: 10, total: 0, totalPages: 0, hasNext: false, hasPrev: false },
+      });
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/users/me/favorites",
+        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(mockUserService.getFavorites).toHaveBeenCalledWith(
+        userId,
+        expect.objectContaining({
+          query: expect.any(Object),
+          initiator: { id: userId, role: "user" },
+        }),
+      );
+    });
+
+    it("should return 401 when not authenticated", async () => {
+      const app = buildApp();
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/users/me/favorites",
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+  });
+
+  describe("GET /api/users/me/comments", () => {
+    it("should return comments when authenticated", async () => {
+      const app = buildApp();
+      verifyToken.mockReturnValue({ userId, email: "user@test.com", role: "user" });
+      mockUserService.getComments.mockResolvedValue({
+        items: [],
+        pagination: { page: 1, limit: 10, total: 0, totalPages: 0, hasNext: false, hasPrev: false },
+      });
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/users/me/comments",
+        headers: authHeader({ userId, email: "user@test.com", role: "user" }),
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(mockUserService.getComments).toHaveBeenCalledWith(
+        userId,
+        expect.objectContaining({
+          query: expect.any(Object),
+          initiator: { id: userId, role: "user" },
+        }),
+      );
+    });
+
+    it("should return 401 when not authenticated", async () => {
+      const app = buildApp();
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/users/me/comments",
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+  });
+});


### PR DESCRIPTION
## Related Issues

<!-- Link related issues: Closes #123, Refs #456 -->

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [x] Tests
- [ ] Other

## Description

Adds integration tests for all backend HTTP routes using Fastify `inject()` with mocked services.

### What was done:
- Created `createTestApp()` helper in `src/__tests__/build-test-app.ts` for setting up a test Fastify instance with Zod validation, serialization, and error handler.
- Registered routes in `beforeEach` to ensure test isolation.

### New test files (7 files, 73 tests):
- `auth.routes.test.ts` — register, login, validation errors, conflict
- `recipe.routes.test.ts` — CRUD recipes, comments, 401/400/404 handling
- `user.routes.test.ts` — /me, /me/favorites, /me/comments
- `category.routes.test.ts` — admin-only routes, 401/403/400
- `favorite.routes.test.ts` — add/remove/check favorite
- `recipe-rating.routes.test.ts` — rate/unrate, validation
- `review.routes.test.ts` — testimonials, stats, feature, admin-only

### Bug fix included:
- Fixed `errorHandler.ts` to properly catch Fastify validation errors (`FST_ERR_VALIDATION`) and return `VALIDATION_ERROR` instead of generic `HTTP_ERROR`.

## Screenshots

<!-- If applicable, add screenshots or recordings of the changes -->

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Added/updated tests for new functionality
- [ ] Updated documentation (if needed)