### PR TITLE
refactor(tests): remove as unknown as casts from service tests

### DIFF
--- a/apps/backend/src/__tests__/helpers.ts
+++ b/apps/backend/src/__tests__/helpers.ts
@@ -7,7 +7,6 @@ import type { CacheService } from "@/common/cache/cache.service.js";
 import { createMemoryCache } from "@/common/cache/memory-cache.service.js";
 import type { TypedEmitter } from "@/common/events.js";
 import { createEventBus } from "@/common/events.js";
-import type { Logger } from "@/common/logger.js";
 import type { CategoryDocument } from "@/modules/categories/category.model.js";
 import type { CommentDocument } from "@/modules/comments/comment.model.js";
 import type {
@@ -20,35 +19,6 @@ import type { UserDocument } from "@/modules/users/user.model.js";
 type LocalProcedure = (...args: unknown[]) => unknown;
 function viFn<T extends LocalProcedure>(fn?: T): Mock<T> {
   return vi.fn(fn);
-}
-
-// ── Logger mocks ──
-
-export interface MockLogger extends Logger {
-  spies: {
-    fatal: Mock;
-    error: Mock;
-    warn: Mock;
-    info: Mock;
-    debug: Mock;
-    trace: Mock;
-  };
-}
-
-export function createMockLogger(): MockLogger {
-  const spies = {
-    fatal: vi.fn(),
-    error: vi.fn(),
-    warn: vi.fn(),
-    info: vi.fn(),
-    debug: vi.fn(),
-    trace: vi.fn(),
-  };
-
-  return {
-    ...spies,
-    spies,
-  } as unknown as MockLogger;
 }
 
 // ── Fastify mocks ──
@@ -260,16 +230,6 @@ export function createMockUserModel(overrides: Record<string, Mock> = {}) {
 export function createMockUserRepository(overrides: Record<string, Mock> = {}) {
   return {
     ...createMockRepository(overrides),
-    ...overrides,
-  };
-}
-
-export function createMockPasswordService(
-  overrides: Record<string, Mock> = {},
-) {
-  return {
-    hash: viFn().mockResolvedValue("hashed-password"),
-    verify: viFn().mockResolvedValue(true),
     ...overrides,
   };
 }

--- a/apps/backend/src/__tests__/helpers.ts
+++ b/apps/backend/src/__tests__/helpers.ts
@@ -3,10 +3,6 @@ import type { FastifyReply, FastifyRequest } from "fastify";
 import { Types } from "mongoose";
 import type { Mock } from "vitest";
 import { vi } from "vitest";
-import type { CacheService } from "@/common/cache/cache.service.js";
-import { createMemoryCache } from "@/common/cache/memory-cache.service.js";
-import type { TypedEmitter } from "@/common/events.js";
-import { createEventBus } from "@/common/events.js";
 import type { CategoryDocument } from "@/modules/categories/category.model.js";
 import type { CommentDocument } from "@/modules/comments/comment.model.js";
 import type {
@@ -168,54 +164,11 @@ export function createReviewDoc(
 
 // ── Mongoose model mock factories ──
 
-export function createMockRepository(overrides: Record<string, Mock> = {}) {
-  return {
-    findById: viFn(),
-    findDocumentById: viFn(),
-    findOne: viFn(),
-    exists: viFn(),
-    create: viFn(),
-    update: viFn(),
-    delete: viFn(),
-    save: viFn(),
-    deleteDocument: viFn(),
-    aggregate: viFn(),
-    ...overrides,
-  };
-}
-
 const chainable = {
   select: viFn().mockReturnThis(),
   sort: viFn().mockReturnThis(),
   lean: viFn().mockResolvedValue(null),
 };
-
-export function createMockCategoryModel(overrides: Record<string, Mock> = {}) {
-  return {
-    find: viFn().mockReturnValue(chainable),
-    aggregate: viFn(),
-    create: viFn(),
-    findByIdAndDelete: viFn(),
-    countDocuments: viFn().mockResolvedValue(0),
-    exists: viFn(),
-    ...overrides,
-  };
-}
-
-export function createMockCategoryRepository(
-  overrides: Record<string, Mock> = {},
-) {
-  return {
-    findMany: viFn(),
-    findById: viFn(),
-    findOne: viFn(),
-    exists: viFn(),
-    create: viFn(),
-    delete: viFn(),
-    aggregate: viFn(),
-    ...overrides,
-  };
-}
 
 export function createMockUserModel(overrides: Record<string, Mock> = {}) {
   return {
@@ -225,167 +178,6 @@ export function createMockUserModel(overrides: Record<string, Mock> = {}) {
     create: viFn(),
     ...overrides,
   };
-}
-
-export function createMockUserRepository(overrides: Record<string, Mock> = {}) {
-  return {
-    ...createMockRepository(overrides),
-    ...overrides,
-  };
-}
-
-export function createMockRecipeModel(overrides: Record<string, Mock> = {}) {
-  return {
-    findById: viFn(),
-    aggregate: viFn(),
-    create: viFn(),
-    countDocuments: viFn().mockResolvedValue(0),
-    exists: viFn(),
-    ...overrides,
-  };
-}
-
-export function createMockRecipeRepository(
-  overrides: Record<string, Mock> = {},
-) {
-  return {
-    aggregateSearch: viFn(),
-    aggregateById: viFn(),
-    findDocumentById: viFn(),
-    create: viFn(),
-    save: viFn(),
-    deleteDocument: viFn(),
-    findById: viFn(),
-    findOne: viFn(),
-    find: viFn(),
-    update: viFn(),
-    delete: viFn(),
-    exists: viFn(),
-    count: viFn(),
-    aggregate: viFn(),
-    ...overrides,
-  };
-}
-
-export function createMockCommentModel(overrides: Record<string, Mock> = {}) {
-  return {
-    aggregate: viFn(),
-    findById: viFn(),
-    create: viFn(),
-    ...overrides,
-  };
-}
-
-export function createMockCommentRepository(
-  overrides: Record<string, Mock> = {},
-) {
-  return {
-    findByRecipe: viFn(),
-    findByAuthor: viFn(),
-    findById: viFn(),
-    findOne: viFn(),
-    create: viFn(),
-    delete: viFn(),
-    aggregate: viFn(),
-    ...overrides,
-  };
-}
-
-export function createMockFavoriteModel(overrides: Record<string, Mock> = {}) {
-  return {
-    aggregate: viFn(),
-    create: viFn(),
-    findOneAndDelete: viFn(),
-    exists: viFn(),
-    findOne: viFn(),
-    ...overrides,
-  };
-}
-
-export function createMockFavoriteRepository(
-  overrides: Record<string, Mock> = {},
-) {
-  return {
-    create: viFn(),
-    delete: viFn(),
-    exists: viFn(),
-    findByUser: viFn(),
-    findOne: viFn(),
-    aggregate: viFn(),
-    ...overrides,
-  };
-}
-
-export function createMockRatingModel(overrides: Record<string, Mock> = {}) {
-  return {
-    findOneAndUpdate: viFn(),
-    findOneAndDelete: viFn(),
-    exists: viFn(),
-    ...overrides,
-  };
-}
-
-export function createMockRecipeRatingRepository(
-  overrides: Record<string, Mock> = {},
-) {
-  return {
-    ...createMockRepository(overrides),
-    upsert: viFn(),
-    ...overrides,
-  };
-}
-
-export function createMockReviewRepository(
-  overrides: Record<string, Mock> = {},
-) {
-  return {
-    ...createMockRepository(overrides),
-    findFeatured: viFn(),
-    findAll: viFn(),
-    aggregateStats: viFn(),
-    ...overrides,
-  };
-}
-
-// ── Cache mock ──
-
-export interface MockCache extends CacheService {
-  spies: {
-    get: Mock;
-    set: Mock;
-    delete: Mock;
-    deletePattern: Mock;
-    flush: Mock;
-  };
-}
-
-export function createMockCache(): MockCache {
-  const memoryCache = createMemoryCache();
-
-  const spies = {
-    get: vi.spyOn(memoryCache, "get"),
-    set: vi.spyOn(memoryCache, "set"),
-    delete: vi.spyOn(memoryCache, "delete"),
-    deletePattern: vi.spyOn(memoryCache, "deletePattern"),
-    flush: vi.spyOn(memoryCache, "flush"),
-  };
-
-  return {
-    ...memoryCache,
-    spies,
-  };
-}
-
-// ── Event bus mock ──
-
-export interface MockBus extends TypedEmitter {
-  emit: Mock;
-}
-
-export function createMockBus(): MockBus {
-  const bus = createEventBus();
-  const emit = vi.spyOn(bus, "emit");
-  return Object.assign(bus, { emit });
 }
 
 // ── Service param builders ──

--- a/apps/backend/src/common/bootstrap/admin.test.ts
+++ b/apps/backend/src/common/bootstrap/admin.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createMockLogger } from "@/__tests__/helpers.js";
 import { ensureRootAdmin } from "@/common/bootstrap/admin.js";
 
 const { UserModel } = await vi.hoisted(async () => ({
@@ -17,7 +16,11 @@ vi.mock("@/modules/users/user.model.js", () => ({
 }));
 
 describe("ensureRootAdmin", () => {
-  const log = createMockLogger();
+  const mockLogger = {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+  };
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -27,7 +30,7 @@ describe("ensureRootAdmin", () => {
     UserModel.findOne.mockResolvedValue(null);
     UserModel.create.mockResolvedValue({});
 
-    await ensureRootAdmin(log);
+    await ensureRootAdmin(mockLogger);
 
     expect(UserModel.findOne).toHaveBeenCalledWith({ role: "admin" });
     expect(UserModel.create).toHaveBeenCalledWith({
@@ -36,16 +39,16 @@ describe("ensureRootAdmin", () => {
       name: "Root Admin",
       role: "admin",
     });
-    expect(log.info).toHaveBeenCalled();
+    expect(mockLogger.info).toHaveBeenCalled();
   });
 
   it("should not create admin when one already exists", async () => {
     UserModel.findOne.mockResolvedValue({ email: "existing@admin.com" });
 
-    await ensureRootAdmin(log);
+    await ensureRootAdmin(mockLogger);
 
     expect(UserModel.findOne).toHaveBeenCalledWith({ role: "admin" });
-    expect(log.info).toHaveBeenCalled();
+    expect(mockLogger.info).toHaveBeenCalled();
     expect(UserModel.create).not.toHaveBeenCalled();
   });
 });

--- a/apps/backend/src/common/bootstrap/admin.ts
+++ b/apps/backend/src/common/bootstrap/admin.ts
@@ -2,7 +2,9 @@ import type { Logger } from "@/common/logger.js";
 import { env } from "@/config/env.js";
 import { UserModel } from "@/modules/users/user.model.js";
 
-export async function ensureRootAdmin(log: Logger): Promise<void> {
+type LoggerPort = Pick<Logger, "error" | "warn" | "info">;
+
+export async function ensureRootAdmin(log: LoggerPort): Promise<void> {
   const existing = await UserModel.findOne({ role: "admin" });
   if (existing) {
     log.info({ email: env.ROOT_ADMIN_EMAIL }, "Root admin already exists");

--- a/apps/backend/src/common/utils/validation.ts
+++ b/apps/backend/src/common/utils/validation.ts
@@ -32,7 +32,7 @@ export function assertValidId<const T extends string>(
  * @throws {NotFoundError} if the ID does not exist in the model
  */
 export async function assertExists<T extends { _id: Types.ObjectId }>(
-  model: Model<unknown> | BaseRepository<T>,
+  model: Model<unknown> | Pick<BaseRepository<T>, "exists" | "modelName">,
   id: string,
 ): Promise<void> {
   const exists = await model.exists({ _id: id });

--- a/apps/backend/src/modules/auth/auth.service.test.ts
+++ b/apps/backend/src/modules/auth/auth.service.test.ts
@@ -1,13 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  createMockLogger,
-  createMockPasswordService,
-  createMockRepository,
-  createUserDoc,
-} from "@/__tests__/helpers.js";
+import { createUserDoc } from "@/__tests__/helpers.js";
 import { ConflictError, UnauthorizedError } from "@/common/errors.js";
-import type { PasswordService } from "@/common/passwords/password.service.js";
-import type { UserRepository } from "@/modules/users/user.repository.js";
 import { createAuthService } from "./auth.service.js";
 
 const { signToken } = vi.hoisted(() => ({
@@ -17,13 +10,24 @@ const { signToken } = vi.hoisted(() => ({
 vi.mock("@/common/utils/jwt.js", () => ({ signToken }));
 
 describe("authService", () => {
-  const userRepository = createMockRepository();
-  const passwordService = createMockPasswordService();
-  const log = createMockLogger();
+  const mockUserRepository = {
+    findOne: vi.fn(),
+    exists: vi.fn(),
+    create: vi.fn(),
+  };
+  const mockPasswordService = {
+    hash: vi.fn().mockResolvedValue("hashed-password"),
+    verify: vi.fn().mockResolvedValue(true),
+  };
+  const mockLogger = {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+  };
   const service = createAuthService(
-    userRepository as unknown as UserRepository,
-    passwordService as unknown as PasswordService,
-    log,
+    mockUserRepository,
+    mockPasswordService,
+    mockLogger,
   );
 
   beforeEach(() => {
@@ -32,9 +36,9 @@ describe("authService", () => {
 
   describe("register", () => {
     it("should register user and return auth response", async () => {
-      userRepository.exists.mockResolvedValue(false);
+      mockUserRepository.exists.mockResolvedValue(false);
       const doc = createUserDoc({ email: "new@test.com", name: "New User" });
-      userRepository.create.mockResolvedValue(doc);
+      mockUserRepository.create.mockResolvedValue(doc);
 
       const result = await service.register({
         email: "new@test.com",
@@ -42,11 +46,11 @@ describe("authService", () => {
         name: "New User",
       });
 
-      expect(userRepository.exists).toHaveBeenCalledWith({
+      expect(mockUserRepository.exists).toHaveBeenCalledWith({
         email: "new@test.com",
       });
-      expect(passwordService.hash).toHaveBeenCalledWith("Password123!");
-      expect(userRepository.create).toHaveBeenCalledWith({
+      expect(mockPasswordService.hash).toHaveBeenCalledWith("Password123!");
+      expect(mockUserRepository.create).toHaveBeenCalledWith({
         email: "new@test.com",
         password: "hashed-password",
         name: "New User",
@@ -57,7 +61,7 @@ describe("authService", () => {
     });
 
     it("should throw ConflictError when email already in use", async () => {
-      userRepository.exists.mockResolvedValue(true);
+      mockUserRepository.exists.mockResolvedValue(true);
 
       await expect(
         service.register({
@@ -79,18 +83,18 @@ describe("authService", () => {
   describe("login", () => {
     it("should login and return auth response", async () => {
       const doc = createUserDoc({ email: "user@test.com" });
-      userRepository.findOne.mockResolvedValue(doc);
+      mockUserRepository.findOne.mockResolvedValue(doc);
 
       const result = await service.login({
         email: "user@test.com",
         password: "correct-password",
       });
 
-      expect(userRepository.findOne).toHaveBeenCalledWith(
+      expect(mockUserRepository.findOne).toHaveBeenCalledWith(
         { email: "user@test.com" },
         { select: "+password" },
       );
-      expect(passwordService.verify).toHaveBeenCalledWith(
+      expect(mockPasswordService.verify).toHaveBeenCalledWith(
         "correct-password",
         "hashedPassword",
       );
@@ -99,7 +103,7 @@ describe("authService", () => {
     });
 
     it("should throw UnauthorizedError when user not found", async () => {
-      userRepository.findOne.mockResolvedValue(null);
+      mockUserRepository.findOne.mockResolvedValue(null);
 
       await expect(
         service.login({ email: "nobody@test.com", password: "pass" }),
@@ -111,8 +115,8 @@ describe("authService", () => {
 
     it("should throw UnauthorizedError when password is wrong", async () => {
       const doc = createUserDoc({ email: "user@test.com" });
-      userRepository.findOne.mockResolvedValue(doc);
-      passwordService.verify.mockResolvedValue(false);
+      mockUserRepository.findOne.mockResolvedValue(doc);
+      mockPasswordService.verify.mockResolvedValue(false);
 
       await expect(
         service.login({ email: "user@test.com", password: "wrong" }),

--- a/apps/backend/src/modules/auth/auth.service.ts
+++ b/apps/backend/src/modules/auth/auth.service.ts
@@ -11,10 +11,13 @@ export interface AuthService {
   login(data: LoginBody): Promise<AuthResponse>;
 }
 
+type UserRepositoryPort = Pick<UserRepository, "findOne" | "exists" | "create">;
+type LoggerPort = Pick<Logger, "error" | "warn" | "info">;
+
 export function createAuthService(
-  userRepository: UserRepository,
+  userRepository: UserRepositoryPort,
   passwordService: PasswordService,
-  log: Logger,
+  log: LoggerPort,
 ): AuthService {
   return {
     register: async (data) => {

--- a/apps/backend/src/modules/categories/category.service.test.ts
+++ b/apps/backend/src/modules/categories/category.service.test.ts
@@ -1,39 +1,41 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { withPagination } from "@recipes/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createCategoryDoc,
-  createMockBus,
-  createMockCache,
-  createMockCategoryRepository,
-  createMockRecipeRepository,
   createObjectId,
   initiator,
   noInitiator,
 } from "@/__tests__/helpers.js";
 import { ConflictError, NotFoundError } from "@/common/errors.js";
 import { categoryCache } from "@/modules/categories/category.cache.js";
-import type { CategoryRepository } from "@/modules/categories/category.repository.js";
 import { createCategoryService } from "@/modules/categories/category.service.js";
-import type { RecipeRepository } from "@/modules/recipes/recipe.repository.js";
 
 describe("categoryService", () => {
-  const categoryRepository = createMockCategoryRepository();
-  const recipeRepository = createMockRecipeRepository();
-  const cache = createMockCache();
-  const bus = createMockBus();
+  const mockCategoryRepository = {
+    findMany: vi.fn(),
+    create: vi.fn(),
+    delete: vi.fn(),
+  };
+  const mockRecipeRepository = {
+    count: vi.fn(),
+  };
+  const mockCache = {
+    get: vi.fn(),
+    set: vi.fn(),
+    deletePattern: vi.fn(),
+  };
+  const mockBus = {
+    emit: vi.fn(),
+  };
   const service = createCategoryService(
-    categoryRepository as unknown as CategoryRepository,
-    recipeRepository as unknown as RecipeRepository,
-    cache,
-    bus,
+    mockCategoryRepository,
+    mockRecipeRepository,
+    mockCache,
+    mockBus,
   );
 
-  beforeEach(async () => {
+  beforeEach(() => {
     vi.clearAllMocks();
-    await cache.flush();
-  });
-
-  afterEach(() => {
-    vi.resetAllMocks();
   });
 
   describe("findAll", () => {
@@ -48,7 +50,7 @@ describe("categoryService", () => {
           recipeCount: 0,
         },
       ];
-      categoryRepository.findMany.mockResolvedValue([docs, 2]);
+      mockCategoryRepository.findMany.mockResolvedValue([docs, 2]);
 
       const query = { sort: "name" as const, page: 1, limit: 10 };
       const result = await service.findAll({
@@ -56,17 +58,19 @@ describe("categoryService", () => {
         initiator: noInitiator(),
       });
 
-      expect(categoryRepository.findMany).toHaveBeenCalledWith(query);
+      expect(mockCategoryRepository.findMany).toHaveBeenCalledWith(query);
       expect(result.items).toHaveLength(2);
       expect(result.items[0]?.name).toBe("Desserts");
       expect(result.items[0]?.recipeCount).toBe(5);
       expect(result.items[1]?.recipeCount).toBe(0);
       expect(result.pagination.total).toBe(2);
-      expect(cache.get).toHaveBeenCalledWith(categoryCache.keys.list(query));
+      expect(mockCache.get).toHaveBeenCalledWith(
+        categoryCache.keys.list(query),
+      );
     });
 
     it("should return empty paginated result when no categories exist", async () => {
-      categoryRepository.findMany.mockResolvedValue([[], 0]);
+      mockCategoryRepository.findMany.mockResolvedValue([[], 0]);
 
       const query = { sort: "name" as const, page: 1, limit: 10 };
       const result = await service.findAll({
@@ -85,25 +89,30 @@ describe("categoryService", () => {
           recipeCount: 3,
         },
       ];
-      categoryRepository.findMany.mockResolvedValue([docs, 1]);
+      mockCategoryRepository.findMany.mockResolvedValue([docs, 1]);
 
       const query = { sort: "name" as const, page: 1, limit: 10 };
       await service.findAll({
         query,
         initiator: noInitiator(),
       });
-      expect(cache.get).toHaveBeenCalledWith(categoryCache.keys.list(query));
+      expect(mockCache.get).toHaveBeenCalledWith(
+        categoryCache.keys.list(query),
+      );
       vi.clearAllMocks();
+      mockCache.get.mockResolvedValue(withPagination(docs, 1, 1, 10));
 
       const result = await service.findAll({
         query,
         initiator: noInitiator(),
       });
 
-      expect(categoryRepository.findMany).not.toHaveBeenCalled();
+      expect(mockCategoryRepository.findMany).not.toHaveBeenCalled();
       expect(result.items).toHaveLength(1);
       expect(result.pagination.total).toBe(1);
-      expect(cache.get).toHaveBeenCalledWith(categoryCache.keys.list(query));
+      expect(mockCache.get).toHaveBeenCalledWith(
+        categoryCache.keys.list(query),
+      );
     });
   });
 
@@ -113,45 +122,45 @@ describe("categoryService", () => {
         name: "New Category",
         slug: "new-category",
       });
-      categoryRepository.create.mockResolvedValue(doc);
+      mockCategoryRepository.create.mockResolvedValue(doc);
 
       const result = await service.create({
         data: { name: "New Category" },
         initiator: initiator(),
       });
 
-      expect(categoryRepository.create).toHaveBeenCalledWith({
+      expect(mockCategoryRepository.create).toHaveBeenCalledWith({
         name: "New Category",
       });
       expect(result.name).toBe("New Category");
       expect(result.slug).toBe("new-category");
-      expect(cache.deletePattern).toHaveBeenCalledWith(
+      expect(mockCache.deletePattern).toHaveBeenCalledWith(
         categoryCache.keys.allPattern(),
       );
-      expect(bus.emit).toHaveBeenCalledWith("category:changed");
+      expect(mockBus.emit).toHaveBeenCalledWith("category:changed");
     });
   });
 
   describe("deleteById", () => {
     it("should delete category when no recipes exist", async () => {
-      recipeRepository.count.mockResolvedValue(0);
-      categoryRepository.delete.mockResolvedValue(createCategoryDoc());
+      mockRecipeRepository.count.mockResolvedValue(0);
+      mockCategoryRepository.delete.mockResolvedValue(createCategoryDoc());
 
       const id = createObjectId().toString();
       await service.deleteById(id, { initiator: initiator() });
 
-      expect(recipeRepository.count).toHaveBeenCalledWith({
+      expect(mockRecipeRepository.count).toHaveBeenCalledWith({
         category: id,
       });
-      expect(categoryRepository.delete).toHaveBeenCalledWith(id);
-      expect(cache.deletePattern).toHaveBeenCalledWith(
+      expect(mockCategoryRepository.delete).toHaveBeenCalledWith(id);
+      expect(mockCache.deletePattern).toHaveBeenCalledWith(
         categoryCache.keys.allPattern(),
       );
-      expect(bus.emit).toHaveBeenCalledWith("category:changed");
+      expect(mockBus.emit).toHaveBeenCalledWith("category:changed");
     });
 
     it("should throw ConflictError when recipes exist", async () => {
-      recipeRepository.count.mockResolvedValue(3);
+      mockRecipeRepository.count.mockResolvedValue(3);
 
       await expect(
         service.deleteById(createObjectId().toString(), {
@@ -161,8 +170,8 @@ describe("categoryService", () => {
     });
 
     it("should throw NotFoundError when category not found", async () => {
-      recipeRepository.count.mockResolvedValue(0);
-      categoryRepository.delete.mockResolvedValue(null);
+      mockRecipeRepository.count.mockResolvedValue(0);
+      mockCategoryRepository.delete.mockResolvedValue(null);
 
       await expect(
         service.deleteById(createObjectId().toString(), {

--- a/apps/backend/src/modules/categories/category.service.ts
+++ b/apps/backend/src/modules/categories/category.service.ts
@@ -27,11 +27,19 @@ export interface CategoryService {
   deleteById(id: string, params: DeleteMethodParams): Promise<void>;
 }
 
+type CategoryRepositoryPort = Pick<
+  CategoryRepository,
+  "findMany" | "create" | "delete"
+>;
+type RecipeRepositoryPort = Pick<RecipeRepository, "count">;
+type CacheServicePort = Pick<CacheService, "get" | "set" | "deletePattern">;
+type TypedEmitterPort = Pick<TypedEmitter, "emit">;
+
 export function createCategoryService(
-  repository: CategoryRepository,
-  recipeRepository: RecipeRepository,
-  cache: CacheService,
-  bus: TypedEmitter,
+  repository: CategoryRepositoryPort,
+  recipeRepository: RecipeRepositoryPort,
+  cache: CacheServicePort,
+  bus: TypedEmitterPort,
 ): CategoryService {
   return {
     findAll: async ({ query }) => {

--- a/apps/backend/src/modules/comments/comment.service.test.ts
+++ b/apps/backend/src/modules/comments/comment.service.test.ts
@@ -1,9 +1,6 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createCommentDoc,
-  createMockCommentRepository,
-  createMockRecipeRepository,
-  createMockUserRepository,
   createObjectId,
   initiator,
   queryParams,
@@ -13,33 +10,38 @@ import {
   ForbiddenError,
   NotFoundError,
 } from "@/common/errors.js";
-import type { CommentRepository } from "@/modules/comments/comment.repository.js";
 import { createCommentService } from "@/modules/comments/comment.service.js";
-import type { RecipeRepository } from "@/modules/recipes/recipe.repository.js";
-import type { UserRepository } from "@/modules/users/user.repository.js";
 
 describe("commentService", () => {
-  const commentRepository = createMockCommentRepository();
-  const recipeRepository = createMockRecipeRepository();
-  const userRepository = createMockUserRepository();
+  const mockCommentRepository = {
+    findByRecipe: vi.fn(),
+    findByAuthor: vi.fn(),
+    findById: vi.fn(),
+    create: vi.fn(),
+    delete: vi.fn(),
+  };
+  const mockRecipeRepository = {
+    exists: vi.fn(),
+    modelName: "Recipe",
+  };
+  const mockUserRepository = {
+    exists: vi.fn(),
+    modelName: "User",
+  };
 
   const service = createCommentService(
-    commentRepository as unknown as CommentRepository,
-    recipeRepository as unknown as RecipeRepository,
-    userRepository as unknown as UserRepository,
+    mockCommentRepository,
+    mockRecipeRepository,
+    mockUserRepository,
   );
 
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  afterEach(() => {
-    vi.resetAllMocks();
-  });
-
   describe("findByRecipe", () => {
     it("should return paginated comments for recipe", async () => {
-      recipeRepository.exists.mockResolvedValue(true);
+      mockRecipeRepository.exists.mockResolvedValue(true);
       const authorId = createObjectId();
       const recipeId = createObjectId();
       const populatedComment = {
@@ -50,7 +52,10 @@ describe("commentService", () => {
         createdAt: new Date("2024-01-01"),
         updatedAt: new Date("2024-01-01"),
       };
-      commentRepository.findByRecipe.mockResolvedValue([[populatedComment], 1]);
+      mockCommentRepository.findByRecipe.mockResolvedValue([
+        [populatedComment],
+        1,
+      ]);
 
       const result = await service.findByRecipe(
         recipeId.toString(),
@@ -69,7 +74,7 @@ describe("commentService", () => {
     });
 
     it("should throw NotFoundError when recipe not found", async () => {
-      recipeRepository.exists.mockResolvedValue(null);
+      mockRecipeRepository.exists.mockResolvedValue(null);
 
       await expect(
         service.findByRecipe(createObjectId().toString(), queryParams()),
@@ -77,8 +82,8 @@ describe("commentService", () => {
     });
 
     it("should return empty result when no comments found", async () => {
-      recipeRepository.exists.mockResolvedValue(true);
-      commentRepository.findByRecipe.mockResolvedValue([[], 0]);
+      mockRecipeRepository.exists.mockResolvedValue(true);
+      mockCommentRepository.findByRecipe.mockResolvedValue([[], 0]);
 
       const result = await service.findByRecipe(
         createObjectId().toString(),
@@ -91,7 +96,7 @@ describe("commentService", () => {
 
   describe("findByAuthor", () => {
     it("should return paginated comments by author", async () => {
-      userRepository.exists.mockResolvedValue(true);
+      mockUserRepository.exists.mockResolvedValue(true);
       const authorId = createObjectId();
       const populatedComment = {
         _id: createObjectId(),
@@ -101,7 +106,10 @@ describe("commentService", () => {
         createdAt: new Date("2024-01-01"),
         updatedAt: new Date("2024-01-01"),
       };
-      commentRepository.findByAuthor.mockResolvedValue([[populatedComment], 1]);
+      mockCommentRepository.findByAuthor.mockResolvedValue([
+        [populatedComment],
+        1,
+      ]);
 
       const result = await service.findByAuthor(
         authorId.toString(),
@@ -121,15 +129,15 @@ describe("commentService", () => {
 
   describe("create", () => {
     it("should create a comment and return populated DTO", async () => {
-      recipeRepository.exists.mockResolvedValue(true);
-      userRepository.exists.mockResolvedValue(true);
+      mockRecipeRepository.exists.mockResolvedValue(true);
+      mockUserRepository.exists.mockResolvedValue(true);
 
       const authorId = createObjectId();
       const populated = {
         ...createCommentDoc({ text: "Great recipe!" }),
         author: { _id: authorId, name: "User", email: "user@test.com" },
       };
-      commentRepository.create.mockResolvedValue(populated);
+      mockCommentRepository.create.mockResolvedValue(populated);
 
       const recipeId = createObjectId().toString();
       const init = initiator(authorId.toString());
@@ -138,7 +146,7 @@ describe("commentService", () => {
         initiator: init,
       });
 
-      expect(commentRepository.create).toHaveBeenCalledWith({
+      expect(mockCommentRepository.create).toHaveBeenCalledWith({
         text: "Great recipe!",
         recipe: recipeId,
         author: init.id,
@@ -165,7 +173,7 @@ describe("commentService", () => {
     });
 
     it("should throw NotFoundError when recipe not found", async () => {
-      recipeRepository.exists.mockResolvedValue(null);
+      mockRecipeRepository.exists.mockResolvedValue(null);
 
       await expect(
         service.create(createObjectId().toString(), {
@@ -176,8 +184,8 @@ describe("commentService", () => {
     });
 
     it("should throw NotFoundError when author not found", async () => {
-      recipeRepository.exists.mockResolvedValue(true);
-      userRepository.exists.mockResolvedValue(null);
+      mockRecipeRepository.exists.mockResolvedValue(true);
+      mockUserRepository.exists.mockResolvedValue(null);
 
       await expect(
         service.create(createObjectId().toString(), {
@@ -192,25 +200,25 @@ describe("commentService", () => {
     it("should delete comment when author matches", async () => {
       const authorId = createObjectId();
       const comment = createCommentDoc({ author: authorId });
-      commentRepository.findById.mockResolvedValue(comment);
+      mockCommentRepository.findById.mockResolvedValue(comment);
 
       await service.delete(createObjectId().toString(), {
         initiator: initiator(authorId.toString()),
       });
 
-      expect(commentRepository.findById).toHaveBeenCalled();
-      expect(commentRepository.delete).toHaveBeenCalled();
+      expect(mockCommentRepository.findById).toHaveBeenCalled();
+      expect(mockCommentRepository.delete).toHaveBeenCalled();
     });
 
     it("should delete comment when user is admin", async () => {
       const comment = createCommentDoc();
-      commentRepository.findById.mockResolvedValue(comment);
+      mockCommentRepository.findById.mockResolvedValue(comment);
 
       await service.delete(createObjectId().toString(), {
         initiator: initiator(createObjectId().toString(), "admin"),
       });
 
-      expect(commentRepository.delete).toHaveBeenCalled();
+      expect(mockCommentRepository.delete).toHaveBeenCalled();
     });
 
     it("should throw BadRequestError for invalid comment ID", async () => {
@@ -220,7 +228,7 @@ describe("commentService", () => {
     });
 
     it("should throw NotFoundError when comment not found", async () => {
-      commentRepository.findById.mockResolvedValue(null);
+      mockCommentRepository.findById.mockResolvedValue(null);
 
       await expect(
         service.delete(createObjectId().toString(), {
@@ -231,7 +239,7 @@ describe("commentService", () => {
 
     it("should throw ForbiddenError when not author and not admin", async () => {
       const comment = createCommentDoc();
-      commentRepository.findById.mockResolvedValue(comment);
+      mockCommentRepository.findById.mockResolvedValue(comment);
 
       await expect(
         service.delete(createObjectId().toString(), {

--- a/apps/backend/src/modules/comments/comment.service.ts
+++ b/apps/backend/src/modules/comments/comment.service.ts
@@ -28,10 +28,17 @@ export interface CommentService {
   delete(commentId: string, params: DeleteMethodParams): Promise<void>;
 }
 
+type CommentRepositoryPort = Pick<
+  CommentRepository,
+  "findByRecipe" | "findByAuthor" | "findById" | "create" | "delete"
+>;
+type RecipeRepositoryPort = Pick<RecipeRepository, "exists" | "modelName">;
+type UserRepositoryPort = Pick<UserRepository, "exists" | "modelName">;
+
 export function createCommentService(
-  repository: CommentRepository,
-  recipeRepository: RecipeRepository,
-  userRepository: UserRepository,
+  repository: CommentRepositoryPort,
+  recipeRepository: RecipeRepositoryPort,
+  userRepository: UserRepositoryPort,
 ): CommentService {
   return {
     findByRecipe: async (recipeId, { query, initiator }) => {

--- a/apps/backend/src/modules/favorites/favorite.service.test.ts
+++ b/apps/backend/src/modules/favorites/favorite.service.test.ts
@@ -1,8 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  createMockFavoriteRepository,
-  createMockRecipeRepository,
-  createMockUserRepository,
   createObjectId,
   createRecipeDoc,
   initiator,
@@ -10,20 +7,28 @@ import {
   queryParams,
 } from "@/__tests__/helpers.js";
 import { BadRequestError, NotFoundError } from "@/common/errors.js";
-import type { FavoriteRepository } from "@/modules/favorites/favorite.repository.js";
 import { createFavoriteService } from "@/modules/favorites/favorite.service.js";
-import type { RecipeRepository } from "@/modules/recipes/recipe.repository.js";
-import type { UserRepository } from "@/modules/users/user.repository.js";
 
 describe("favoriteService", () => {
-  const favoriteRepository = createMockFavoriteRepository();
-  const recipeRepository = createMockRecipeRepository();
-  const userRepository = createMockUserRepository();
+  const mockFavoriteRepository = {
+    create: vi.fn(),
+    delete: vi.fn(),
+    exists: vi.fn(),
+    findByUser: vi.fn(),
+  };
+  const mockRecipeRepository = {
+    exists: vi.fn(),
+    modelName: "Recipe",
+  };
+  const mockUserRepository = {
+    exists: vi.fn(),
+    modelName: "User",
+  };
 
   const service = createFavoriteService(
-    favoriteRepository as unknown as FavoriteRepository,
-    recipeRepository as unknown as RecipeRepository,
-    userRepository as unknown as UserRepository,
+    mockFavoriteRepository,
+    mockRecipeRepository,
+    mockUserRepository,
   );
 
   beforeEach(() => {
@@ -32,15 +37,15 @@ describe("favoriteService", () => {
 
   describe("add", () => {
     it("should add a favorite and return favorited: true", async () => {
-      userRepository.exists.mockResolvedValue(true);
-      recipeRepository.exists.mockResolvedValue(true);
+      mockUserRepository.exists.mockResolvedValue(true);
+      mockRecipeRepository.exists.mockResolvedValue(true);
 
       const init = initiator();
       const recipeId = createObjectId().toString();
       const result = await service.add(recipeId, { initiator: init });
 
       expect(result).toEqual({ favorited: true });
-      expect(favoriteRepository.create).toHaveBeenCalledWith({
+      expect(mockFavoriteRepository.create).toHaveBeenCalledWith({
         user: init.id,
         recipe: recipeId,
       });
@@ -55,7 +60,7 @@ describe("favoriteService", () => {
     });
 
     it("should throw BadRequestError for invalid recipe ID", async () => {
-      userRepository.exists.mockResolvedValue(true);
+      mockUserRepository.exists.mockResolvedValue(true);
 
       await expect(
         service.add("invalid-id", { initiator: initiator() }),
@@ -63,8 +68,8 @@ describe("favoriteService", () => {
     });
 
     it("should throw NotFoundError when user does not exist", async () => {
-      userRepository.exists.mockResolvedValue(false);
-      recipeRepository.exists.mockResolvedValue(true);
+      mockUserRepository.exists.mockResolvedValue(false);
+      mockRecipeRepository.exists.mockResolvedValue(true);
 
       await expect(
         service.add(createObjectId().toString(), { initiator: initiator() }),
@@ -72,8 +77,8 @@ describe("favoriteService", () => {
     });
 
     it("should throw NotFoundError when recipe does not exist", async () => {
-      userRepository.exists.mockResolvedValue(true);
-      recipeRepository.exists.mockResolvedValue(false);
+      mockUserRepository.exists.mockResolvedValue(true);
+      mockRecipeRepository.exists.mockResolvedValue(false);
 
       await expect(
         service.add(createObjectId().toString(), { initiator: initiator() }),
@@ -83,15 +88,15 @@ describe("favoriteService", () => {
 
   describe("remove", () => {
     it("should remove a favorite and return favorited: false", async () => {
-      userRepository.exists.mockResolvedValue(true);
-      recipeRepository.exists.mockResolvedValue(true);
+      mockUserRepository.exists.mockResolvedValue(true);
+      mockRecipeRepository.exists.mockResolvedValue(true);
 
       const init = initiator();
       const recipeId = createObjectId().toString();
       const result = await service.remove(recipeId, { initiator: init });
 
       expect(result).toEqual({ favorited: false });
-      expect(favoriteRepository.delete).toHaveBeenCalledWith({
+      expect(mockFavoriteRepository.delete).toHaveBeenCalledWith({
         user: init.id,
         recipe: recipeId,
       });
@@ -100,7 +105,7 @@ describe("favoriteService", () => {
 
   describe("isFavorited", () => {
     it("should return true when favorite exists", async () => {
-      favoriteRepository.exists.mockResolvedValue(true);
+      mockFavoriteRepository.exists.mockResolvedValue(true);
 
       const result = await service.isFavorited(createObjectId().toString(), {
         initiator: initiator(),
@@ -110,7 +115,7 @@ describe("favoriteService", () => {
     });
 
     it("should return false when favorite does not exist", async () => {
-      favoriteRepository.exists.mockResolvedValue(false);
+      mockFavoriteRepository.exists.mockResolvedValue(false);
 
       const result = await service.isFavorited(createObjectId().toString(), {
         initiator: initiator(),
@@ -122,11 +127,11 @@ describe("favoriteService", () => {
 
   describe("findByUser", () => {
     it("should return paginated recipes from favorites", async () => {
-      userRepository.exists.mockResolvedValue(true);
+      mockUserRepository.exists.mockResolvedValue(true);
       const recipe = populateRecipeDoc(createRecipeDoc(), {
         isFavorited: true,
       });
-      favoriteRepository.findByUser.mockResolvedValue([[recipe], 1]);
+      mockFavoriteRepository.findByUser.mockResolvedValue([[recipe], 1]);
 
       const result = await service.findByUser(
         createObjectId().toString(),
@@ -138,8 +143,8 @@ describe("favoriteService", () => {
     });
 
     it("should return empty paginated result when no favorites", async () => {
-      userRepository.exists.mockResolvedValue(true);
-      favoriteRepository.findByUser.mockResolvedValue([[], 0]);
+      mockUserRepository.exists.mockResolvedValue(true);
+      mockFavoriteRepository.findByUser.mockResolvedValue([[], 0]);
 
       const result = await service.findByUser(
         createObjectId().toString(),

--- a/apps/backend/src/modules/favorites/favorite.service.ts
+++ b/apps/backend/src/modules/favorites/favorite.service.ts
@@ -34,10 +34,17 @@ export interface FavoriteService {
   ): Promise<boolean>;
 }
 
+type FavoriteRepositoryPort = Pick<
+  FavoriteRepository,
+  "findByUser" | "create" | "delete" | "exists"
+>;
+type RecipeRepositoryPort = Pick<RecipeRepository, "exists" | "modelName">;
+type UserRepositoryPort = Pick<UserRepository, "exists" | "modelName">;
+
 export function createFavoriteService(
-  repository: FavoriteRepository,
-  recipeRepository: RecipeRepository,
-  userRepository: UserRepository,
+  repository: FavoriteRepositoryPort,
+  recipeRepository: RecipeRepositoryPort,
+  userRepository: UserRepositoryPort,
 ): FavoriteService {
   async function validateUser(id: string): Promise<void> {
     assertValidId(id, "User");

--- a/apps/backend/src/modules/recipe-ratings/recipe-rating.service.test.ts
+++ b/apps/backend/src/modules/recipe-ratings/recipe-rating.service.test.ts
@@ -1,29 +1,30 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  createMockBus,
-  createMockRecipeRatingRepository,
-  createMockRecipeRepository,
-  createMockUserRepository,
-  createObjectId,
-  initiator,
-} from "@/__tests__/helpers.js";
+import { createObjectId, initiator } from "@/__tests__/helpers.js";
 import { BadRequestError, NotFoundError } from "@/common/errors.js";
-import type { RecipeRatingRepository } from "@/modules/recipe-ratings/recipe-rating.repository.js";
 import { createRecipeRatingService } from "@/modules/recipe-ratings/recipe-rating.service.js";
-import type { RecipeRepository } from "@/modules/recipes/recipe.repository.js";
-import type { UserRepository } from "@/modules/users/user.repository.js";
 
 describe("recipeRatingService", () => {
-  const repository = createMockRecipeRatingRepository();
-  const recipeRepository = createMockRecipeRepository();
-  const userRepository = createMockUserRepository();
-  const bus = createMockBus();
+  const mockRecipeRatingRepository = {
+    upsert: vi.fn(),
+    delete: vi.fn(),
+  };
+  const mockRecipeRepository = {
+    exists: vi.fn(),
+    modelName: "Recipe",
+  };
+  const mockUserRepository = {
+    exists: vi.fn(),
+    modelName: "User",
+  };
+  const mockBus = {
+    emit: vi.fn(),
+  };
 
   const service = createRecipeRatingService(
-    repository as unknown as RecipeRatingRepository,
-    recipeRepository as unknown as RecipeRepository,
-    userRepository as unknown as UserRepository,
-    bus,
+    mockRecipeRatingRepository,
+    mockRecipeRepository,
+    mockUserRepository,
+    mockBus,
   );
 
   beforeEach(() => {
@@ -32,9 +33,9 @@ describe("recipeRatingService", () => {
 
   describe("rate", () => {
     it("should create a new rating", async () => {
-      userRepository.exists.mockResolvedValue(true);
-      recipeRepository.exists.mockResolvedValue(true);
-      repository.upsert.mockResolvedValue({
+      mockUserRepository.exists.mockResolvedValue(true);
+      mockRecipeRepository.exists.mockResolvedValue(true);
+      mockRecipeRatingRepository.upsert.mockResolvedValue({
         _id: createObjectId(),
         user: createObjectId(),
         recipe: createObjectId(),
@@ -50,17 +51,17 @@ describe("recipeRatingService", () => {
       });
 
       expect(result).toEqual({ value: 4 });
-      expect(repository.upsert).toHaveBeenCalledWith(
+      expect(mockRecipeRatingRepository.upsert).toHaveBeenCalledWith(
         { user: init.id, recipe: recipeId },
         4,
       );
-      expect(bus.emit).toHaveBeenCalledWith("recipe:rated", recipeId);
+      expect(mockBus.emit).toHaveBeenCalledWith("recipe:rated", recipeId);
     });
 
     it("should update an existing rating", async () => {
-      userRepository.exists.mockResolvedValue(true);
-      recipeRepository.exists.mockResolvedValue(true);
-      repository.upsert.mockResolvedValue({
+      mockUserRepository.exists.mockResolvedValue(true);
+      mockRecipeRepository.exists.mockResolvedValue(true);
+      mockRecipeRatingRepository.upsert.mockResolvedValue({
         _id: createObjectId(),
         user: createObjectId(),
         recipe: createObjectId(),
@@ -88,7 +89,7 @@ describe("recipeRatingService", () => {
     });
 
     it("should throw BadRequestError for invalid recipe ID", async () => {
-      userRepository.exists.mockResolvedValue(true);
+      mockUserRepository.exists.mockResolvedValue(true);
 
       await expect(
         service.rate("invalid-id", {
@@ -99,8 +100,8 @@ describe("recipeRatingService", () => {
     });
 
     it("should throw NotFoundError when user does not exist", async () => {
-      userRepository.exists.mockResolvedValue(false);
-      recipeRepository.exists.mockResolvedValue(true);
+      mockUserRepository.exists.mockResolvedValue(false);
+      mockRecipeRepository.exists.mockResolvedValue(true);
 
       await expect(
         service.rate(createObjectId().toString(), {
@@ -111,8 +112,8 @@ describe("recipeRatingService", () => {
     });
 
     it("should throw NotFoundError when recipe does not exist", async () => {
-      userRepository.exists.mockResolvedValue(true);
-      recipeRepository.exists.mockResolvedValue(false);
+      mockUserRepository.exists.mockResolvedValue(true);
+      mockRecipeRepository.exists.mockResolvedValue(false);
 
       await expect(
         service.rate(createObjectId().toString(), {
@@ -125,9 +126,9 @@ describe("recipeRatingService", () => {
 
   describe("remove", () => {
     it("should remove an existing rating", async () => {
-      userRepository.exists.mockResolvedValue(true);
-      recipeRepository.exists.mockResolvedValue(true);
-      repository.delete.mockResolvedValue({
+      mockUserRepository.exists.mockResolvedValue(true);
+      mockRecipeRepository.exists.mockResolvedValue(true);
+      mockRecipeRatingRepository.delete.mockResolvedValue({
         _id: createObjectId(),
         user: createObjectId(),
         recipe: createObjectId(),
@@ -139,17 +140,17 @@ describe("recipeRatingService", () => {
       const recipeId = createObjectId().toString();
       await service.remove(recipeId, { initiator: init });
 
-      expect(repository.delete).toHaveBeenCalledWith({
+      expect(mockRecipeRatingRepository.delete).toHaveBeenCalledWith({
         user: init.id,
         recipe: recipeId,
       });
-      expect(bus.emit).toHaveBeenCalledWith("recipe:rated", recipeId);
+      expect(mockBus.emit).toHaveBeenCalledWith("recipe:rated", recipeId);
     });
 
     it("should throw NotFoundError when rating does not exist", async () => {
-      userRepository.exists.mockResolvedValue(true);
-      recipeRepository.exists.mockResolvedValue(true);
-      repository.delete.mockResolvedValue(null);
+      mockUserRepository.exists.mockResolvedValue(true);
+      mockRecipeRepository.exists.mockResolvedValue(true);
+      mockRecipeRatingRepository.delete.mockResolvedValue(null);
 
       await expect(
         service.remove(createObjectId().toString(), {
@@ -167,8 +168,8 @@ describe("recipeRatingService", () => {
     });
 
     it("should throw NotFoundError when recipe does not exist", async () => {
-      userRepository.exists.mockResolvedValue(true);
-      recipeRepository.exists.mockResolvedValue(false);
+      mockUserRepository.exists.mockResolvedValue(true);
+      mockRecipeRepository.exists.mockResolvedValue(false);
 
       await expect(
         service.remove(createObjectId().toString(), {

--- a/apps/backend/src/modules/recipe-ratings/recipe-rating.service.ts
+++ b/apps/backend/src/modules/recipe-ratings/recipe-rating.service.ts
@@ -18,11 +18,19 @@ export interface RecipeRatingService {
   remove(recipeId: string, params: DeleteMethodParams): Promise<void>;
 }
 
+type RecipeRatingRepositoryPort = Pick<
+  RecipeRatingRepository,
+  "upsert" | "delete"
+>;
+type RecipeRepositoryPort = Pick<RecipeRepository, "exists" | "modelName">;
+type UserRepositoryPort = Pick<UserRepository, "exists" | "modelName">;
+type TypedEmitterPort = Pick<TypedEmitter, "emit">;
+
 export function createRecipeRatingService(
-  repository: RecipeRatingRepository,
-  recipeRepository: RecipeRepository,
-  userRepository: UserRepository,
-  bus: TypedEmitter,
+  repository: RecipeRatingRepositoryPort,
+  recipeRepository: RecipeRepositoryPort,
+  userRepository: UserRepositoryPort,
+  bus: TypedEmitterPort,
 ): RecipeRatingService {
   async function validateUser(userId: string): Promise<void> {
     assertValidId(userId, "User");

--- a/apps/backend/src/modules/recipes/recipe.service.test.ts
+++ b/apps/backend/src/modules/recipes/recipe.service.test.ts
@@ -2,12 +2,6 @@ import type { Minutes, RecipeQuery } from "@recipes/shared";
 import type { Types } from "mongoose";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  createMockBus,
-  createMockCache,
-  createMockCategoryRepository,
-  createMockFavoriteRepository,
-  createMockRecipeRepository,
-  createMockUserRepository,
   createObjectId,
   createRecipeDoc,
   initiator,
@@ -19,12 +13,8 @@ import {
   ForbiddenError,
   NotFoundError,
 } from "@/common/errors.js";
-import type { CategoryRepository } from "@/modules/categories/category.repository.js";
-import type { FavoriteRepository } from "@/modules/favorites/favorite.repository.js";
 import { recipeCache } from "@/modules/recipes/recipe.cache.js";
-import type { RecipeRepository } from "@/modules/recipes/recipe.repository.js";
 import { createRecipeService } from "@/modules/recipes/recipe.service.js";
-import type { UserRepository } from "@/modules/users/user.repository.js";
 
 function createMockRecipe(authorId?: Types.ObjectId) {
   const author = authorId ?? createObjectId();
@@ -41,30 +31,56 @@ function createMockRecipe(authorId?: Types.ObjectId) {
 }
 
 describe("recipeService", () => {
-  const recipeRepository = createMockRecipeRepository();
-  const userRepository = createMockUserRepository();
-  const favoriteRepository = createMockFavoriteRepository();
-  const categoryRepository = createMockCategoryRepository();
-  const cache = createMockCache();
-  const bus = createMockBus();
+  const mockRecipeRepository = {
+    findDocumentById: vi.fn(),
+    create: vi.fn(),
+    save: vi.fn(),
+    deleteDocument: vi.fn(),
+    aggregateSearch: vi.fn(),
+    aggregateById: vi.fn(),
+  };
+  const mockUserRepository = {
+    exists: vi.fn(),
+    modelName: "User",
+  };
+  const mockFavoriteRepository = {
+    exists: vi.fn(),
+    findByUser: vi.fn(),
+    create: vi.fn(),
+    delete: vi.fn(),
+    isFavorited: vi.fn(),
+  };
+  const mockCategoryRepository = {
+    exists: vi.fn(),
+    modelName: "Category",
+  };
+  const mockCache = {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+    deletePattern: vi.fn(),
+  };
+  const mockBus = {
+    emit: vi.fn(),
+  };
+
   const service = createRecipeService(
-    recipeRepository as unknown as RecipeRepository,
-    userRepository as unknown as UserRepository,
-    favoriteRepository as unknown as FavoriteRepository,
-    categoryRepository as unknown as CategoryRepository,
-    cache,
-    bus,
+    mockRecipeRepository,
+    mockUserRepository,
+    mockFavoriteRepository,
+    mockCategoryRepository,
+    mockCache,
+    mockBus,
   );
 
-  beforeEach(async () => {
+  beforeEach(() => {
     vi.clearAllMocks();
-    await cache.flush();
   });
 
   describe("findAll", () => {
     it("should return paginated recipes", async () => {
       const populated = populateRecipeDoc(createRecipeDoc());
-      recipeRepository.aggregateSearch.mockResolvedValue([[populated], 1]);
+      mockRecipeRepository.aggregateSearch.mockResolvedValue([[populated], 1]);
 
       const query = {
         page: 1,
@@ -79,11 +95,11 @@ describe("recipeService", () => {
       expect(result.items).toHaveLength(1);
       expect(result.items[0]?.title).toBe("Test Recipe");
       expect(result.pagination.total).toBe(1);
-      expect(cache.get).toHaveBeenCalledWith(recipeCache.keys.list(query));
+      expect(mockCache.get).toHaveBeenCalledWith(recipeCache.keys.list(query));
     });
 
     it("should return empty when aggregate returns empty result", async () => {
-      recipeRepository.aggregateSearch.mockResolvedValue([[], 0]);
+      mockRecipeRepository.aggregateSearch.mockResolvedValue([[], 0]);
 
       const query = {
         page: 1,
@@ -112,8 +128,8 @@ describe("recipeService", () => {
       });
 
       expect(result.items).toEqual([]);
-      expect(recipeRepository.aggregateSearch).not.toHaveBeenCalled();
-      expect(cache.get).not.toHaveBeenCalled();
+      expect(mockRecipeRepository.aggregateSearch).not.toHaveBeenCalled();
+      expect(mockCache.get).not.toHaveBeenCalled();
     });
 
     it("should return rating data from aggregation", async () => {
@@ -122,7 +138,7 @@ describe("recipeService", () => {
         averageRating: 4.2,
         ratingCount: 15,
       });
-      recipeRepository.aggregateSearch.mockResolvedValue([[populated], 1]);
+      mockRecipeRepository.aggregateSearch.mockResolvedValue([[populated], 1]);
 
       const query = {
         page: 1,
@@ -141,7 +157,7 @@ describe("recipeService", () => {
 
     it("should return null ratings when recipe has no ratings", async () => {
       const populated = populateRecipeDoc(createRecipeDoc());
-      recipeRepository.aggregateSearch.mockResolvedValue([[populated], 1]);
+      mockRecipeRepository.aggregateSearch.mockResolvedValue([[populated], 1]);
 
       const query = {
         page: 1,
@@ -162,7 +178,7 @@ describe("recipeService", () => {
   describe("findById", () => {
     it("should return recipe by ID", async () => {
       const populated = populateRecipeDoc(createRecipeDoc());
-      recipeRepository.aggregateById.mockResolvedValue(populated);
+      mockRecipeRepository.aggregateById.mockResolvedValue(populated);
 
       const id = createObjectId().toString();
       const result = await service.findById(id, {
@@ -170,25 +186,27 @@ describe("recipeService", () => {
       });
 
       expect(result.title).toBe("Test Recipe");
-      expect(cache.get).toHaveBeenCalledWith(recipeCache.keys.byId(id));
+      expect(mockCache.get).toHaveBeenCalledWith(recipeCache.keys.byId(id));
     });
 
     it("should return cached recipe on second call for unauthenticated user", async () => {
       const populated = populateRecipeDoc(createRecipeDoc());
-      recipeRepository.aggregateById.mockResolvedValue(populated);
+      mockRecipeRepository.aggregateById.mockResolvedValue(populated);
 
       const id = createObjectId().toString();
       await service.findById(id, { initiator: noInitiator() });
+      expect(mockCache.get).toHaveBeenCalledWith(recipeCache.keys.byId(id));
 
       vi.clearAllMocks();
+      mockCache.get.mockResolvedValue(populated);
 
       const result = await service.findById(id, {
         initiator: noInitiator(),
       });
 
-      expect(recipeRepository.aggregateById).not.toHaveBeenCalled();
+      expect(mockRecipeRepository.aggregateById).not.toHaveBeenCalled();
       expect(result.title).toBe("Test Recipe");
-      expect(cache.get).toHaveBeenCalledWith(recipeCache.keys.byId(id));
+      expect(mockCache.get).toHaveBeenCalledWith(recipeCache.keys.byId(id));
     });
 
     it("should throw BadRequestError for invalid ID", async () => {
@@ -200,7 +218,8 @@ describe("recipeService", () => {
     });
 
     it("should throw NotFoundError when recipe not found", async () => {
-      recipeRepository.aggregateById.mockResolvedValue(undefined);
+      mockRecipeRepository.aggregateById.mockResolvedValue(undefined);
+      mockCache.get.mockResolvedValue(undefined);
 
       const id = createObjectId().toString();
       await expect(
@@ -208,7 +227,7 @@ describe("recipeService", () => {
           initiator: noInitiator(),
         }),
       ).rejects.toThrow(NotFoundError);
-      expect(cache.get).toHaveBeenCalledWith(recipeCache.keys.byId(id));
+      expect(mockCache.get).toHaveBeenCalledWith(recipeCache.keys.byId(id));
     });
 
     it("should return rating data from aggregation", async () => {
@@ -217,7 +236,7 @@ describe("recipeService", () => {
         averageRating: 3.8,
         ratingCount: 42,
       });
-      recipeRepository.aggregateById.mockResolvedValue(populated);
+      mockRecipeRepository.aggregateById.mockResolvedValue(populated);
 
       const id = createObjectId().toString();
       const result = await service.findById(id, {
@@ -243,8 +262,8 @@ describe("recipeService", () => {
     };
 
     it("should create and return a recipe", async () => {
-      categoryRepository.exists.mockResolvedValue(true);
-      userRepository.exists.mockResolvedValue(true);
+      mockCategoryRepository.exists.mockResolvedValue(true);
+      mockUserRepository.exists.mockResolvedValue(true);
 
       const authorId = createObjectId();
       const categoryId = createObjectId();
@@ -256,14 +275,14 @@ describe("recipeService", () => {
         },
       );
 
-      recipeRepository.create.mockResolvedValue(populated);
+      mockRecipeRepository.create.mockResolvedValue(populated);
 
       const result = await service.create({
         data: { ...createData, category: categoryId.toString() },
         initiator: initiator(authorId.toString()),
       });
 
-      expect(recipeRepository.create).toHaveBeenCalledWith({
+      expect(mockRecipeRepository.create).toHaveBeenCalledWith({
         ...createData,
         category: categoryId.toString(),
         author: authorId.toString(),
@@ -272,10 +291,10 @@ describe("recipeService", () => {
       expect(result.userRating).toBeNull();
       expect(result.averageRating).toBeNull();
       expect(result.ratingCount).toBe(0);
-      expect(cache.deletePattern).toHaveBeenCalledWith(
+      expect(mockCache.deletePattern).toHaveBeenCalledWith(
         recipeCache.keys.listPattern(),
       );
-      expect(bus.emit).toHaveBeenCalledWith("recipe:changed");
+      expect(mockBus.emit).toHaveBeenCalledWith("recipe:changed");
     });
 
     it("should throw BadRequestError for invalid author ID", async () => {
@@ -297,7 +316,7 @@ describe("recipeService", () => {
     });
 
     it("should throw NotFoundError when category not found", async () => {
-      categoryRepository.exists.mockResolvedValue(null);
+      mockCategoryRepository.exists.mockResolvedValue(null);
 
       await expect(
         service.create({
@@ -308,8 +327,8 @@ describe("recipeService", () => {
     });
 
     it("should throw NotFoundError when author not found", async () => {
-      categoryRepository.exists.mockResolvedValue(true);
-      userRepository.exists.mockResolvedValue(null);
+      mockCategoryRepository.exists.mockResolvedValue(true);
+      mockUserRepository.exists.mockResolvedValue(null);
 
       await expect(
         service.create({
@@ -324,9 +343,9 @@ describe("recipeService", () => {
     it("should update recipe when author matches", async () => {
       const authorId = createObjectId();
       const recipe = createMockRecipe(authorId);
-      recipeRepository.findDocumentById.mockResolvedValue(recipe);
-      favoriteRepository.exists.mockResolvedValue(false);
-      recipeRepository.save.mockResolvedValue(
+      mockRecipeRepository.findDocumentById.mockResolvedValue(recipe);
+      mockFavoriteRepository.exists.mockResolvedValue(false);
+      mockRecipeRepository.save.mockResolvedValue(
         populateRecipeDoc(createRecipeDoc({ author: authorId }), {
           title: "Updated",
         }),
@@ -338,29 +357,29 @@ describe("recipeService", () => {
         initiator: initiator(authorId.toString()),
       });
 
-      expect(recipeRepository.findDocumentById).toHaveBeenCalledWith(id, {
+      expect(mockRecipeRepository.findDocumentById).toHaveBeenCalledWith(id, {
         populate: false,
       });
-      expect(recipeRepository.save).toHaveBeenCalledWith(recipe, {
+      expect(mockRecipeRepository.save).toHaveBeenCalledWith(recipe, {
         title: "Updated",
       });
       expect(result.title).toBe("Updated");
       expect(result.userRating).toBeNull();
       expect(result.averageRating).toBeNull();
       expect(result.ratingCount).toBe(0);
-      expect(cache.delete).toHaveBeenCalledWith(recipeCache.keys.byId(id));
-      expect(cache.deletePattern).toHaveBeenCalledWith(
+      expect(mockCache.delete).toHaveBeenCalledWith(recipeCache.keys.byId(id));
+      expect(mockCache.deletePattern).toHaveBeenCalledWith(
         recipeCache.keys.listPattern(),
       );
-      expect(bus.emit).toHaveBeenCalledWith("recipe:changed");
+      expect(mockBus.emit).toHaveBeenCalledWith("recipe:changed");
     });
 
     it("should update recipe when user is admin", async () => {
       const authorId = createObjectId();
       const recipe = createMockRecipe(authorId);
-      recipeRepository.findDocumentById.mockResolvedValue(recipe);
-      favoriteRepository.exists.mockResolvedValue(false);
-      recipeRepository.save.mockResolvedValue(
+      mockRecipeRepository.findDocumentById.mockResolvedValue(recipe);
+      mockFavoriteRepository.exists.mockResolvedValue(false);
+      mockRecipeRepository.save.mockResolvedValue(
         populateRecipeDoc(createRecipeDoc({ author: authorId }), {
           title: "Updated",
         }),
@@ -373,11 +392,11 @@ describe("recipeService", () => {
           initiator: initiator(createObjectId().toString(), "admin"),
         }),
       ).resolves.toBeDefined();
-      expect(cache.delete).toHaveBeenCalledWith(recipeCache.keys.byId(id));
-      expect(cache.deletePattern).toHaveBeenCalledWith(
+      expect(mockCache.delete).toHaveBeenCalledWith(recipeCache.keys.byId(id));
+      expect(mockCache.deletePattern).toHaveBeenCalledWith(
         recipeCache.keys.listPattern(),
       );
-      expect(bus.emit).toHaveBeenCalledWith("recipe:changed");
+      expect(mockBus.emit).toHaveBeenCalledWith("recipe:changed");
     });
 
     it("should throw BadRequestError for invalid ID", async () => {
@@ -390,7 +409,7 @@ describe("recipeService", () => {
     });
 
     it("should throw NotFoundError when recipe not found", async () => {
-      recipeRepository.findDocumentById.mockResolvedValue(null);
+      mockRecipeRepository.findDocumentById.mockResolvedValue(null);
 
       await expect(
         service.update(createObjectId().toString(), {
@@ -402,7 +421,7 @@ describe("recipeService", () => {
 
     it("should throw ForbiddenError when not author and not admin", async () => {
       const recipe = createMockRecipe();
-      recipeRepository.findDocumentById.mockResolvedValue(recipe);
+      mockRecipeRepository.findDocumentById.mockResolvedValue(recipe);
 
       await expect(
         service.update(recipe._id.toString(), {
@@ -417,7 +436,7 @@ describe("recipeService", () => {
     it("should delete recipe when author matches", async () => {
       const authorId = createObjectId();
       const recipe = createMockRecipe(authorId);
-      recipeRepository.findDocumentById.mockResolvedValue(recipe);
+      mockRecipeRepository.findDocumentById.mockResolvedValue(recipe);
 
       const id = createObjectId().toString();
       await expect(
@@ -425,17 +444,17 @@ describe("recipeService", () => {
           initiator: initiator(authorId.toString()),
         }),
       ).resolves.toBeUndefined();
-      expect(recipeRepository.deleteDocument).toHaveBeenCalledWith(recipe);
-      expect(cache.delete).toHaveBeenCalledWith(recipeCache.keys.byId(id));
-      expect(cache.deletePattern).toHaveBeenCalledWith(
+      expect(mockRecipeRepository.deleteDocument).toHaveBeenCalledWith(recipe);
+      expect(mockCache.delete).toHaveBeenCalledWith(recipeCache.keys.byId(id));
+      expect(mockCache.deletePattern).toHaveBeenCalledWith(
         recipeCache.keys.listPattern(),
       );
-      expect(bus.emit).toHaveBeenCalledWith("recipe:changed");
+      expect(mockBus.emit).toHaveBeenCalledWith("recipe:changed");
     });
 
     it("should delete recipe when user is admin", async () => {
       const recipe = createMockRecipe();
-      recipeRepository.findDocumentById.mockResolvedValue(recipe);
+      mockRecipeRepository.findDocumentById.mockResolvedValue(recipe);
 
       const id = createObjectId().toString();
       await expect(
@@ -443,12 +462,12 @@ describe("recipeService", () => {
           initiator: initiator(createObjectId().toString(), "admin"),
         }),
       ).resolves.toBeUndefined();
-      expect(recipeRepository.deleteDocument).toHaveBeenCalledWith(recipe);
-      expect(cache.delete).toHaveBeenCalledWith(recipeCache.keys.byId(id));
-      expect(cache.deletePattern).toHaveBeenCalledWith(
+      expect(mockRecipeRepository.deleteDocument).toHaveBeenCalledWith(recipe);
+      expect(mockCache.delete).toHaveBeenCalledWith(recipeCache.keys.byId(id));
+      expect(mockCache.deletePattern).toHaveBeenCalledWith(
         recipeCache.keys.listPattern(),
       );
-      expect(bus.emit).toHaveBeenCalledWith("recipe:changed");
+      expect(mockBus.emit).toHaveBeenCalledWith("recipe:changed");
     });
 
     it("should throw BadRequestError for invalid ID", async () => {
@@ -458,7 +477,7 @@ describe("recipeService", () => {
     });
 
     it("should throw NotFoundError when recipe not found", async () => {
-      recipeRepository.findDocumentById.mockResolvedValue(null);
+      mockRecipeRepository.findDocumentById.mockResolvedValue(null);
 
       await expect(
         service.delete(createObjectId().toString(), {
@@ -469,7 +488,7 @@ describe("recipeService", () => {
 
     it("should throw ForbiddenError when not author and not admin", async () => {
       const recipe = createMockRecipe();
-      recipeRepository.findDocumentById.mockResolvedValue(recipe);
+      mockRecipeRepository.findDocumentById.mockResolvedValue(recipe);
 
       await expect(
         service.delete(createObjectId().toString(), {

--- a/apps/backend/src/modules/recipes/recipe.service.ts
+++ b/apps/backend/src/modules/recipes/recipe.service.ts
@@ -44,13 +44,31 @@ export interface RecipeService {
   delete(id: string, params: DeleteMethodParams): Promise<void>;
 }
 
+type RecipeRepositoryPort = Pick<
+  RecipeRepository,
+  | "findDocumentById"
+  | "create"
+  | "save"
+  | "deleteDocument"
+  | "aggregateSearch"
+  | "aggregateById"
+>;
+type UserRepositoryPort = Pick<UserRepository, "exists" | "modelName">;
+type FavoriteRepositoryPort = Pick<FavoriteRepository, "exists">;
+type CategoryRepositoryPort = Pick<CategoryRepository, "exists" | "modelName">;
+type CacheServicePort = Pick<
+  CacheService,
+  "get" | "set" | "delete" | "deletePattern"
+>;
+type TypedEmitterPort = Pick<TypedEmitter, "emit">;
+
 export function createRecipeService(
-  repository: RecipeRepository,
-  userRepository: UserRepository,
-  favoriteRepository: FavoriteRepository,
-  categoryRepository: CategoryRepository,
-  cache: CacheService,
-  bus: TypedEmitter,
+  repository: RecipeRepositoryPort,
+  userRepository: UserRepositoryPort,
+  favoriteRepository: FavoriteRepositoryPort,
+  categoryRepository: CategoryRepositoryPort,
+  cache: CacheServicePort,
+  bus: TypedEmitterPort,
 ): RecipeService {
   return {
     findAll: async ({ query, initiator }) => {

--- a/apps/backend/src/modules/reviews/review.service.test.ts
+++ b/apps/backend/src/modules/reviews/review.service.test.ts
@@ -1,7 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  createMockReviewRepository,
-  createMockUserRepository,
   createObjectId,
   createReviewDoc,
   initiator,
@@ -12,18 +10,25 @@ import {
   ForbiddenError,
   NotFoundError,
 } from "@/common/errors.js";
-import type { ReviewRepository } from "@/modules/reviews/review.repository.js";
 import { createReviewService } from "@/modules/reviews/review.service.js";
-import type { UserRepository } from "@/modules/users/user.repository.js";
 
 describe("reviewService", () => {
-  const reviewRepository = createMockReviewRepository();
-  const userRepository = createMockUserRepository();
+  const mockReviewRepository = {
+    findFeatured: vi.fn(),
+    findAll: vi.fn(),
+    findOne: vi.fn(),
+    findDocumentById: vi.fn(),
+    create: vi.fn(),
+    save: vi.fn(),
+    deleteDocument: vi.fn(),
+    aggregateStats: vi.fn(),
+  };
+  const mockUserRepository = {
+    exists: vi.fn(),
+    modelName: "User",
+  };
 
-  const service = createReviewService(
-    reviewRepository as unknown as ReviewRepository,
-    userRepository as unknown as UserRepository,
-  );
+  const service = createReviewService(mockReviewRepository, mockUserRepository);
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -35,15 +40,15 @@ describe("reviewService", () => {
 
   describe("create", () => {
     it("should create a review when user has none", async () => {
-      userRepository.exists.mockResolvedValue(true);
-      reviewRepository.findOne.mockResolvedValue(null);
+      mockUserRepository.exists.mockResolvedValue(true);
+      mockReviewRepository.findOne.mockResolvedValue(null);
 
       const authorId = createObjectId();
       const populatedReview = {
         ...createReviewDoc({ author: authorId, text: "Love it!", rating: 5 }),
         author: { _id: authorId, name: "Alice", email: "alice@test.com" },
       };
-      reviewRepository.create.mockResolvedValue(populatedReview);
+      mockReviewRepository.create.mockResolvedValue(populatedReview);
 
       const init = initiator(authorId.toString());
       const result = await service.create({
@@ -51,7 +56,7 @@ describe("reviewService", () => {
         initiator: init,
       });
 
-      expect(reviewRepository.create).toHaveBeenCalledWith({
+      expect(mockReviewRepository.create).toHaveBeenCalledWith({
         author: init.id,
         text: "Love it!",
         rating: 5,
@@ -61,8 +66,8 @@ describe("reviewService", () => {
     });
 
     it("should throw ConflictError when user already has a review", async () => {
-      userRepository.exists.mockResolvedValue(true);
-      reviewRepository.findOne.mockResolvedValue(createReviewDoc());
+      mockUserRepository.exists.mockResolvedValue(true);
+      mockReviewRepository.findOne.mockResolvedValue(createReviewDoc());
 
       await expect(
         service.create({
@@ -82,7 +87,7 @@ describe("reviewService", () => {
     });
 
     it("should throw NotFoundError when user does not exist", async () => {
-      userRepository.exists.mockResolvedValue(false);
+      mockUserRepository.exists.mockResolvedValue(false);
 
       await expect(
         service.create({
@@ -102,17 +107,17 @@ describe("reviewService", () => {
           author: { _id: authorId, name: "Bob", email: "bob@test.com" },
         },
       ];
-      reviewRepository.findFeatured.mockResolvedValue(reviews);
+      mockReviewRepository.findFeatured.mockResolvedValue(reviews);
 
       const result = await service.findFeatured();
 
-      expect(reviewRepository.findFeatured).toHaveBeenCalledWith(6);
+      expect(mockReviewRepository.findFeatured).toHaveBeenCalledWith(6);
       expect(result).toHaveLength(1);
       expect(result[0]?.author.name).toBe("Bob");
     });
 
     it("should return empty array when no featured reviews", async () => {
-      reviewRepository.findFeatured.mockResolvedValue([]);
+      mockReviewRepository.findFeatured.mockResolvedValue([]);
 
       const result = await service.findFeatured();
 
@@ -127,7 +132,7 @@ describe("reviewService", () => {
         ...createReviewDoc({ author: authorId }),
         author: { _id: authorId, name: "Carol", email: "carol@test.com" },
       };
-      reviewRepository.findAll.mockResolvedValue([[review], 1]);
+      mockReviewRepository.findAll.mockResolvedValue([[review], 1]);
 
       const result = await service.findAll({
         query: { page: 1, limit: 10, sort: "-createdAt" },
@@ -143,21 +148,21 @@ describe("reviewService", () => {
     it("should update own review", async () => {
       const authorId = createObjectId();
       const review = createReviewDoc({ author: authorId });
-      reviewRepository.findDocumentById.mockResolvedValue(review);
+      mockReviewRepository.findDocumentById.mockResolvedValue(review);
 
       const updated = {
         ...review,
         text: "Updated text",
         author: { _id: authorId, name: "Dave", email: "dave@test.com" },
       };
-      reviewRepository.save.mockResolvedValue(updated);
+      mockReviewRepository.save.mockResolvedValue(updated);
 
       const result = await service.update(review._id.toString(), {
         data: { text: "Updated text" },
         initiator: initiator(authorId.toString()),
       });
 
-      expect(reviewRepository.save).toHaveBeenCalledWith(review, {
+      expect(mockReviewRepository.save).toHaveBeenCalledWith(review, {
         text: "Updated text",
       });
       expect(result.text).toBe("Updated text");
@@ -165,14 +170,14 @@ describe("reviewService", () => {
 
     it("should allow admin to update any review", async () => {
       const review = createReviewDoc();
-      reviewRepository.findDocumentById.mockResolvedValue(review);
+      mockReviewRepository.findDocumentById.mockResolvedValue(review);
 
       const updated = {
         ...review,
         text: "Admin update",
         author: { _id: review.author, name: "Eve", email: "eve@test.com" },
       };
-      reviewRepository.save.mockResolvedValue(updated);
+      mockReviewRepository.save.mockResolvedValue(updated);
 
       const result = await service.update(review._id.toString(), {
         data: { text: "Admin update" },
@@ -192,7 +197,7 @@ describe("reviewService", () => {
     });
 
     it("should throw NotFoundError when review not found", async () => {
-      reviewRepository.findDocumentById.mockResolvedValue(null);
+      mockReviewRepository.findDocumentById.mockResolvedValue(null);
 
       await expect(
         service.update(createObjectId().toString(), {
@@ -204,7 +209,7 @@ describe("reviewService", () => {
 
     it("should throw ForbiddenError when not author and not admin", async () => {
       const review = createReviewDoc();
-      reviewRepository.findDocumentById.mockResolvedValue(review);
+      mockReviewRepository.findDocumentById.mockResolvedValue(review);
 
       await expect(
         service.update(review._id.toString(), {
@@ -218,14 +223,14 @@ describe("reviewService", () => {
   describe("feature", () => {
     it("should feature a review when admin", async () => {
       const review = createReviewDoc();
-      reviewRepository.findDocumentById.mockResolvedValue(review);
+      mockReviewRepository.findDocumentById.mockResolvedValue(review);
 
       const updated = {
         ...review,
         isFeatured: true,
         author: { _id: review.author, name: "Frank", email: "frank@test.com" },
       };
-      reviewRepository.save.mockResolvedValue(updated);
+      mockReviewRepository.save.mockResolvedValue(updated);
 
       const result = await service.feature(
         review._id.toString(),
@@ -233,7 +238,7 @@ describe("reviewService", () => {
         true,
       );
 
-      expect(reviewRepository.save).toHaveBeenCalledWith(review, {
+      expect(mockReviewRepository.save).toHaveBeenCalledWith(review, {
         isFeatured: true,
       });
       expect(result.isFeatured).toBe(true);
@@ -250,7 +255,7 @@ describe("reviewService", () => {
     });
 
     it("should throw NotFoundError when review not found", async () => {
-      reviewRepository.findDocumentById.mockResolvedValue(null);
+      mockReviewRepository.findDocumentById.mockResolvedValue(null);
 
       await expect(
         service.feature(
@@ -266,24 +271,24 @@ describe("reviewService", () => {
     it("should delete own review", async () => {
       const authorId = createObjectId();
       const review = createReviewDoc({ author: authorId });
-      reviewRepository.findDocumentById.mockResolvedValue(review);
+      mockReviewRepository.findDocumentById.mockResolvedValue(review);
 
       await service.delete(review._id.toString(), {
         initiator: initiator(authorId.toString()),
       });
 
-      expect(reviewRepository.deleteDocument).toHaveBeenCalledWith(review);
+      expect(mockReviewRepository.deleteDocument).toHaveBeenCalledWith(review);
     });
 
     it("should allow admin to delete any review", async () => {
       const review = createReviewDoc();
-      reviewRepository.findDocumentById.mockResolvedValue(review);
+      mockReviewRepository.findDocumentById.mockResolvedValue(review);
 
       await service.delete(review._id.toString(), {
         initiator: initiator(createObjectId().toString(), "admin"),
       });
 
-      expect(reviewRepository.deleteDocument).toHaveBeenCalledWith(review);
+      expect(mockReviewRepository.deleteDocument).toHaveBeenCalledWith(review);
     });
 
     it("should throw BadRequestError for invalid review ID", async () => {
@@ -293,7 +298,7 @@ describe("reviewService", () => {
     });
 
     it("should throw NotFoundError when review not found", async () => {
-      reviewRepository.findDocumentById.mockResolvedValue(null);
+      mockReviewRepository.findDocumentById.mockResolvedValue(null);
 
       await expect(
         service.delete(createObjectId().toString(), {
@@ -304,7 +309,7 @@ describe("reviewService", () => {
 
     it("should throw ForbiddenError when not author and not admin", async () => {
       const review = createReviewDoc();
-      reviewRepository.findDocumentById.mockResolvedValue(review);
+      mockReviewRepository.findDocumentById.mockResolvedValue(review);
 
       await expect(
         service.delete(review._id.toString(), {
@@ -321,7 +326,7 @@ describe("reviewService", () => {
         averageRating: 4.5,
         happyCooksCount: 38,
       };
-      reviewRepository.aggregateStats.mockResolvedValue(stats);
+      mockReviewRepository.aggregateStats.mockResolvedValue(stats);
 
       const result = await service.getStats();
 

--- a/apps/backend/src/modules/reviews/review.service.ts
+++ b/apps/backend/src/modules/reviews/review.service.ts
@@ -42,9 +42,22 @@ export interface ReviewService {
   getStats(): Promise<ReviewStats>;
 }
 
+type ReviewRepositoryPort = Pick<
+  ReviewRepository,
+  | "findFeatured"
+  | "findAll"
+  | "findOne"
+  | "findDocumentById"
+  | "create"
+  | "save"
+  | "deleteDocument"
+  | "aggregateStats"
+>;
+type UserRepositoryPort = Pick<UserRepository, "exists" | "modelName">;
+
 export function createReviewService(
-  repository: ReviewRepository,
-  userRepository: UserRepository,
+  repository: ReviewRepositoryPort,
+  userRepository: UserRepositoryPort,
 ): ReviewService {
   return {
     create: async ({ data, initiator }) => {

--- a/apps/backend/src/modules/users/user.service.test.ts
+++ b/apps/backend/src/modules/users/user.service.test.ts
@@ -1,34 +1,32 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  createMockUserRepository,
   createObjectId,
   createUserDoc,
   queryParams,
 } from "@/__tests__/helpers.js";
 import { NotFoundError } from "@/common/errors.js";
-import type { CommentService } from "@/modules/comments/comment.service.js";
-import type { FavoriteService } from "@/modules/favorites/favorite.service.js";
 import { createUserService } from "@/modules/users/user.service.js";
-import type { UserRepository } from "./user.repository.js";
 
 describe("userService", () => {
-  const userRepository = createMockUserRepository();
-  const commentService = {
+  const mockUserRepository = {
+    findById: vi.fn(),
+  };
+  const mockCommentService = {
     findByAuthor: vi.fn(),
     findByRecipe: vi.fn(),
     create: vi.fn(),
     delete: vi.fn(),
   };
-  const favoriteService = {
+  const mockFavoriteService = {
     findByUser: vi.fn(),
     add: vi.fn(),
     remove: vi.fn(),
     isFavorited: vi.fn(),
   };
   const service = createUserService(
-    userRepository as unknown as UserRepository,
-    commentService as unknown as CommentService,
-    favoriteService as unknown as FavoriteService,
+    mockUserRepository,
+    mockCommentService,
+    mockFavoriteService,
   );
 
   beforeEach(() => {
@@ -38,7 +36,7 @@ describe("userService", () => {
   describe("getCurrentUser", () => {
     it("should return user by ID", async () => {
       const doc = createUserDoc({ email: "user@test.com", name: "Test" });
-      userRepository.findById.mockReturnValue(doc);
+      mockUserRepository.findById.mockReturnValue(doc);
 
       const result = await service.getCurrentUser(createObjectId().toString());
 
@@ -48,7 +46,7 @@ describe("userService", () => {
     });
 
     it("should throw NotFoundError when user not found", async () => {
-      userRepository.findById.mockReturnValue(null);
+      mockUserRepository.findById.mockReturnValue(null);
 
       await expect(
         service.getCurrentUser(createObjectId().toString()),
@@ -69,14 +67,14 @@ describe("userService", () => {
           hasPrev: false,
         },
       };
-      favoriteService.findByUser.mockResolvedValue(expected);
+      mockFavoriteService.findByUser.mockResolvedValue(expected);
 
       const result = await service.getFavorites(
         createObjectId().toString(),
         queryParams(),
       );
 
-      expect(favoriteService.findByUser).toHaveBeenCalled();
+      expect(mockFavoriteService.findByUser).toHaveBeenCalled();
       expect(result).toBe(expected);
     });
   });
@@ -94,14 +92,14 @@ describe("userService", () => {
           hasPrev: false,
         },
       };
-      commentService.findByAuthor.mockResolvedValue(expected);
+      mockCommentService.findByAuthor.mockResolvedValue(expected);
 
       const result = await service.getComments(
         createObjectId().toString(),
         queryParams(),
       );
 
-      expect(commentService.findByAuthor).toHaveBeenCalled();
+      expect(mockCommentService.findByAuthor).toHaveBeenCalled();
       expect(result).toBe(expected);
     });
   });

--- a/apps/backend/src/modules/users/user.service.ts
+++ b/apps/backend/src/modules/users/user.service.ts
@@ -27,10 +27,14 @@ export interface UserService {
   ): Promise<Paginated<Comment>>;
 }
 
+type UserRepositoryPort = Pick<UserRepository, "findById">;
+type CommentServicePort = Pick<CommentService, "findByAuthor">;
+type FavoriteServicePort = Pick<FavoriteService, "findByUser">;
+
 export function createUserService(
-  repository: UserRepository,
-  commentService: CommentService,
-  favoriteService: FavoriteService,
+  repository: UserRepositoryPort,
+  commentService: CommentServicePort,
+  favoriteService: FavoriteServicePort,
 ): UserService {
   return {
     getCurrentUser: async (userId) => {


### PR DESCRIPTION
## Related Issues

Closes #84

## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring
- [ ] Tests
- [ ] Other

## Description

Refactored all backend service tests to eliminate unsafe `as unknown as` type casts by introducing explicit Port types via `Pick<>`.

### Changes

**Service layer:**
- Added Port types (`Pick<Repository, 'method1' | 'method2'>`) for all service dependencies
- Services now declare minimal interfaces instead of concrete repository classes
- Affected services: `auth`, `category`, `comment`, `favorite`, `recipe`, `recipe-rating`, `review`, `user`

**Test layer:**
- Replaced helper-generated mocks with inline typed mocks in each test file
- Removed `as unknown as` casts from all 8 service test files
- Removed unused helper functions: `createMockLogger`, `createMockPasswordService`, `createMockRepository`, `createMockCategoryRepository`, `createMockUserRepository`, `createMockRecipeRepository`, `createMockFavoriteRepository`, `createMockReviewRepository`, `createMockRecipeRatingRepository`, `createMockCategoryModel`
- Simplified `admin.test.ts` with inline logger mock and `LoggerPort` type

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] All existing tests updated to new pattern
- [x] No new functionality added (pure refactoring)