### PR TITLE
refactor(events): separate recipe-rating lifecycle events with previous values

### DIFF
--- a/apps/backend/src/app.services.ts
+++ b/apps/backend/src/app.services.ts
@@ -1,4 +1,5 @@
 import type { CacheService } from "@/common/cache/cache.service.js";
+import { createNamespacedCache } from "@/common/cache/namespaced-cache.js";
 import type { TypedEmitter } from "@/common/events.js";
 import type { Logger } from "@/common/logger.js";
 import { createBcryptPasswordService } from "@/common/passwords/bcrypt.service.js";
@@ -34,7 +35,7 @@ import { UserRepository } from "@/modules/users/user.repository.js";
 import type { UserService } from "@/modules/users/user.service.js";
 import { createUserService } from "@/modules/users/user.service.js";
 
-export interface Services {
+export interface AppServices {
   auth: AuthService;
   user: UserService;
   recipe: RecipeService;
@@ -43,14 +44,18 @@ export interface Services {
   recipeRating: RecipeRatingService;
   category: CategoryService;
   review: ReviewService;
+
+  recipeCache: CacheService;
+  categoryCache: CacheService;
+
+  log: Logger;
 }
 
 export function createServices(
-  recipeCache: CacheService,
-  categoryCache: CacheService,
+  cache: CacheService,
   bus: TypedEmitter,
   log: Logger,
-): Services {
+): AppServices {
   const commentRepository = new CommentRepository(CommentModel);
   const categoryRepository = new CategoryRepository(CategoryModel);
   const favoriteRepository = new FavoriteRepository(FavoriteModel);
@@ -58,6 +63,9 @@ export function createServices(
   const userRepository = new UserRepository(UserModel);
   const recipeRepository = new RecipeRepository(RecipeModel);
   const reviewRepository = new ReviewRepository(ReviewModel);
+
+  const recipeCache = createNamespacedCache("recipes", cache);
+  const categoryCache = createNamespacedCache("categories", cache);
 
   const passwordService = createBcryptPasswordService(env.BCRYPT_SALT_ROUNDS);
 
@@ -108,5 +116,10 @@ export function createServices(
     recipeRating: recipeRatingService,
     category: categoryService,
     review: reviewService,
+
+    recipeCache,
+    categoryCache,
+
+    log,
   };
 }

--- a/apps/backend/src/app.services.ts
+++ b/apps/backend/src/app.services.ts
@@ -73,11 +73,13 @@ export function createServices(
     commentRepository,
     recipeRepository,
     userRepository,
+    bus,
   );
   const favoriteService = createFavoriteService(
     favoriteRepository,
     recipeRepository,
     userRepository,
+    bus,
   );
   const userService = createUserService(
     userRepository,

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -10,7 +10,6 @@ import {
   validatorCompiler,
 } from "fastify-type-provider-zod";
 import { createCacheService } from "@/common/cache/create-cache.service.js";
-import { createNamespacedCache } from "@/common/cache/namespaced-cache.js";
 import { createEventBus } from "@/common/events.js";
 import type { Logger } from "@/common/logger.js";
 import { errorHandler } from "@/common/middleware/errorHandler.js";
@@ -21,6 +20,7 @@ import { authRoutes } from "@/modules/auth/auth.routes.js";
 import { categoryRoutes } from "@/modules/categories/category.routes.js";
 import { favoriteRoutes } from "@/modules/favorites/favorite.routes.js";
 import { recipeRatingRoutes } from "@/modules/recipe-ratings/recipe-rating.routes.js";
+import { registerRecipeEventHandlers } from "@/modules/recipes/recipe.events.js";
 import { recipeRoutes } from "@/modules/recipes/recipe.routes.js";
 import { reviewRoutes } from "@/modules/reviews/review.routes.js";
 import { userRoutes } from "@/modules/users/user.routes.js";
@@ -65,13 +65,9 @@ export async function buildApp(log: Logger) {
   app.get("/health", async () => ({ status: "ok" }));
 
   const bus = createEventBus();
-  const recipeCache = createNamespacedCache("recipes", cache);
-  const categoryCache = createNamespacedCache("categories", cache);
-  const services = createServices(recipeCache, categoryCache, bus, log);
+  const services = createServices(cache, bus, log);
 
-  // Cross-service cache invalidation via events
-  bus.on("category:changed", () => recipeCache.deletePattern("*"));
-  bus.on("recipe:rated", () => recipeCache.deletePattern("*"));
+  registerRecipeEventHandlers(bus, services);
 
   // Routes
   app.register(authRoutes, {

--- a/apps/backend/src/common/events.ts
+++ b/apps/backend/src/common/events.ts
@@ -1,20 +1,55 @@
 import { EventEmitter } from "node:events";
 
-export interface CacheEvents {
-  "recipe:changed": () => void;
-  "recipe:rated": (recipeId: string) => void;
-  "category:changed": () => void;
-}
+export type DomainEvents = {
+  "recipe:created": { recipeId: string };
+  "recipe:updated": { recipeId: string };
+  "recipe:deleted": { recipeId: string };
+
+  "category:created": { categoryId: string };
+  "category:deleted": { categoryId: string };
+
+  "comment:created": {
+    recipeId: string;
+    commentId: string;
+  };
+  "comment:deleted": {
+    recipeId: string;
+    commentId: string;
+  };
+
+  "favorite:created": { recipeId: string; userId: string };
+  "favorite:deleted": { recipeId: string; userId: string };
+
+  "recipe-rating:created": {
+    recipeId: string;
+    userId: string;
+    value: number;
+  };
+  "recipe-rating:deleted": {
+    recipeId: string;
+    userId: string;
+  };
+};
+
+export type DomainEventHandler<K extends keyof DomainEvents> = (
+  args: DomainEvents[K],
+) => void;
 
 export interface TypedEmitter extends EventEmitter {
-  on<K extends keyof CacheEvents>(event: K, listener: CacheEvents[K]): this;
-  off<K extends keyof CacheEvents>(event: K, listener: CacheEvents[K]): this;
-  once<K extends keyof CacheEvents>(event: K, listener: CacheEvents[K]): this;
-  emit<K extends keyof CacheEvents>(
+  on<K extends keyof DomainEvents>(
     event: K,
-    ...args: Parameters<CacheEvents[K]>
-  ): boolean;
-  removeAllListeners<K extends keyof CacheEvents>(event?: K): this;
+    listener: DomainEventHandler<K>,
+  ): this;
+  off<K extends keyof DomainEvents>(
+    event: K,
+    listener: DomainEventHandler<K>,
+  ): this;
+  once<K extends keyof DomainEvents>(
+    event: K,
+    listener: DomainEventHandler<K>,
+  ): this;
+  emit<K extends keyof DomainEvents>(event: K, args: DomainEvents[K]): boolean;
+  removeAllListeners<K extends keyof DomainEvents>(event?: K): this;
 }
 
 export function createEventBus(): TypedEmitter {

--- a/apps/backend/src/common/events.ts
+++ b/apps/backend/src/common/events.ts
@@ -25,6 +25,12 @@ export type DomainEvents = {
     userId: string;
     value: number;
   };
+  "recipe-rating:updated": {
+    recipeId: string;
+    userId: string;
+    previousValue: number | null;
+    value: number;
+  };
   "recipe-rating:deleted": {
     recipeId: string;
     userId: string;

--- a/apps/backend/src/common/events.ts
+++ b/apps/backend/src/common/events.ts
@@ -34,6 +34,7 @@ export type DomainEvents = {
   "recipe-rating:deleted": {
     recipeId: string;
     userId: string;
+    value: number;
   };
 };
 

--- a/apps/backend/src/modules/categories/category.service.test.ts
+++ b/apps/backend/src/modules/categories/category.service.test.ts
@@ -141,7 +141,9 @@ describe("categoryService", () => {
       expect(mockCache.deletePattern).toHaveBeenCalledWith(
         categoryCache.keys.allPattern(),
       );
-      expect(mockBus.emit).toHaveBeenCalledWith("category:changed");
+      expect(mockBus.emit).toHaveBeenCalledWith("category:created", {
+        categoryId: doc._id.toHexString(),
+      });
     });
   });
 
@@ -160,7 +162,9 @@ describe("categoryService", () => {
       expect(mockCache.deletePattern).toHaveBeenCalledWith(
         categoryCache.keys.allPattern(),
       );
-      expect(mockBus.emit).toHaveBeenCalledWith("category:changed");
+      expect(mockBus.emit).toHaveBeenCalledWith("category:deleted", {
+        categoryId: id,
+      });
     });
 
     it("should throw ConflictError when recipes exist", async () => {

--- a/apps/backend/src/modules/categories/category.service.ts
+++ b/apps/backend/src/modules/categories/category.service.ts
@@ -67,7 +67,7 @@ export function createCategoryService(
       const category = await repository.create(data);
 
       await cache.deletePattern(categoryCache.keys.allPattern());
-      bus.emit("category:changed");
+      bus.emit("category:created", { categoryId: category._id.toHexString() });
 
       return toCategory(category);
     },
@@ -86,7 +86,7 @@ export function createCategoryService(
       }
 
       await cache.deletePattern(categoryCache.keys.allPattern());
-      bus.emit("category:changed");
+      bus.emit("category:deleted", { categoryId: id });
     },
   };
 }

--- a/apps/backend/src/modules/comments/comment.service.test.ts
+++ b/apps/backend/src/modules/comments/comment.service.test.ts
@@ -28,11 +28,15 @@ describe("commentService", () => {
     exists: vi.fn(),
     modelName: "User",
   };
+  const mockBus = {
+    emit: vi.fn(),
+  };
 
   const service = createCommentService(
     mockCommentRepository,
     mockRecipeRepository,
     mockUserRepository,
+    mockBus,
   );
 
   beforeEach(() => {
@@ -152,6 +156,10 @@ describe("commentService", () => {
         author: init.id,
       });
       expect(result.text).toBe("Great recipe!");
+      expect(mockBus.emit).toHaveBeenCalledWith("comment:created", {
+        recipeId,
+        commentId: populated._id.toHexString(),
+      });
     });
 
     it("should throw BadRequestError for invalid recipe ID", async () => {
@@ -202,23 +210,31 @@ describe("commentService", () => {
       const comment = createCommentDoc({ author: authorId });
       mockCommentRepository.findById.mockResolvedValue(comment);
 
-      await service.delete(createObjectId().toString(), {
+      await service.delete(comment._id.toString(), {
         initiator: initiator(authorId.toString()),
       });
 
       expect(mockCommentRepository.findById).toHaveBeenCalled();
       expect(mockCommentRepository.delete).toHaveBeenCalled();
+      expect(mockBus.emit).toHaveBeenCalledWith("comment:deleted", {
+        recipeId: comment.recipe._id.toHexString(),
+        commentId: comment._id.toHexString(),
+      });
     });
 
     it("should delete comment when user is admin", async () => {
       const comment = createCommentDoc();
       mockCommentRepository.findById.mockResolvedValue(comment);
 
-      await service.delete(createObjectId().toString(), {
+      await service.delete(comment._id.toString(), {
         initiator: initiator(createObjectId().toString(), "admin"),
       });
 
       expect(mockCommentRepository.delete).toHaveBeenCalled();
+      expect(mockBus.emit).toHaveBeenCalledWith("comment:deleted", {
+        recipeId: comment.recipe._id.toHexString(),
+        commentId: comment._id.toHexString(),
+      });
     });
 
     it("should throw BadRequestError for invalid comment ID", async () => {

--- a/apps/backend/src/modules/comments/comment.service.ts
+++ b/apps/backend/src/modules/comments/comment.service.ts
@@ -1,6 +1,7 @@
 import type { Comment, CreateCommentBody, Paginated } from "@recipes/shared";
 import { withPagination } from "@recipes/shared";
 import { ForbiddenError, NotFoundError } from "@/common/errors.js";
+import type { TypedEmitter } from "@/common/events.js";
 import type {
   CreateMethodParams,
   DeleteMethodParams,
@@ -35,10 +36,13 @@ type CommentRepositoryPort = Pick<
 type RecipeRepositoryPort = Pick<RecipeRepository, "exists" | "modelName">;
 type UserRepositoryPort = Pick<UserRepository, "exists" | "modelName">;
 
+type TypedEmitterPort = Pick<TypedEmitter, "emit">;
+
 export function createCommentService(
   repository: CommentRepositoryPort,
   recipeRepository: RecipeRepositoryPort,
   userRepository: UserRepositoryPort,
+  bus: TypedEmitterPort,
 ): CommentService {
   return {
     findByRecipe: async (recipeId, { query, initiator }) => {
@@ -88,6 +92,11 @@ export function createCommentService(
         author: initiator.id,
       });
 
+      bus.emit("comment:created", {
+        recipeId: recipeId,
+        commentId: comment._id.toHexString(),
+      });
+
       return toComment(comment);
     },
 
@@ -107,6 +116,11 @@ export function createCommentService(
       }
 
       await repository.delete(id);
+
+      bus.emit("comment:deleted", {
+        recipeId: comment.recipe._id.toHexString(),
+        commentId: id,
+      });
     },
   };
 }

--- a/apps/backend/src/modules/favorites/favorite.service.test.ts
+++ b/apps/backend/src/modules/favorites/favorite.service.test.ts
@@ -24,11 +24,15 @@ describe("favoriteService", () => {
     exists: vi.fn(),
     modelName: "User",
   };
+  const mockBus = {
+    emit: vi.fn(),
+  };
 
   const service = createFavoriteService(
     mockFavoriteRepository,
     mockRecipeRepository,
     mockUserRepository,
+    mockBus,
   );
 
   beforeEach(() => {
@@ -48,6 +52,10 @@ describe("favoriteService", () => {
       expect(mockFavoriteRepository.create).toHaveBeenCalledWith({
         user: init.id,
         recipe: recipeId,
+      });
+      expect(mockBus.emit).toHaveBeenCalledWith("favorite:created", {
+        recipeId,
+        userId: init.id,
       });
     });
 
@@ -99,6 +107,10 @@ describe("favoriteService", () => {
       expect(mockFavoriteRepository.delete).toHaveBeenCalledWith({
         user: init.id,
         recipe: recipeId,
+      });
+      expect(mockBus.emit).toHaveBeenCalledWith("favorite:deleted", {
+        recipeId,
+        userId: init.id,
       });
     });
   });

--- a/apps/backend/src/modules/favorites/favorite.service.ts
+++ b/apps/backend/src/modules/favorites/favorite.service.ts
@@ -4,6 +4,7 @@ import type {
   RecipeWithComputed,
 } from "@recipes/shared";
 import { withPagination } from "@recipes/shared";
+import type { TypedEmitter } from "@/common/events.js";
 import type {
   DefaultInitiator,
   InitiatedMethodParams,
@@ -41,10 +42,13 @@ type FavoriteRepositoryPort = Pick<
 type RecipeRepositoryPort = Pick<RecipeRepository, "exists" | "modelName">;
 type UserRepositoryPort = Pick<UserRepository, "exists" | "modelName">;
 
+type TypedEmitterPort = Pick<TypedEmitter, "emit">;
+
 export function createFavoriteService(
   repository: FavoriteRepositoryPort,
   recipeRepository: RecipeRepositoryPort,
   userRepository: UserRepositoryPort,
+  bus: TypedEmitterPort,
 ): FavoriteService {
   async function validateUser(id: string): Promise<void> {
     assertValidId(id, "User");
@@ -62,6 +66,11 @@ export function createFavoriteService(
       await validateRecipe(recipeId);
 
       await repository.create({ user: initiator.id, recipe: recipeId });
+      bus.emit("favorite:created", {
+        recipeId,
+        userId: initiator.id,
+      });
+
       return { favorited: true };
     },
 
@@ -70,6 +79,11 @@ export function createFavoriteService(
       await validateRecipe(recipeId);
 
       await repository.delete({ user: initiator.id, recipe: recipeId });
+      bus.emit("favorite:deleted", {
+        recipeId,
+        userId: initiator.id,
+      });
+
       return { favorited: false };
     },
 

--- a/apps/backend/src/modules/recipe-ratings/recipe-rating.repository.int.test.ts
+++ b/apps/backend/src/modules/recipe-ratings/recipe-rating.repository.int.test.ts
@@ -19,9 +19,10 @@ describe("RecipeRatingRepository", () => {
       expect(result.document.value).toBe(4);
       expect(result.document.user.toString()).toBe(user._id.toString());
       expect(result.document.recipe.toString()).toBe(recipe._id.toString());
+      expect(result.oldDoc).toBeNull();
     });
 
-    it("should update an existing rating", async () => {
+    it("should update an existing rating and return oldDoc", async () => {
       const user = await createDbUser();
       const recipe = await createDbRecipe();
 
@@ -32,6 +33,8 @@ describe("RecipeRatingRepository", () => {
       );
 
       expect(updated.document.value).toBe(5);
+      expect(updated.oldDoc).not.toBeNull();
+      expect(updated.oldDoc!.value).toBe(3);
     });
   });
 

--- a/apps/backend/src/modules/recipe-ratings/recipe-rating.repository.int.test.ts
+++ b/apps/backend/src/modules/recipe-ratings/recipe-rating.repository.int.test.ts
@@ -16,9 +16,9 @@ describe("RecipeRatingRepository", () => {
         4,
       );
 
-      expect(result.value).toBe(4);
-      expect(result.user.toString()).toBe(user._id.toString());
-      expect(result.recipe.toString()).toBe(recipe._id.toString());
+      expect(result.document.value).toBe(4);
+      expect(result.document.user.toString()).toBe(user._id.toString());
+      expect(result.document.recipe.toString()).toBe(recipe._id.toString());
     });
 
     it("should update an existing rating", async () => {
@@ -31,7 +31,7 @@ describe("RecipeRatingRepository", () => {
         5,
       );
 
-      expect(updated.value).toBe(5);
+      expect(updated.document.value).toBe(5);
     });
   });
 

--- a/apps/backend/src/modules/recipe-ratings/recipe-rating.repository.ts
+++ b/apps/backend/src/modules/recipe-ratings/recipe-rating.repository.ts
@@ -18,7 +18,23 @@ export class RecipeRatingRepository extends BaseRepository<
   async upsert(
     filter: QueryFilter<RecipeRatingDocument>,
     value: number,
-  ): Promise<RecipeRatingDocument> {
-    return this.update(filter, { value }, { upsert: true });
+  ): Promise<{
+    document: RecipeRatingDocument;
+    oldDoc: RecipeRatingDocument | null;
+  }> {
+    const oldDoc = await this.findOne(filter);
+
+    const document = await this.model
+      .findOneAndUpdate(filter, this.castInput({ value }), {
+        upsert: true,
+        returnDocument: "after",
+        runValidators: true,
+      })
+      .lean();
+
+    return {
+      document,
+      oldDoc,
+    };
   }
 }

--- a/apps/backend/src/modules/recipe-ratings/recipe-rating.service.test.ts
+++ b/apps/backend/src/modules/recipe-ratings/recipe-rating.service.test.ts
@@ -167,6 +167,7 @@ describe("recipeRatingService", () => {
       expect(mockBus.emit).toHaveBeenCalledWith("recipe-rating:deleted", {
         recipeId,
         userId: init.id,
+        value: 4,
       });
     });
 

--- a/apps/backend/src/modules/recipe-ratings/recipe-rating.service.test.ts
+++ b/apps/backend/src/modules/recipe-ratings/recipe-rating.service.test.ts
@@ -55,7 +55,11 @@ describe("recipeRatingService", () => {
         { user: init.id, recipe: recipeId },
         4,
       );
-      expect(mockBus.emit).toHaveBeenCalledWith("recipe:rated", recipeId);
+      expect(mockBus.emit).toHaveBeenCalledWith("recipe-rating:created", {
+        recipeId: recipeId,
+        userId: init.id,
+        value: 4,
+      });
     });
 
     it("should update an existing rating", async () => {
@@ -144,7 +148,10 @@ describe("recipeRatingService", () => {
         user: init.id,
         recipe: recipeId,
       });
-      expect(mockBus.emit).toHaveBeenCalledWith("recipe:rated", recipeId);
+      expect(mockBus.emit).toHaveBeenCalledWith("recipe-rating:deleted", {
+        recipeId,
+        userId: init.id,
+      });
     });
 
     it("should throw NotFoundError when rating does not exist", async () => {

--- a/apps/backend/src/modules/recipe-ratings/recipe-rating.service.test.ts
+++ b/apps/backend/src/modules/recipe-ratings/recipe-rating.service.test.ts
@@ -36,11 +36,14 @@ describe("recipeRatingService", () => {
       mockUserRepository.exists.mockResolvedValue(true);
       mockRecipeRepository.exists.mockResolvedValue(true);
       mockRecipeRatingRepository.upsert.mockResolvedValue({
-        _id: createObjectId(),
-        user: createObjectId(),
-        recipe: createObjectId(),
-        value: 4,
-        createdAt: new Date(),
+        document: {
+          _id: createObjectId(),
+          user: createObjectId(),
+          recipe: createObjectId(),
+          value: 4,
+          createdAt: new Date(),
+        },
+        oldDoc: null,
       });
 
       const init = initiator();
@@ -65,12 +68,19 @@ describe("recipeRatingService", () => {
     it("should update an existing rating", async () => {
       mockUserRepository.exists.mockResolvedValue(true);
       mockRecipeRepository.exists.mockResolvedValue(true);
-      mockRecipeRatingRepository.upsert.mockResolvedValue({
+      const baseDoc = {
         _id: createObjectId(),
         user: createObjectId(),
         recipe: createObjectId(),
         value: 5,
         createdAt: new Date(),
+      };
+      mockRecipeRatingRepository.upsert.mockResolvedValue({
+        document: baseDoc,
+        oldDoc: {
+          ...baseDoc,
+          value: 3,
+        },
       });
 
       const init = initiator();
@@ -81,6 +91,12 @@ describe("recipeRatingService", () => {
       });
 
       expect(result).toEqual({ value: 5 });
+      expect(mockBus.emit).toHaveBeenCalledWith("recipe-rating:updated", {
+        recipeId,
+        userId: init.id,
+        previousValue: 3,
+        value: 5,
+      });
     });
 
     it("should throw BadRequestError for invalid user ID", async () => {

--- a/apps/backend/src/modules/recipe-ratings/recipe-rating.service.ts
+++ b/apps/backend/src/modules/recipe-ratings/recipe-rating.service.ts
@@ -47,16 +47,25 @@ export function createRecipeRatingService(
       await validateUser(initiator.id);
       await validateRecipe(recipeId);
 
-      const rating = await repository.upsert(
+      const { document: rating, oldDoc } = await repository.upsert(
         { user: initiator.id, recipe: recipeId },
         data.value,
       );
 
-      bus.emit("recipe-rating:created", {
-        recipeId,
-        userId: initiator.id,
-        value: rating.value,
-      });
+      if (oldDoc === null) {
+        bus.emit("recipe-rating:created", {
+          recipeId,
+          userId: initiator.id,
+          value: rating.value,
+        });
+      } else {
+        bus.emit("recipe-rating:updated", {
+          recipeId,
+          userId: initiator.id,
+          previousValue: oldDoc.value,
+          value: rating.value,
+        });
+      }
 
       return { value: rating.value };
     },

--- a/apps/backend/src/modules/recipe-ratings/recipe-rating.service.ts
+++ b/apps/backend/src/modules/recipe-ratings/recipe-rating.service.ts
@@ -52,7 +52,11 @@ export function createRecipeRatingService(
         data.value,
       );
 
-      bus.emit("recipe:rated", recipeId);
+      bus.emit("recipe-rating:created", {
+        recipeId,
+        userId: initiator.id,
+        value: rating.value,
+      });
 
       return { value: rating.value };
     },
@@ -72,7 +76,10 @@ export function createRecipeRatingService(
         );
       }
 
-      bus.emit("recipe:rated", recipeId);
+      bus.emit("recipe-rating:deleted", {
+        recipeId,
+        userId: initiator.id,
+      });
     },
   };
 }

--- a/apps/backend/src/modules/recipe-ratings/recipe-rating.service.ts
+++ b/apps/backend/src/modules/recipe-ratings/recipe-rating.service.ts
@@ -88,6 +88,7 @@ export function createRecipeRatingService(
       bus.emit("recipe-rating:deleted", {
         recipeId,
         userId: initiator.id,
+        value: result.value,
       });
     },
   };

--- a/apps/backend/src/modules/recipes/recipe.events.ts
+++ b/apps/backend/src/modules/recipes/recipe.events.ts
@@ -11,4 +11,5 @@ export function registerRecipeEventHandlers(
 ) {
   bus.on("category:deleted", () => deps.recipeCache.deletePattern("*"));
   bus.on("recipe-rating:created", () => deps.recipeCache.deletePattern("*"));
+  bus.on("recipe-rating:deleted", () => deps.recipeCache.deletePattern("*"));
 }

--- a/apps/backend/src/modules/recipes/recipe.events.ts
+++ b/apps/backend/src/modules/recipes/recipe.events.ts
@@ -9,6 +9,6 @@ export function registerRecipeEventHandlers(
     log: Logger;
   },
 ) {
-  bus.on("category:changed", () => deps.recipeCache.deletePattern("*"));
-  bus.on("recipe:rated", () => deps.recipeCache.deletePattern("*"));
+  bus.on("category:deleted", () => deps.recipeCache.deletePattern("*"));
+  bus.on("recipe-rating:created", () => deps.recipeCache.deletePattern("*"));
 }

--- a/apps/backend/src/modules/recipes/recipe.events.ts
+++ b/apps/backend/src/modules/recipes/recipe.events.ts
@@ -11,5 +11,6 @@ export function registerRecipeEventHandlers(
 ) {
   bus.on("category:deleted", () => deps.recipeCache.deletePattern("*"));
   bus.on("recipe-rating:created", () => deps.recipeCache.deletePattern("*"));
+  bus.on("recipe-rating:updated", () => deps.recipeCache.deletePattern("*"));
   bus.on("recipe-rating:deleted", () => deps.recipeCache.deletePattern("*"));
 }

--- a/apps/backend/src/modules/recipes/recipe.events.ts
+++ b/apps/backend/src/modules/recipes/recipe.events.ts
@@ -1,0 +1,14 @@
+import type { CacheService } from "@/common/cache/cache.service.js";
+import type { TypedEmitter } from "@/common/events.js";
+import type { Logger } from "@/common/logger.js";
+
+export function registerRecipeEventHandlers(
+  bus: TypedEmitter,
+  deps: {
+    recipeCache: CacheService;
+    log: Logger;
+  },
+) {
+  bus.on("category:changed", () => deps.recipeCache.deletePattern("*"));
+  bus.on("recipe:rated", () => deps.recipeCache.deletePattern("*"));
+}

--- a/apps/backend/src/modules/recipes/recipe.service.test.ts
+++ b/apps/backend/src/modules/recipes/recipe.service.test.ts
@@ -300,7 +300,9 @@ describe("recipeService", () => {
       expect(mockCache.deletePattern).toHaveBeenCalledWith(
         recipeCache.keys.listPattern(),
       );
-      expect(mockBus.emit).toHaveBeenCalledWith("recipe:changed");
+      expect(mockBus.emit).toHaveBeenCalledWith("recipe:created", {
+        recipeId: populated._id.toHexString(),
+      });
     });
 
     it("should throw BadRequestError for invalid author ID", async () => {
@@ -377,7 +379,9 @@ describe("recipeService", () => {
       expect(mockCache.deletePattern).toHaveBeenCalledWith(
         recipeCache.keys.listPattern(),
       );
-      expect(mockBus.emit).toHaveBeenCalledWith("recipe:changed");
+      expect(mockBus.emit).toHaveBeenCalledWith("recipe:updated", {
+        recipeId: id,
+      });
     });
 
     it("should update recipe when user is admin", async () => {
@@ -402,7 +406,9 @@ describe("recipeService", () => {
       expect(mockCache.deletePattern).toHaveBeenCalledWith(
         recipeCache.keys.listPattern(),
       );
-      expect(mockBus.emit).toHaveBeenCalledWith("recipe:changed");
+      expect(mockBus.emit).toHaveBeenCalledWith("recipe:updated", {
+        recipeId: id,
+      });
     });
 
     it("should throw BadRequestError for invalid ID", async () => {
@@ -455,7 +461,9 @@ describe("recipeService", () => {
       expect(mockCache.deletePattern).toHaveBeenCalledWith(
         recipeCache.keys.listPattern(),
       );
-      expect(mockBus.emit).toHaveBeenCalledWith("recipe:changed");
+      expect(mockBus.emit).toHaveBeenCalledWith("recipe:deleted", {
+        recipeId: id,
+      });
     });
 
     it("should delete recipe when user is admin", async () => {
@@ -473,7 +481,9 @@ describe("recipeService", () => {
       expect(mockCache.deletePattern).toHaveBeenCalledWith(
         recipeCache.keys.listPattern(),
       );
-      expect(mockBus.emit).toHaveBeenCalledWith("recipe:changed");
+      expect(mockBus.emit).toHaveBeenCalledWith("recipe:deleted", {
+        recipeId: id,
+      });
     });
 
     it("should throw BadRequestError for invalid ID", async () => {

--- a/apps/backend/src/modules/recipes/recipe.service.ts
+++ b/apps/backend/src/modules/recipes/recipe.service.ts
@@ -152,7 +152,7 @@ export function createRecipeService(
       });
 
       await cache.deletePattern(recipeCache.keys.listPattern());
-      bus.emit("recipe:changed");
+      bus.emit("recipe:created", { recipeId: recipe._id.toHexString() });
 
       return toRecipe(recipe, false);
     },
@@ -181,7 +181,7 @@ export function createRecipeService(
         cache.delete(recipeCache.keys.byId(id)),
         cache.deletePattern(recipeCache.keys.listPattern()),
       ]);
-      bus.emit("recipe:changed");
+      bus.emit("recipe:updated", { recipeId: id });
 
       return toRecipe(updated, isFavorited);
     },
@@ -203,7 +203,7 @@ export function createRecipeService(
 
       await cache.delete(recipeCache.keys.byId(id));
       await cache.deletePattern(recipeCache.keys.listPattern());
-      bus.emit("recipe:changed");
+      bus.emit("recipe:deleted", { recipeId: id });
     },
   };
 }


### PR DESCRIPTION
## Related Issues

<!-- Link related issues: Closes #123, Refs #456 -->

## PR Type

- [ ] Bugfix
- [x] Feature
- [x] Refactoring
- [x] Tests
- [ ] Other

## Description

Improves recipe rating events by separating create/update lifecycle and including previous values for incremental statistics.

### Changes

1. **Separated rating lifecycle events**
   - Added `recipe-rating:updated` event with `previousValue` and `value` fields
   - Existing `recipe-rating:created` stays unchanged
   - `recipe-rating:deleted` now includes `value` field

2. **Updated repository layer**
   - `RecipeRatingRepository.upsert()` now returns `{ document, oldDoc }` instead of just the document
   - `oldDoc` is `null` for new ratings, populated for updates
   - Uses `findOne` + `findOneAndUpdate` pattern (acceptable race condition for this use case)

3. **Updated service layer**
   - `rate()` method emits `recipe-rating:created` when `oldDoc === null`
   - Emits `recipe-rating:updated` with `previousValue: oldDoc.value` for existing ratings
   - `remove()` method emits `recipe-rating:deleted` with deleted rating `value`

4. **Updated event handlers**
   - `recipe.events.ts` now listens to all 4 rating events:
     - `recipe-rating:created`
     - `recipe-rating:updated` (new)
     - `recipe-rating:deleted`
   - All invalidate recipe cache

5. **Added/updated tests**
   - `recipe-rating.service.test.ts` — tests for both created and updated events
   - `recipe-rating.repository.int.test.ts` — added `oldDoc` assertions (null for new, populated for update)

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Added/updated tests for new functionality
- [ ] Updated documentation (if needed)