### PR TITLE
feat(recipe): add recipe popularity stats and sorting

### DIFF
--- a/apps/backend/src/__tests__/db-factories.ts
+++ b/apps/backend/src/__tests__/db-factories.ts
@@ -1,4 +1,4 @@
-import type { Minutes } from "@recipes/shared";
+import type { Minutes, RecipeStats } from "@recipes/shared";
 import type { Types } from "mongoose";
 import { CategoryModel } from "@/modules/categories/category.model.js";
 import { CommentModel } from "@/modules/comments/comment.model.js";
@@ -63,6 +63,7 @@ export async function createDbRecipe(
     servings: number;
     isPublic: boolean;
     image: { url: string; alt?: string };
+    stats: RecipeStats;
   }> = {},
 ) {
   return RecipeModel.create({

--- a/apps/backend/src/__tests__/helpers.ts
+++ b/apps/backend/src/__tests__/helpers.ts
@@ -111,6 +111,14 @@ export function createRecipeDoc(
     servings: 4,
     isPublic: true,
     image: { url: "https://example.com/image.jpg" },
+    stats: {
+      favoritesCount: 0,
+      commentsCount: 0,
+      ratingCount: 0,
+      ratingSum: 0,
+      averageRating: null,
+      popularity: 0,
+    },
     createdAt: new Date("2024-01-01"),
     updatedAt: new Date("2024-01-01"),
     ...overrides,
@@ -132,8 +140,14 @@ export function populateRecipeDoc(
     author: { _id: createObjectId(), name: "Chef", email: "chef@test.com" },
     isFavorited: false,
     userRating: null,
-    averageRating: null,
-    ratingCount: 0,
+    stats: {
+      favoritesCount: 0,
+      commentsCount: 0,
+      ratingCount: 0,
+      ratingSum: 0,
+      averageRating: null,
+      popularity: 0,
+    },
     ...overrides,
   };
 }

--- a/apps/backend/src/app.services.ts
+++ b/apps/backend/src/app.services.ts
@@ -26,6 +26,8 @@ import { RecipeModel } from "@/modules/recipes/recipe.model.js";
 import { RecipeRepository } from "@/modules/recipes/recipe.repository.js";
 import type { RecipeService } from "@/modules/recipes/recipe.service.js";
 import { createRecipeService } from "@/modules/recipes/recipe.service.js";
+import type { RecipeStatsService } from "@/modules/recipes/recipe-stats.service.js";
+import { createRecipeStatsService } from "@/modules/recipes/recipe-stats.service.js";
 import { ReviewModel } from "@/modules/reviews/review.model.js";
 import { ReviewRepository } from "@/modules/reviews/review.repository.js";
 import type { ReviewService } from "@/modules/reviews/review.service.js";
@@ -39,6 +41,7 @@ export interface AppServices {
   auth: AuthService;
   user: UserService;
   recipe: RecipeService;
+  recipeStats: RecipeStatsService;
   comment: CommentService;
   favorite: FavoriteService;
   recipeRating: RecipeRatingService;
@@ -106,6 +109,7 @@ export function createServices(
     recipeCache,
     bus,
   );
+  const recipeStatsService = createRecipeStatsService(recipeRepository);
   const reviewService = createReviewService(reviewRepository, userRepository);
   const authService = createAuthService(userRepository, passwordService, log);
 
@@ -113,6 +117,7 @@ export function createServices(
     auth: authService,
     user: userService,
     recipe: recipeService,
+    recipeStats: recipeStatsService,
     comment: commentService,
     favorite: favoriteService,
     recipeRating: recipeRatingService,

--- a/apps/backend/src/common/utils/stages.ts
+++ b/apps/backend/src/common/utils/stages.ts
@@ -18,6 +18,18 @@ export function cond(
   };
 }
 
+export function max(...pipeline: Expression[]) {
+  return {
+    $max: [...pipeline],
+  };
+}
+
+export function multiply(...pipeline: Expression[]) {
+  return {
+    $multiply: [...pipeline],
+  };
+}
+
 export type UnsetStage<T> =
   | (keyof T extends string ? keyof T : never)[]
   | string[];
@@ -71,6 +83,12 @@ export function project(
   fields: Record<string, 1 | 0> | Expression,
 ): PipelineStage.Project {
   return { $project: fields };
+}
+
+export function set(pipeline: PipelineStage.Set["$set"]) {
+  return {
+    $set: pipeline,
+  };
 }
 
 export function addFields(
@@ -177,6 +195,8 @@ export function extractPaginatedResult<T>(
 
 export default {
   cond,
+  max,
+  multiply,
   unset,
   match,
   skip,
@@ -185,6 +205,7 @@ export default {
   sort,
   group,
   project,
+  set,
   addFields,
   lookup,
   paginated,

--- a/apps/backend/src/modules/favorites/favorite.repository.int.test.ts
+++ b/apps/backend/src/modules/favorites/favorite.repository.int.test.ts
@@ -100,6 +100,14 @@ describe("FavoriteRepository", () => {
         author: author._id,
         category: category._id,
         isPublic: true,
+        stats: {
+          favoritesCount: 0,
+          commentsCount: 0,
+          ratingCount: 2,
+          ratingSum: 9,
+          averageRating: 4.5,
+          popularity: 0,
+        },
       });
       const otherUser = await createDbUser();
 
@@ -124,8 +132,8 @@ describe("FavoriteRepository", () => {
       });
 
       expect(recipes[0]?.userRating).toBe(4);
-      expect(recipes[0]?.averageRating).toBe(4.5);
-      expect(recipes[0]?.ratingCount).toBe(2);
+      expect(recipes[0]?.stats.averageRating).toBe(4.5);
+      expect(recipes[0]?.stats.ratingCount).toBe(2);
     });
 
     it("should paginate correctly", async () => {

--- a/apps/backend/src/modules/favorites/favorite.repository.ts
+++ b/apps/backend/src/modules/favorites/favorite.repository.ts
@@ -12,7 +12,6 @@ import stages, { extractPaginatedResult } from "@/common/utils/stages.js";
 import {
   byVisibility,
   withAuthor,
-  withAverageRating,
   withCategories,
   withUserRating,
 } from "@/modules/recipes/recipe.aggregation.js";
@@ -83,7 +82,6 @@ function withRecipe(
         withCategories(),
         withAuthor(),
         withUserRating(initiator.id),
-        withAverageRating(),
       ].flat(),
       as: "recipe",
     },

--- a/apps/backend/src/modules/recipes/recipe-stats.service.test.ts
+++ b/apps/backend/src/modules/recipes/recipe-stats.service.test.ts
@@ -1,0 +1,318 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createObjectId } from "@/__tests__/helpers.js";
+import { RECIPE_POPULARITY_WEIGHTS } from "./recipe.repository.js";
+import {
+  computeAverageRating,
+  computePopularity,
+  createRecipeStatsService,
+  rebuildRecipeStats,
+} from "./recipe-stats.service.js";
+
+describe("computeAverageRating", () => {
+  it("should return null when ratingCount is 0", () => {
+    const result = computeAverageRating({
+      ratingCount: 0,
+      ratingSum: 0,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("should return null when ratingCount is negative", () => {
+    const result = computeAverageRating({
+      ratingCount: -1,
+      ratingSum: 0,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("should compute average for single rating", () => {
+    const result = computeAverageRating({
+      ratingCount: 1,
+      ratingSum: 4,
+    });
+
+    expect(result).toBe(4);
+  });
+
+  it("should compute average for multiple ratings", () => {
+    const result = computeAverageRating({
+      ratingCount: 3,
+      ratingSum: 13,
+    });
+
+    expect(result).toBe(4.3); // 13/3 = 4.333... rounded to 1 decimal
+  });
+});
+
+describe("computePopularity", () => {
+  it("should return 0 for empty stats", () => {
+    const result = computePopularity({
+      favoritesCount: 0,
+      commentsCount: 0,
+      ratingCount: 0,
+      ratingSum: 0,
+    });
+
+    expect(result).toBe(0);
+  });
+
+  it("should compute popularity with all stats present", () => {
+    // 5*favorites + 3*comments + 1*ratings + 4.5*avgRating
+    // 5*3 + 3*2 + 10*1 + 4.5*5 = 15 + 6 + 10 + 22.5 = 53.5
+    const result = computePopularity({
+      favoritesCount: 5,
+      commentsCount: 3,
+      ratingCount: 10,
+      ratingSum: 45,
+    });
+
+    expect(result).toBe(53.5);
+  });
+
+  it("should treat null averageRating as 0", () => {
+    // 2*3 + 1*2 + 0*1 + 0*5 = 6 + 2 + 0 + 0 = 8
+    const result = computePopularity({
+      favoritesCount: 2,
+      commentsCount: 1,
+      ratingCount: 0,
+      ratingSum: 0,
+    });
+
+    expect(result).toBe(8);
+  });
+
+  it("should use weights from RECIPE_POPULARITY_WEIGHTS", () => {
+    const result = computePopularity({
+      favoritesCount: 1,
+      commentsCount: 1,
+      ratingCount: 1,
+      ratingSum: 5,
+    });
+
+    // avg = 5.0
+    // 1*3 + 1*2 + 1*1 + 5.0*5 = 3 + 2 + 1 + 25 = 31
+    const expected =
+      RECIPE_POPULARITY_WEIGHTS.favorites +
+      RECIPE_POPULARITY_WEIGHTS.comments +
+      RECIPE_POPULARITY_WEIGHTS.ratings +
+      5 * RECIPE_POPULARITY_WEIGHTS.averageRating;
+
+    expect(result).toBe(expected);
+    expect(result).toBe(31);
+  });
+});
+
+describe("createRecipeStatsService", () => {
+  const mockRecipeRepository = {
+    applyFavoritesDelta: vi.fn(),
+    applyCommentsDelta: vi.fn(),
+    applyRatingCreated: vi.fn(),
+    applyRatingUpdated: vi.fn(),
+    applyRatingDeleted: vi.fn(),
+  };
+
+  const service = createRecipeStatsService(mockRecipeRepository);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should delegate onFavoriteCreated to applyFavoritesDelta with +1", async () => {
+    mockRecipeRepository.applyFavoritesDelta.mockResolvedValue(null);
+
+    await service.onFavoriteCreated("recipe123");
+
+    expect(mockRecipeRepository.applyFavoritesDelta).toHaveBeenCalledWith(
+      "recipe123",
+      1,
+    );
+  });
+
+  it("should delegate onFavoriteDeleted to applyFavoritesDelta with -1", async () => {
+    mockRecipeRepository.applyFavoritesDelta.mockResolvedValue(null);
+
+    await service.onFavoriteDeleted("recipe123");
+
+    expect(mockRecipeRepository.applyFavoritesDelta).toHaveBeenCalledWith(
+      "recipe123",
+      -1,
+    );
+  });
+
+  it("should delegate onCommentCreated to applyCommentsDelta with +1", async () => {
+    mockRecipeRepository.applyCommentsDelta.mockResolvedValue(null);
+
+    await service.onCommentCreated("recipe123");
+
+    expect(mockRecipeRepository.applyCommentsDelta).toHaveBeenCalledWith(
+      "recipe123",
+      1,
+    );
+  });
+
+  it("should delegate onCommentDeleted to applyCommentsDelta with -1", async () => {
+    mockRecipeRepository.applyCommentsDelta.mockResolvedValue(null);
+
+    await service.onCommentDeleted("recipe123");
+
+    expect(mockRecipeRepository.applyCommentsDelta).toHaveBeenCalledWith(
+      "recipe123",
+      -1,
+    );
+  });
+
+  it("should delegate onRatingCreated to applyRatingCreated", async () => {
+    mockRecipeRepository.applyRatingCreated.mockResolvedValue(null);
+
+    await service.onRatingCreated("recipe123", 4);
+
+    expect(mockRecipeRepository.applyRatingCreated).toHaveBeenCalledWith(
+      "recipe123",
+      4,
+    );
+  });
+
+  it("should delegate onRatingUpdated with previousValue", async () => {
+    mockRecipeRepository.applyRatingUpdated.mockResolvedValue(null);
+
+    await service.onRatingUpdated("recipe123", 3, 5);
+
+    expect(mockRecipeRepository.applyRatingUpdated).toHaveBeenCalledWith(
+      "recipe123",
+      3,
+      5,
+    );
+  });
+
+  it("should delegate onRatingUpdated with null previousValue as 0", async () => {
+    mockRecipeRepository.applyRatingUpdated.mockResolvedValue(null);
+
+    await service.onRatingUpdated("recipe123", null, 5);
+
+    expect(mockRecipeRepository.applyRatingUpdated).toHaveBeenCalledWith(
+      "recipe123",
+      0,
+      5,
+    );
+  });
+
+  it("should delegate onRatingDeleted to applyRatingDeleted", async () => {
+    mockRecipeRepository.applyRatingDeleted.mockResolvedValue(null);
+
+    await service.onRatingDeleted("recipe123", 4);
+
+    expect(mockRecipeRepository.applyRatingDeleted).toHaveBeenCalledWith(
+      "recipe123",
+      4,
+    );
+  });
+});
+
+describe("rebuildRecipeStats", () => {
+  it("should rebuild stats for all recipes from aggregated data", async () => {
+    const recipeId1 = createObjectId().toHexString();
+    const recipeId2 = createObjectId().toHexString();
+
+    const mockRecipeModel = {
+      find: vi.fn().mockReturnValue({
+        lean: vi
+          .fn()
+          .mockResolvedValue([
+            { _id: { toString: () => recipeId1 } },
+            { _id: { toString: () => recipeId2 } },
+          ]),
+      }),
+      bulkWrite: vi.fn().mockResolvedValue({ modifiedCount: 2 }),
+    };
+
+    const mockFavoriteModel = {
+      aggregate: vi.fn().mockResolvedValue([
+        { _id: { toString: () => recipeId1 }, count: 5 },
+        { _id: { toString: () => recipeId2 }, count: 2 },
+      ]),
+    };
+
+    const mockCommentModel = {
+      aggregate: vi
+        .fn()
+        .mockResolvedValue([{ _id: { toString: () => recipeId1 }, count: 3 }]),
+    };
+
+    const mockRecipeRatingModel = {
+      aggregate: vi.fn().mockResolvedValue([
+        {
+          _id: { toString: () => recipeId1 },
+          ratingCount: 10,
+          ratingSum: 45,
+          averageRating: 4.5,
+        },
+      ]),
+    };
+
+    await rebuildRecipeStats(
+      mockRecipeModel,
+      mockFavoriteModel,
+      mockCommentModel,
+      mockRecipeRatingModel,
+    );
+
+    expect(mockRecipeModel.find).toHaveBeenCalledWith({}, { _id: 1 });
+    expect(mockFavoriteModel.aggregate).toHaveBeenCalled();
+    expect(mockCommentModel.aggregate).toHaveBeenCalled();
+    expect(mockRecipeRatingModel.aggregate).toHaveBeenCalled();
+
+    expect(mockRecipeModel.bulkWrite).toHaveBeenCalledTimes(1);
+    const ops = mockRecipeModel.bulkWrite.mock.calls[0]?.[0];
+
+    expect(ops).toHaveLength(2);
+
+    // Recipe 1: has favorites, comments, ratings
+    const op1 = ops[0];
+    expect(op1.updateOne.filter).toEqual({
+      _id: expect.any(Object),
+    });
+    expect(op1.updateOne.update.$set.stats).toEqual({
+      favoritesCount: 5,
+      commentsCount: 3,
+      ratingCount: 10,
+      ratingSum: 45,
+      averageRating: 4.5,
+      popularity: 53.5, // 5*3 + 3*2 + 10*1 + 4.5*5
+    });
+
+    // Recipe 2: has only favorites, no comments or ratings
+    const op2 = ops[1];
+    expect(op2.updateOne.update.$set.stats).toEqual({
+      favoritesCount: 2,
+      commentsCount: 0,
+      ratingCount: 0,
+      ratingSum: 0,
+      averageRating: null,
+      popularity: 6, // 2*3 + 0*2 + 0*1 + 0*5
+    });
+  });
+
+  it("should not call bulkWrite when no recipes exist", async () => {
+    const mockRecipeModel = {
+      find: vi.fn().mockReturnValue({
+        lean: vi.fn().mockResolvedValue([]),
+      }),
+      bulkWrite: vi.fn(),
+    };
+
+    const mockFavoriteModel = { aggregate: vi.fn().mockResolvedValue([]) };
+    const mockCommentModel = { aggregate: vi.fn().mockResolvedValue([]) };
+    const mockRecipeRatingModel = { aggregate: vi.fn().mockResolvedValue([]) };
+
+    await rebuildRecipeStats(
+      mockRecipeModel,
+      mockFavoriteModel,
+      mockCommentModel,
+      mockRecipeRatingModel,
+    );
+
+    expect(mockRecipeModel.bulkWrite).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/modules/recipes/recipe-stats.service.ts
+++ b/apps/backend/src/modules/recipes/recipe-stats.service.ts
@@ -8,12 +8,26 @@ import type { RecipeModelType } from "./recipe.model.js";
 import type { RecipeRepository } from "./recipe.repository.js";
 import { RECIPE_POPULARITY_WEIGHTS } from "./recipe.repository.js";
 
-export function computePopularity(stats: Omit<RecipeStats, "popularity">) {
+export function computeAverageRating(
+  stats: Pick<RecipeStats, "ratingCount" | "ratingSum">,
+): number | null {
+  if (stats.ratingCount <= 0) {
+    return null;
+  }
+
+  return Number((stats.ratingSum / stats.ratingCount).toFixed(1));
+}
+
+export function computePopularity(
+  stats: Omit<RecipeStats, "popularity" | "averageRating">,
+) {
+  const averageRating = computeAverageRating(stats);
+
   return (
     stats.favoritesCount * RECIPE_POPULARITY_WEIGHTS.favorites +
     stats.commentsCount * RECIPE_POPULARITY_WEIGHTS.comments +
     stats.ratingCount * RECIPE_POPULARITY_WEIGHTS.ratings +
-    (stats.averageRating ?? 0) * RECIPE_POPULARITY_WEIGHTS.averageRating
+    (averageRating ?? 0) * RECIPE_POPULARITY_WEIGHTS.averageRating
   );
 }
 
@@ -108,7 +122,6 @@ export async function rebuildRecipeStats(
       commentsCount,
       ratingCount,
       ratingSum,
-      averageRating,
     });
 
     return {

--- a/apps/backend/src/modules/recipes/recipe-stats.service.ts
+++ b/apps/backend/src/modules/recipes/recipe-stats.service.ts
@@ -1,0 +1,98 @@
+import type { RecipeStats } from "@recipes/shared";
+import type { Types } from "mongoose";
+import stages from "@/common/utils/stages.js";
+import type { CommentModelType } from "@/modules/comments/comment.model.js";
+import type { FavoriteModelType } from "@/modules/favorites/favorite.model.js";
+import type { RecipeRatingModelType } from "@/modules/recipe-ratings/recipe-rating.model.js";
+import type { RecipeModelType } from "./recipe.model.js";
+
+export function computePopularity(stats: Omit<RecipeStats, "popularity">) {
+  return (
+    stats.favoritesCount * 3 +
+    stats.commentsCount * 2 +
+    stats.ratingCount * 1 +
+    (stats.averageRating ?? 0) * 5
+  );
+}
+
+export async function rebuildRecipeStats(
+  recipeModel: Pick<RecipeModelType, "find" | "bulkWrite">,
+  favoriteModel: Pick<FavoriteModelType, "aggregate">,
+  commentModel: Pick<CommentModelType, "aggregate">,
+  recipeRatingModel: Pick<RecipeRatingModelType, "aggregate">,
+) {
+  const [recipes, favorites, comments, ratings] = await Promise.all([
+    recipeModel.find({}, { _id: 1 }).lean(),
+    favoriteModel.aggregate<{ _id: Types.ObjectId; count: number }>([
+      { $group: { _id: "$recipe", count: { $sum: 1 } } },
+    ]),
+    commentModel.aggregate<{ _id: Types.ObjectId; count: number }>([
+      { $group: { _id: "$recipe", count: { $sum: 1 } } },
+    ]),
+    recipeRatingModel.aggregate<{
+      _id: Types.ObjectId;
+      ratingCount: number;
+      ratingSum: number;
+      averageRating: number;
+    }>([
+      stages.group({
+        _id: "$recipe",
+        ratingCount: { $sum: 1 },
+        ratingSum: { $sum: "$value" },
+        averageRating: { $avg: "$value" },
+      }),
+      stages.project({
+        ratingCount: 1,
+        ratingSum: 1,
+        averageRating: { $round: ["$averageRating", 1] },
+      }),
+    ]),
+  ]);
+
+  const favoriteMap = new Map(
+    favorites.map((x) => [x._id.toString(), x.count]),
+  );
+  const commentMap = new Map(comments.map((x) => [x._id.toString(), x.count]));
+  const ratingMap = new Map(ratings.map((x) => [x._id.toString(), x]));
+
+  const ops = recipes.map((recipe) => {
+    const id = recipe._id.toString();
+    const favoritesCount = favoriteMap.get(id) ?? 0;
+    const commentsCount = commentMap.get(id) ?? 0;
+    const rating = ratingMap.get(id);
+
+    const ratingCount = rating?.ratingCount ?? 0;
+    const ratingSum = rating?.ratingSum ?? 0;
+    const averageRating = rating?.averageRating ?? null;
+
+    const popularity = computePopularity({
+      favoritesCount,
+      commentsCount,
+      ratingCount,
+      ratingSum,
+      averageRating,
+    });
+
+    return {
+      updateOne: {
+        filter: { _id: recipe._id },
+        update: {
+          $set: {
+            stats: {
+              favoritesCount,
+              commentsCount,
+              ratingCount,
+              ratingSum,
+              averageRating,
+              popularity,
+            },
+          },
+        },
+      },
+    };
+  });
+
+  if (ops.length > 0) {
+    await recipeModel.bulkWrite(ops);
+  }
+}

--- a/apps/backend/src/modules/recipes/recipe-stats.service.ts
+++ b/apps/backend/src/modules/recipes/recipe-stats.service.ts
@@ -33,7 +33,18 @@ export function computePopularity(
 
 export type RecipeStatsService = ReturnType<typeof createRecipeStatsService>;
 
-export function createRecipeStatsService(recipeRepository: RecipeRepository) {
+type RecipeRepositoryPort = Pick<
+  RecipeRepository,
+  | "applyFavoritesDelta"
+  | "applyCommentsDelta"
+  | "applyRatingCreated"
+  | "applyRatingUpdated"
+  | "applyRatingDeleted"
+>;
+
+export function createRecipeStatsService(
+  recipeRepository: RecipeRepositoryPort,
+) {
   return {
     async onFavoriteCreated(recipeId: string) {
       return recipeRepository.applyFavoritesDelta(recipeId, 1);

--- a/apps/backend/src/modules/recipes/recipe-stats.service.ts
+++ b/apps/backend/src/modules/recipes/recipe-stats.service.ts
@@ -5,6 +5,7 @@ import type { CommentModelType } from "@/modules/comments/comment.model.js";
 import type { FavoriteModelType } from "@/modules/favorites/favorite.model.js";
 import type { RecipeRatingModelType } from "@/modules/recipe-ratings/recipe-rating.model.js";
 import type { RecipeModelType } from "./recipe.model.js";
+import type { RecipeRepository } from "./recipe.repository.js";
 
 export function computePopularity(stats: Omit<RecipeStats, "popularity">) {
   return (
@@ -13,6 +14,42 @@ export function computePopularity(stats: Omit<RecipeStats, "popularity">) {
     stats.ratingCount * 1 +
     (stats.averageRating ?? 0) * 5
   );
+}
+
+export type RecipeStatsService = ReturnType<typeof createRecipeStatsService>;
+
+export function createRecipeStatsService(recipeRepository: RecipeRepository) {
+  return {
+    async onFavoriteCreated(recipeId: string) {
+      return recipeRepository.applyFavoritesDelta(recipeId, 1);
+    },
+    async onFavoriteDeleted(recipeId: string) {
+      return recipeRepository.applyFavoritesDelta(recipeId, -1);
+    },
+    async onCommentCreated(recipeId: string) {
+      return recipeRepository.applyCommentsDelta(recipeId, 1);
+    },
+    async onCommentDeleted(recipeId: string) {
+      return recipeRepository.applyCommentsDelta(recipeId, -1);
+    },
+    async onRatingCreated(recipeId: string, value: number) {
+      return recipeRepository.applyRatingCreated(recipeId, value);
+    },
+    async onRatingUpdated(
+      recipeId: string,
+      previousValue: number | null,
+      value: number,
+    ) {
+      return recipeRepository.applyRatingUpdated(
+        recipeId,
+        previousValue ?? 0,
+        value,
+      );
+    },
+    async onRatingDeleted(recipeId: string, value: number) {
+      return recipeRepository.applyRatingDeleted(recipeId, value);
+    },
+  };
 }
 
 export async function rebuildRecipeStats(

--- a/apps/backend/src/modules/recipes/recipe-stats.service.ts
+++ b/apps/backend/src/modules/recipes/recipe-stats.service.ts
@@ -6,13 +6,14 @@ import type { FavoriteModelType } from "@/modules/favorites/favorite.model.js";
 import type { RecipeRatingModelType } from "@/modules/recipe-ratings/recipe-rating.model.js";
 import type { RecipeModelType } from "./recipe.model.js";
 import type { RecipeRepository } from "./recipe.repository.js";
+import { RECIPE_POPULARITY_WEIGHTS } from "./recipe.repository.js";
 
 export function computePopularity(stats: Omit<RecipeStats, "popularity">) {
   return (
-    stats.favoritesCount * 3 +
-    stats.commentsCount * 2 +
-    stats.ratingCount * 1 +
-    (stats.averageRating ?? 0) * 5
+    stats.favoritesCount * RECIPE_POPULARITY_WEIGHTS.favorites +
+    stats.commentsCount * RECIPE_POPULARITY_WEIGHTS.comments +
+    stats.ratingCount * RECIPE_POPULARITY_WEIGHTS.ratings +
+    (stats.averageRating ?? 0) * RECIPE_POPULARITY_WEIGHTS.averageRating
   );
 }
 

--- a/apps/backend/src/modules/recipes/recipe.aggregation.ts
+++ b/apps/backend/src/modules/recipes/recipe.aggregation.ts
@@ -135,34 +135,3 @@ export function withUserRating(userId?: string) {
     stages.unset("userRatingDoc"),
   ].flat();
 }
-
-export function withAverageRating() {
-  return [
-    stages.lookup(
-      {
-        from: recipeRatingsCollectionName,
-        localField: "_id",
-        foreignField: "recipe",
-        pipeline: [
-          stages.group({
-            _id: null,
-            avg: { $avg: "$value" },
-            count: { $sum: 1 },
-          }),
-          stages.project({
-            _id: 0,
-            avg: { $round: ["$avg", 1] },
-            count: 1,
-          }),
-        ],
-        as: "ratingStats",
-      },
-      { required: false },
-    ),
-    stages.addFields({
-      averageRating: "$ratingStats.avg",
-      ratingCount: { $ifNull: ["$ratingStats.count", 0] },
-    }),
-    stages.unset("ratingStats"),
-  ].flat();
-}

--- a/apps/backend/src/modules/recipes/recipe.events.ts
+++ b/apps/backend/src/modules/recipes/recipe.events.ts
@@ -1,16 +1,46 @@
 import type { CacheService } from "@/common/cache/cache.service.js";
 import type { TypedEmitter } from "@/common/events.js";
 import type { Logger } from "@/common/logger.js";
+import { recipeCache as recipeCacheOptions } from "./recipe.cache.js";
+import type { RecipeStatsService } from "./recipe-stats.service.js";
 
 export function registerRecipeEventHandlers(
   bus: TypedEmitter,
   deps: {
+    recipeStats: RecipeStatsService;
     recipeCache: CacheService;
     log: Logger;
   },
 ) {
-  bus.on("category:deleted", () => deps.recipeCache.deletePattern("*"));
-  bus.on("recipe-rating:created", () => deps.recipeCache.deletePattern("*"));
-  bus.on("recipe-rating:updated", () => deps.recipeCache.deletePattern("*"));
-  bus.on("recipe-rating:deleted", () => deps.recipeCache.deletePattern("*"));
+  bus.on("favorite:created", async ({ recipeId }) => {
+    await deps.recipeStats.onFavoriteCreated(recipeId);
+    deps.recipeCache.delete(recipeCacheOptions.keys.byId(recipeId));
+  });
+  bus.on("favorite:deleted", async ({ recipeId }) => {
+    await deps.recipeStats.onFavoriteDeleted(recipeId);
+    deps.recipeCache.delete(recipeCacheOptions.keys.byId(recipeId));
+  });
+  bus.on("comment:created", async ({ recipeId }) => {
+    await deps.recipeStats.onCommentCreated(recipeId);
+    deps.recipeCache.delete(recipeCacheOptions.keys.byId(recipeId));
+  });
+  bus.on("comment:deleted", async ({ recipeId }) => {
+    await deps.recipeStats.onCommentDeleted(recipeId);
+    deps.recipeCache.delete(recipeCacheOptions.keys.byId(recipeId));
+  });
+  bus.on("recipe-rating:created", async ({ recipeId, value }) => {
+    await deps.recipeStats.onRatingCreated(recipeId, value);
+    deps.recipeCache.delete(recipeCacheOptions.keys.byId(recipeId));
+  });
+  bus.on(
+    "recipe-rating:updated",
+    async ({ recipeId, previousValue, value }) => {
+      await deps.recipeStats.onRatingUpdated(recipeId, previousValue, value);
+      deps.recipeCache.delete(recipeCacheOptions.keys.byId(recipeId));
+    },
+  );
+  bus.on("recipe-rating:deleted", async ({ recipeId, value }) => {
+    await deps.recipeStats.onRatingDeleted(recipeId, value);
+    deps.recipeCache.delete(recipeCacheOptions.keys.byId(recipeId));
+  });
 }

--- a/apps/backend/src/modules/recipes/recipe.events.ts
+++ b/apps/backend/src/modules/recipes/recipe.events.ts
@@ -13,34 +13,90 @@ export function registerRecipeEventHandlers(
   },
 ) {
   bus.on("favorite:created", async ({ recipeId }) => {
-    await deps.recipeStats.onFavoriteCreated(recipeId);
-    deps.recipeCache.delete(recipeCacheOptions.keys.byId(recipeId));
+    try {
+      await deps.recipeStats.onFavoriteCreated(recipeId);
+      await deps.recipeCache.delete(recipeCacheOptions.keys.byId(recipeId));
+      await deps.recipeCache.delete(recipeCacheOptions.keys.listPattern());
+    } catch (err) {
+      deps.log.error(
+        { err, recipeId, event: "favorite:created" },
+        "Failed to update recipe stats",
+      );
+    }
   });
   bus.on("favorite:deleted", async ({ recipeId }) => {
-    await deps.recipeStats.onFavoriteDeleted(recipeId);
-    deps.recipeCache.delete(recipeCacheOptions.keys.byId(recipeId));
+    try {
+      await deps.recipeStats.onFavoriteDeleted(recipeId);
+      await deps.recipeCache.delete(recipeCacheOptions.keys.byId(recipeId));
+      await deps.recipeCache.delete(recipeCacheOptions.keys.listPattern());
+    } catch (err) {
+      deps.log.error(
+        { err, recipeId, event: "favorite:deleted" },
+        "Failed to update recipe stats",
+      );
+    }
   });
   bus.on("comment:created", async ({ recipeId }) => {
-    await deps.recipeStats.onCommentCreated(recipeId);
-    deps.recipeCache.delete(recipeCacheOptions.keys.byId(recipeId));
+    try {
+      await deps.recipeStats.onCommentCreated(recipeId);
+      await deps.recipeCache.delete(recipeCacheOptions.keys.byId(recipeId));
+      await deps.recipeCache.delete(recipeCacheOptions.keys.listPattern());
+    } catch (err) {
+      deps.log.error(
+        { err, recipeId, event: "comment:created" },
+        "Failed to update recipe stats",
+      );
+    }
   });
   bus.on("comment:deleted", async ({ recipeId }) => {
-    await deps.recipeStats.onCommentDeleted(recipeId);
-    deps.recipeCache.delete(recipeCacheOptions.keys.byId(recipeId));
+    try {
+      await deps.recipeStats.onCommentDeleted(recipeId);
+      await deps.recipeCache.delete(recipeCacheOptions.keys.byId(recipeId));
+      await deps.recipeCache.delete(recipeCacheOptions.keys.listPattern());
+    } catch (err) {
+      deps.log.error(
+        { err, recipeId, event: "comment:deleted" },
+        "Failed to update recipe stats",
+      );
+    }
   });
   bus.on("recipe-rating:created", async ({ recipeId, value }) => {
-    await deps.recipeStats.onRatingCreated(recipeId, value);
-    deps.recipeCache.delete(recipeCacheOptions.keys.byId(recipeId));
+    try {
+      await deps.recipeStats.onRatingCreated(recipeId, value);
+      await deps.recipeCache.delete(recipeCacheOptions.keys.byId(recipeId));
+      await deps.recipeCache.delete(recipeCacheOptions.keys.listPattern());
+    } catch (err) {
+      deps.log.error(
+        { err, recipeId, event: "recipe-rating:created" },
+        "Failed to update recipe stats",
+      );
+    }
   });
   bus.on(
     "recipe-rating:updated",
     async ({ recipeId, previousValue, value }) => {
-      await deps.recipeStats.onRatingUpdated(recipeId, previousValue, value);
-      deps.recipeCache.delete(recipeCacheOptions.keys.byId(recipeId));
+      try {
+        await deps.recipeStats.onRatingUpdated(recipeId, previousValue, value);
+        await deps.recipeCache.delete(recipeCacheOptions.keys.byId(recipeId));
+        await deps.recipeCache.delete(recipeCacheOptions.keys.listPattern());
+      } catch (err) {
+        deps.log.error(
+          { err, recipeId, event: "recipe-rating:updated" },
+          "Failed to update recipe stats",
+        );
+      }
     },
   );
   bus.on("recipe-rating:deleted", async ({ recipeId, value }) => {
-    await deps.recipeStats.onRatingDeleted(recipeId, value);
-    deps.recipeCache.delete(recipeCacheOptions.keys.byId(recipeId));
+    try {
+      await deps.recipeStats.onRatingDeleted(recipeId, value);
+      await deps.recipeCache.delete(recipeCacheOptions.keys.byId(recipeId));
+      await deps.recipeCache.delete(recipeCacheOptions.keys.listPattern());
+    } catch (err) {
+      deps.log.error(
+        { err, recipeId, event: "recipe-rating:deleted" },
+        "Failed to update recipe stats",
+      );
+    }
   });
 }

--- a/apps/backend/src/modules/recipes/recipe.mapper.test.ts
+++ b/apps/backend/src/modules/recipes/recipe.mapper.test.ts
@@ -116,4 +116,30 @@ describe("toRecipe", () => {
 
     expect(result.isFavorited).toBe(false);
   });
+
+  it("should default partial stats fields when some are missing", () => {
+    const doc = {
+      ...createRecipeDoc(),
+      category: {
+        _id: createObjectId(),
+        name: "Cat",
+        slug: "cat",
+        image: { url: "https://example.com/cat.jpg" },
+      },
+      author: { _id: createObjectId(), name: "Auth", email: "a@b.c" },
+      stats: {
+        favoritesCount: 5,
+        commentsCount: 3,
+      } as never,
+    };
+
+    const result = toRecipe(doc, false);
+
+    expect(result.stats.favoritesCount).toBe(5);
+    expect(result.stats.commentsCount).toBe(3);
+    expect(result.stats.ratingCount).toBe(0);
+    expect(result.stats.ratingSum).toBe(0);
+    expect(result.stats.averageRating).toBeNull();
+    expect(result.stats.popularity).toBe(0);
+  });
 });

--- a/apps/backend/src/modules/recipes/recipe.mapper.test.ts
+++ b/apps/backend/src/modules/recipes/recipe.mapper.test.ts
@@ -46,8 +46,14 @@ describe("toRecipe", () => {
       },
       isFavorited: true,
       userRating: 4,
-      averageRating: 4.2,
-      ratingCount: 10,
+      stats: {
+        favoritesCount: 2,
+        commentsCount: 4,
+        ratingCount: 10,
+        ratingSum: 20,
+        averageRating: 4.2,
+        popularity: 10,
+      },
     } satisfies RecipeDocumentPopulated & RecipeComputed;
 
     const result = toRecipe(doc, doc.isFavorited);
@@ -67,8 +73,12 @@ describe("toRecipe", () => {
       name: "Chef",
     });
     expect(result.userRating).toBe(4);
-    expect(result.averageRating).toBe(4.2);
-    expect(result.ratingCount).toBe(10);
+    expect(result.stats.averageRating).toBe(4.2);
+    expect(result.stats.ratingCount).toBe(10);
+    expect(result.stats.ratingSum).toBe(20);
+    expect(result.stats.favoritesCount).toBe(2);
+    expect(result.stats.commentsCount).toBe(4);
+    expect(result.stats.popularity).toBe(10);
   });
 
   it("should default rating fields when missing", () => {
@@ -86,8 +96,8 @@ describe("toRecipe", () => {
     const result = toRecipe(doc, false);
 
     expect(result.userRating).toBeNull();
-    expect(result.averageRating).toBeNull();
-    expect(result.ratingCount).toBe(0);
+    expect(result.stats.averageRating).toBeNull();
+    expect(result.stats.ratingCount).toBe(0);
   });
 
   it("should map isFavorited=false", () => {

--- a/apps/backend/src/modules/recipes/recipe.mapper.ts
+++ b/apps/backend/src/modules/recipes/recipe.mapper.ts
@@ -2,6 +2,7 @@ import type {
   Difficulty,
   Image,
   Minutes,
+  RecipeStats,
   RecipeSummary,
   RecipeWithComputed,
 } from "@recipes/shared";
@@ -32,9 +33,8 @@ export type RecipeView = RecipeSummaryView & {
   servings: number;
   isPublic: boolean;
   image: Image;
+  stats: RecipeStats;
   userRating?: number | null;
-  averageRating?: number | null;
-  ratingCount?: number | null;
   createdAt: Date | string;
   updatedAt: Date | string;
 };
@@ -67,8 +67,14 @@ export function toRecipe(
     },
     isFavorited,
     userRating: view.userRating ?? null,
-    averageRating: view.averageRating ?? null,
-    ratingCount: view.ratingCount ?? 0,
+    stats: {
+      favoritesCount: view.stats.favoritesCount ?? 0,
+      commentsCount: view.stats.commentsCount ?? 0,
+      ratingCount: view.stats.ratingCount ?? 0,
+      ratingSum: view.stats.ratingSum ?? 0,
+      averageRating: view.stats.averageRating ?? null,
+      popularity: view.stats.popularity ?? 0,
+    },
     createdAt: new Date(view.createdAt).toISOString(),
     updatedAt: new Date(view.updatedAt).toISOString(),
   };

--- a/apps/backend/src/modules/recipes/recipe.model.test.ts
+++ b/apps/backend/src/modules/recipes/recipe.model.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { RecipeModel } from "./recipe.model.js";
+
+describe("RecipeModel", () => {
+  describe("stats defaults", () => {
+    it("should create recipe with default stats when stats not provided", () => {
+      const recipe = new RecipeModel({
+        title: "Test Recipe",
+        description: "A test recipe",
+        ingredients: [{ name: "Flour", quantity: 200, unit: "g" }],
+        instructions: ["Mix ingredients"],
+        category: "507f1f77bcf86cd799439011",
+        author: "507f1f77bcf86cd799439022",
+        difficulty: "easy",
+        cookingTime: 30,
+        servings: 4,
+        isPublic: true,
+        image: { url: "https://example.com/image.jpg" },
+      });
+
+      expect(recipe.stats.favoritesCount).toBe(0);
+      expect(recipe.stats.commentsCount).toBe(0);
+      expect(recipe.stats.ratingCount).toBe(0);
+      expect(recipe.stats.ratingSum).toBe(0);
+      expect(recipe.stats.averageRating).toBeNull();
+      expect(recipe.stats.popularity).toBe(0);
+    });
+
+    it("should allow custom stats on creation", () => {
+      const recipe = new RecipeModel({
+        title: "Test Recipe",
+        description: "A test recipe",
+        ingredients: [{ name: "Flour", quantity: 200, unit: "g" }],
+        instructions: ["Mix ingredients"],
+        category: "507f1f77bcf86cd799439011",
+        author: "507f1f77bcf86cd799439022",
+        difficulty: "easy",
+        cookingTime: 30,
+        servings: 4,
+        isPublic: true,
+        image: { url: "https://example.com/image.jpg" },
+        stats: {
+          favoritesCount: 5,
+          commentsCount: 3,
+          ratingCount: 10,
+          ratingSum: 45,
+          averageRating: 4.5,
+          popularity: 42,
+        },
+      });
+
+      expect(recipe.stats.favoritesCount).toBe(5);
+      expect(recipe.stats.commentsCount).toBe(3);
+      expect(recipe.stats.ratingCount).toBe(10);
+      expect(recipe.stats.ratingSum).toBe(45);
+      expect(recipe.stats.averageRating).toBe(4.5);
+      expect(recipe.stats.popularity).toBe(42);
+    });
+
+    it("should default missing stat fields to their defaults", () => {
+      const recipe = new RecipeModel({
+        title: "Test Recipe",
+        description: "A test recipe",
+        ingredients: [{ name: "Flour", quantity: 200, unit: "g" }],
+        instructions: ["Mix ingredients"],
+        category: "507f1f77bcf86cd799439011",
+        author: "507f1f77bcf86cd799439022",
+        difficulty: "easy",
+        cookingTime: 30,
+        servings: 4,
+        isPublic: true,
+        image: { url: "https://example.com/image.jpg" },
+        stats: {
+          favoritesCount: 7,
+        } as never,
+      });
+
+      expect(recipe.stats.favoritesCount).toBe(7);
+      expect(recipe.stats.commentsCount).toBe(0);
+      expect(recipe.stats.ratingCount).toBe(0);
+      expect(recipe.stats.ratingSum).toBe(0);
+      expect(recipe.stats.averageRating).toBeNull();
+      expect(recipe.stats.popularity).toBe(0);
+    });
+  });
+});

--- a/apps/backend/src/modules/recipes/recipe.model.ts
+++ b/apps/backend/src/modules/recipes/recipe.model.ts
@@ -1,8 +1,9 @@
 import type {
   Difficulty,
   Image,
+  Merge,
   Minutes,
-  Replace,
+  RecipeStats,
   RequireKeys,
 } from "@recipes/shared";
 import type { Model, Types } from "mongoose";
@@ -31,10 +32,11 @@ export interface RecipeDocument extends BaseDocument {
   servings: number;
   isPublic: boolean;
   image: RecipeImage;
+  stats: RecipeStats;
 }
 
 export interface RecipeDocumentPopulated
-  extends Replace<
+  extends Merge<
     RecipeDocument,
     {
       category: Pick<CategoryDocument, "_id" | "name" | "slug" | "image">;
@@ -57,6 +59,18 @@ const imageSchema = new Schema<RecipeImage>(
   {
     url: { type: String, required: true },
     alt: { type: String, trim: true, required: false },
+  },
+  { _id: false },
+);
+
+const recipeStatsSchema = new Schema<RecipeStats>(
+  {
+    favoritesCount: { type: Number, default: 0 },
+    commentsCount: { type: Number, default: 0 },
+    ratingCount: { type: Number, default: 0 },
+    ratingSum: { type: Number, default: 0 },
+    averageRating: { type: Number, default: null },
+    popularity: { type: Number, default: 0 },
   },
   { _id: false },
 );
@@ -100,6 +114,7 @@ const recipeSchema = new Schema<RecipeDocument>(
     servings: { type: Number, required: true, min: 1 },
     isPublic: { type: Boolean, default: true },
     image: { type: imageSchema, required: true },
+    stats: { type: recipeStatsSchema, default: {} },
   },
   {
     timestamps: true,

--- a/apps/backend/src/modules/recipes/recipe.repository.int.test.ts
+++ b/apps/backend/src/modules/recipes/recipe.repository.int.test.ts
@@ -6,6 +6,7 @@ import {
   createDbRecipeRating,
   createDbUser,
 } from "@/__tests__/db-factories.js";
+import { noInitiator } from "@/__tests__/helpers.js";
 import { RecipeModel } from "./recipe.model.js";
 import { RecipeRepository } from "./recipe.repository.js";
 
@@ -258,6 +259,120 @@ describe("RecipeRepository", () => {
 
       expect(total).toBe(2);
       expect(recipes).toHaveLength(1);
+    });
+
+    it("should sort by popularity descending", async () => {
+      const author = await createDbUser();
+      const category = await createDbCategory();
+      await createDbRecipe({
+        author: author._id,
+        category: category._id,
+        title: "Low",
+        isPublic: true,
+        stats: {
+          favoritesCount: 0,
+          commentsCount: 0,
+          ratingCount: 0,
+          ratingSum: 0,
+          averageRating: null,
+          popularity: 5,
+        },
+      });
+      await createDbRecipe({
+        author: author._id,
+        category: category._id,
+        title: "High",
+        isPublic: true,
+        stats: {
+          favoritesCount: 0,
+          commentsCount: 0,
+          ratingCount: 0,
+          ratingSum: 0,
+          averageRating: null,
+          popularity: 50,
+        },
+      });
+      await createDbRecipe({
+        author: author._id,
+        category: category._id,
+        title: "Medium",
+        isPublic: true,
+        stats: {
+          favoritesCount: 0,
+          commentsCount: 0,
+          ratingCount: 0,
+          ratingSum: 0,
+          averageRating: null,
+          popularity: 20,
+        },
+      });
+
+      const [recipes] = await repository.aggregateSearch({
+        query: { page: 1, limit: 10, sort: "-popularity" },
+        initiator: noInitiator(),
+      });
+
+      expect(recipes).toHaveLength(3);
+      expect(recipes[0]?.title).toBe("High");
+      expect(recipes[1]?.title).toBe("Medium");
+      expect(recipes[2]?.title).toBe("Low");
+    });
+
+    it("should sort by popularity ascending", async () => {
+      const author = await createDbUser();
+      const category = await createDbCategory();
+      await createDbRecipe({
+        author: author._id,
+        category: category._id,
+        title: "Low",
+        isPublic: true,
+        stats: {
+          favoritesCount: 0,
+          commentsCount: 0,
+          ratingCount: 0,
+          ratingSum: 0,
+          averageRating: null,
+          popularity: 5,
+        },
+      });
+      await createDbRecipe({
+        author: author._id,
+        category: category._id,
+        title: "High",
+        isPublic: true,
+        stats: {
+          favoritesCount: 0,
+          commentsCount: 0,
+          ratingCount: 0,
+          ratingSum: 0,
+          averageRating: null,
+          popularity: 50,
+        },
+      });
+      await createDbRecipe({
+        author: author._id,
+        category: category._id,
+        title: "Medium",
+        isPublic: true,
+        stats: {
+          favoritesCount: 0,
+          commentsCount: 0,
+          ratingCount: 0,
+          ratingSum: 0,
+          averageRating: null,
+          popularity: 20,
+        },
+      });
+
+      const [recipes] = await repository.aggregateSearch({
+        query: { page: 1, limit: 10, sort: "popularity" },
+        initiator: noInitiator(),
+      });
+
+      expect(recipes).toHaveLength(3);
+      expect(recipes[0]?.title).toBe("Low");
+      expect(recipes[1]?.title).toBe("Medium");
+      expect(recipes[2]?.title).toBe("High");
     });
   });
 

--- a/apps/backend/src/modules/recipes/recipe.repository.int.test.ts
+++ b/apps/backend/src/modules/recipes/recipe.repository.int.test.ts
@@ -319,6 +319,277 @@ describe("RecipeRepository", () => {
     });
   });
 
+  describe("applyFavoritesDelta", () => {
+    it("should increment favoritesCount and recalculate popularity", async () => {
+      const author = await createDbUser();
+      const category = await createDbCategory();
+      const recipe = await createDbRecipe({
+        author: author._id,
+        category: category._id,
+        isPublic: true,
+      });
+
+      const result = await repository.applyFavoritesDelta(
+        recipe._id.toString(),
+        1,
+      );
+
+      expect(result?.stats.favoritesCount).toBe(1);
+      expect(result?.stats.popularity).toBe(3);
+    });
+
+    it("should decrement favoritesCount", async () => {
+      const author = await createDbUser();
+      const category = await createDbCategory();
+      const recipe = await createDbRecipe({
+        author: author._id,
+        category: category._id,
+        isPublic: true,
+        stats: {
+          favoritesCount: 2,
+          commentsCount: 0,
+          ratingCount: 0,
+          ratingSum: 0,
+          averageRating: null,
+          popularity: 6,
+        },
+      });
+
+      const result = await repository.applyFavoritesDelta(
+        recipe._id.toString(),
+        -1,
+      );
+
+      expect(result?.stats.favoritesCount).toBe(1);
+      expect(result?.stats.popularity).toBe(3);
+    });
+
+    it("should not allow favoritesCount to go below zero", async () => {
+      const author = await createDbUser();
+      const category = await createDbCategory();
+      const recipe = await createDbRecipe({
+        author: author._id,
+        category: category._id,
+        isPublic: true,
+      });
+
+      const result = await repository.applyFavoritesDelta(
+        recipe._id.toString(),
+        -1,
+      );
+
+      expect(result?.stats.favoritesCount).toBe(0);
+      expect(result?.stats.popularity).toBe(0);
+    });
+  });
+
+  describe("applyCommentsDelta", () => {
+    it("should increment commentsCount and recalculate popularity", async () => {
+      const author = await createDbUser();
+      const category = await createDbCategory();
+      const recipe = await createDbRecipe({
+        author: author._id,
+        category: category._id,
+        isPublic: true,
+      });
+
+      const result = await repository.applyCommentsDelta(
+        recipe._id.toString(),
+        1,
+      );
+
+      expect(result?.stats.commentsCount).toBe(1);
+      expect(result?.stats.popularity).toBe(2);
+    });
+
+    it("should not allow commentsCount to go below zero", async () => {
+      const author = await createDbUser();
+      const category = await createDbCategory();
+      const recipe = await createDbRecipe({
+        author: author._id,
+        category: category._id,
+        isPublic: true,
+      });
+
+      const result = await repository.applyCommentsDelta(
+        recipe._id.toString(),
+        -1,
+      );
+
+      expect(result?.stats.commentsCount).toBe(0);
+    });
+  });
+
+  describe("applyRatingCreated", () => {
+    it("should add first rating and compute averageRating", async () => {
+      const author = await createDbUser();
+      const category = await createDbCategory();
+      const recipe = await createDbRecipe({
+        author: author._id,
+        category: category._id,
+        isPublic: true,
+      });
+
+      const result = await repository.applyRatingCreated(
+        recipe._id.toString(),
+        4,
+      );
+
+      expect(result?.stats.ratingCount).toBe(1);
+      expect(result?.stats.ratingSum).toBe(4);
+      expect(result?.stats.averageRating).toBe(4);
+      expect(result?.stats.popularity).toBe(21);
+    });
+
+    it("should add second rating and update average", async () => {
+      const author = await createDbUser();
+      const category = await createDbCategory();
+      const recipe = await createDbRecipe({
+        author: author._id,
+        category: category._id,
+        isPublic: true,
+        stats: {
+          favoritesCount: 0,
+          commentsCount: 0,
+          ratingCount: 1,
+          ratingSum: 4,
+          averageRating: 4,
+          popularity: 21,
+        },
+      });
+
+      const result = await repository.applyRatingCreated(
+        recipe._id.toString(),
+        5,
+      );
+
+      expect(result?.stats.ratingCount).toBe(2);
+      expect(result?.stats.ratingSum).toBe(9);
+      expect(result?.stats.averageRating).toBe(4.5);
+      expect(result?.stats.popularity).toBe(24.5);
+    });
+  });
+
+  describe("applyRatingUpdated", () => {
+    it("should update rating sum and average", async () => {
+      const author = await createDbUser();
+      const category = await createDbCategory();
+      const recipe = await createDbRecipe({
+        author: author._id,
+        category: category._id,
+        isPublic: true,
+        stats: {
+          favoritesCount: 0,
+          commentsCount: 0,
+          ratingCount: 2,
+          ratingSum: 9,
+          averageRating: 4.5,
+          popularity: 24.5,
+        },
+      });
+
+      const result = await repository.applyRatingUpdated(
+        recipe._id.toString(),
+        4,
+        5,
+      );
+
+      expect(result?.stats.ratingCount).toBe(2);
+      expect(result?.stats.ratingSum).toBe(10);
+      expect(result?.stats.averageRating).toBe(5);
+      expect(result?.stats.popularity).toBe(27);
+    });
+  });
+
+  describe("applyRatingDeleted", () => {
+    it("should remove rating and update average", async () => {
+      const author = await createDbUser();
+      const category = await createDbCategory();
+      const recipe = await createDbRecipe({
+        author: author._id,
+        category: category._id,
+        isPublic: true,
+        stats: {
+          favoritesCount: 0,
+          commentsCount: 0,
+          ratingCount: 2,
+          ratingSum: 9,
+          averageRating: 4.5,
+          popularity: 24.5,
+        },
+      });
+
+      const result = await repository.applyRatingDeleted(
+        recipe._id.toString(),
+        5,
+      );
+
+      expect(result?.stats.ratingCount).toBe(1);
+      expect(result?.stats.ratingSum).toBe(4);
+      expect(result?.stats.averageRating).toBe(4);
+      expect(result?.stats.popularity).toBe(21);
+    });
+
+    it("should set averageRating to null when last rating is deleted", async () => {
+      const author = await createDbUser();
+      const category = await createDbCategory();
+      const recipe = await createDbRecipe({
+        author: author._id,
+        category: category._id,
+        isPublic: true,
+        stats: {
+          favoritesCount: 0,
+          commentsCount: 0,
+          ratingCount: 1,
+          ratingSum: 4,
+          averageRating: 4,
+          popularity: 21,
+        },
+      });
+
+      const result = await repository.applyRatingDeleted(
+        recipe._id.toString(),
+        4,
+      );
+
+      expect(result?.stats.ratingCount).toBe(0);
+      expect(result?.stats.ratingSum).toBe(0);
+      expect(result?.stats.averageRating).toBeNull();
+      expect(result?.stats.popularity).toBe(0);
+    });
+  });
+
+  describe("combined stats update", () => {
+    it("should recalculate popularity correctly after multiple deltas", async () => {
+      const author = await createDbUser();
+      const category = await createDbCategory();
+      const recipe = await createDbRecipe({
+        author: author._id,
+        category: category._id,
+        isPublic: true,
+        stats: {
+          favoritesCount: 2,
+          commentsCount: 1,
+          ratingCount: 3,
+          ratingSum: 12,
+          averageRating: 4,
+          popularity: 0,
+        },
+      });
+
+      const result = await repository.applyFavoritesDelta(
+        recipe._id.toString(),
+        1,
+      );
+
+      expect(result?.stats.favoritesCount).toBe(3);
+      expect(result?.stats.commentsCount).toBe(1);
+      expect(result?.stats.ratingCount).toBe(3);
+      expect(result?.stats.averageRating).toBe(4);
+      expect(result?.stats.popularity).toBe(34);
+    });
+  });
+
   describe("inherited BaseRepository methods", () => {
     it("should create and findById a recipe", async () => {
       const author = await createDbUser();

--- a/apps/backend/src/modules/recipes/recipe.repository.int.test.ts
+++ b/apps/backend/src/modules/recipes/recipe.repository.int.test.ts
@@ -202,6 +202,14 @@ describe("RecipeRepository", () => {
         author: author._id,
         category: category._id,
         isPublic: true,
+        stats: {
+          favoritesCount: 0,
+          commentsCount: 0,
+          ratingCount: 2,
+          ratingSum: 9,
+          averageRating: 4.5,
+          popularity: 0,
+        },
       });
       await createDbRecipeRating({
         user: user._id,
@@ -223,8 +231,8 @@ describe("RecipeRepository", () => {
       });
 
       expect(recipes[0]?.userRating).toBe(4);
-      expect(recipes[0]?.averageRating).toBe(4.5);
-      expect(recipes[0]?.ratingCount).toBe(2);
+      expect(recipes[0]?.stats.averageRating).toBe(4.5);
+      expect(recipes[0]?.stats.ratingCount).toBe(2);
     });
 
     it("should paginate correctly", async () => {

--- a/apps/backend/src/modules/recipes/recipe.repository.ts
+++ b/apps/backend/src/modules/recipes/recipe.repository.ts
@@ -15,7 +15,6 @@ import type { UserDocument } from "@/modules/users/user.model.js";
 import {
   byVisibility,
   withAuthor,
-  withAverageRating,
   withCategories,
   withFavorited,
   withUserRating,
@@ -101,7 +100,6 @@ export function buildSearchPipeline({
 
     withFavorited(initiator.id),
     withUserRating(initiator.id),
-    withAverageRating(),
     stages.match<RecipeDocument>({
       ...(isFavorited !== undefined && { isFavorited }),
     }),
@@ -132,6 +130,5 @@ export function buildFindByIdPipeline(
     withAuthor(),
     withFavorited(initiator.id),
     withUserRating(initiator.id),
-    withAverageRating(),
   ].flat();
 }

--- a/apps/backend/src/modules/recipes/recipe.repository.ts
+++ b/apps/backend/src/modules/recipes/recipe.repository.ts
@@ -73,6 +73,11 @@ export class RecipeRepository extends BaseRepository<
     const { page, limit, sort, isFavorited, search, categoryId, difficulty } =
       query;
 
+    const sortWithPopularityReplaced = sort.replace(
+      "popularity",
+      "stats.popularity",
+    );
+
     const pipeline = [
       stages.match<RecipeDocument>({
         ...byVisibility(initiator),
@@ -90,7 +95,7 @@ export class RecipeRepository extends BaseRepository<
 
       stages.paginated(
         {
-          sort,
+          sort: sortWithPopularityReplaced,
           page,
           limit,
         },

--- a/apps/backend/src/modules/recipes/recipe.repository.ts
+++ b/apps/backend/src/modules/recipes/recipe.repository.ts
@@ -146,30 +146,22 @@ export class RecipeRepository extends BaseRepository<
   private buildPopularityExpression() {
     return {
       $add: [
-        {
-          $multiply: [
-            { $ifNull: ["$stats.favoritesCount", 0] },
-            RECIPE_POPULARITY_WEIGHTS.favorites,
-          ],
-        },
-        {
-          $multiply: [
-            { $ifNull: ["$stats.commentsCount", 0] },
-            RECIPE_POPULARITY_WEIGHTS.comments,
-          ],
-        },
-        {
-          $multiply: [
-            { $ifNull: ["$stats.ratingCount", 0] },
-            RECIPE_POPULARITY_WEIGHTS.ratings,
-          ],
-        },
-        {
-          $multiply: [
-            { $ifNull: ["$stats.averageRating", 0] },
-            RECIPE_POPULARITY_WEIGHTS.averageRating,
-          ],
-        },
+        stages.multiply(
+          { $ifNull: ["$stats.favoritesCount", 0] },
+          RECIPE_POPULARITY_WEIGHTS.favorites,
+        ),
+        stages.multiply(
+          { $ifNull: ["$stats.commentsCount", 0] },
+          RECIPE_POPULARITY_WEIGHTS.comments,
+        ),
+        stages.multiply(
+          { $ifNull: ["$stats.ratingCount", 0] },
+          RECIPE_POPULARITY_WEIGHTS.ratings,
+        ),
+        stages.multiply(
+          { $ifNull: ["$stats.averageRating", 0] },
+          RECIPE_POPULARITY_WEIGHTS.averageRating,
+        ),
       ],
     };
   }
@@ -187,77 +179,37 @@ export class RecipeRepository extends BaseRepository<
       .findOneAndUpdate(
         { _id: toObjectId(recipeId) },
         [
-          {
-            $set: {
-              "stats.favoritesCount": {
-                $max: [
-                  0,
+          stages.set({
+            "stats.favoritesCount": stages.max(0, {
+              $add: [{ $ifNull: ["$stats.favoritesCount", 0] }, favoritesDelta],
+            }),
+            "stats.commentsCount": stages.max(0, {
+              $add: [{ $ifNull: ["$stats.commentsCount", 0] }, commentsDelta],
+            }),
+            "stats.ratingCount": stages.max(0, {
+              $add: [{ $ifNull: ["$stats.ratingCount", 0] }, ratingCountDelta],
+            }),
+            "stats.ratingSum": stages.max(0, {
+              $add: [{ $ifNull: ["$stats.ratingSum", 0] }, ratingSumDelta],
+            }),
+          }),
+          stages.set({
+            "stats.averageRating": stages.cond(
+              { $gt: ["$stats.ratingCount", 0] },
+              {
+                $round: [
                   {
-                    $add: [
-                      { $ifNull: ["$stats.favoritesCount", 0] },
-                      favoritesDelta,
-                    ],
+                    $divide: ["$stats.ratingSum", "$stats.ratingCount"],
                   },
+                  1,
                 ],
               },
-              "stats.commentsCount": {
-                $max: [
-                  0,
-                  {
-                    $add: [
-                      { $ifNull: ["$stats.commentsCount", 0] },
-                      commentsDelta,
-                    ],
-                  },
-                ],
-              },
-              "stats.ratingCount": {
-                $max: [
-                  0,
-                  {
-                    $add: [
-                      { $ifNull: ["$stats.ratingCount", 0] },
-                      ratingCountDelta,
-                    ],
-                  },
-                ],
-              },
-              "stats.ratingSum": {
-                $max: [
-                  0,
-                  {
-                    $add: [
-                      { $ifNull: ["$stats.ratingSum", 0] },
-                      ratingSumDelta,
-                    ],
-                  },
-                ],
-              },
-            },
-          },
-          {
-            $set: {
-              "stats.averageRating": {
-                $cond: [
-                  { $gt: ["$stats.ratingCount", 0] },
-                  {
-                    $round: [
-                      {
-                        $divide: ["$stats.ratingSum", "$stats.ratingCount"],
-                      },
-                      1,
-                    ],
-                  },
-                  null,
-                ],
-              },
-            },
-          },
-          {
-            $set: {
-              "stats.popularity": this.buildPopularityExpression(),
-            },
-          },
+              null,
+            ),
+          }),
+          stages.set({
+            "stats.popularity": this.buildPopularityExpression(),
+          }),
         ],
         {
           returnDocument: "after",

--- a/apps/backend/src/modules/recipes/recipe.repository.ts
+++ b/apps/backend/src/modules/recipes/recipe.repository.ts
@@ -1,5 +1,4 @@
 import type { RecipeComputed, RecipeQuery, RequireKeys } from "@recipes/shared";
-import type { PipelineStage } from "mongoose";
 import type { CreateInput, UpdateInput } from "@/common/base.repository.js";
 import { BaseRepository } from "@/common/base.repository.js";
 import type {

--- a/apps/backend/src/modules/recipes/recipe.repository.ts
+++ b/apps/backend/src/modules/recipes/recipe.repository.ts
@@ -136,6 +136,17 @@ export class RecipeRepository extends BaseRepository<
     ];
   }
 
+  private buildPopularityExpression() {
+    return {
+      $add: [
+        { $multiply: [{ $ifNull: ["$stats.favoritesCount", 0] }, 3] },
+        { $multiply: [{ $ifNull: ["$stats.commentsCount", 0] }, 2] },
+        { $ifNull: ["$stats.ratingCount", 0] },
+        { $multiply: [{ $ifNull: ["$stats.averageRating", 0] }, 5] },
+      ],
+    };
+  }
+
   private async applyStatsDelta(
     recipeId: string,
     delta: RecipeStatsDelta,
@@ -217,16 +228,7 @@ export class RecipeRepository extends BaseRepository<
           },
           {
             $set: {
-              "stats.popularity": {
-                $add: [
-                  { $multiply: ["$stats.favoritesCount", 3] },
-                  { $multiply: ["$stats.commentsCount", 2] },
-                  "$stats.ratingCount",
-                  {
-                    $multiply: [{ $ifNull: ["$stats.averageRating", 0] }, 5],
-                  },
-                ],
-              },
+              "stats.popularity": this.buildPopularityExpression(),
             },
           },
         ],

--- a/apps/backend/src/modules/recipes/recipe.repository.ts
+++ b/apps/backend/src/modules/recipes/recipe.repository.ts
@@ -24,6 +24,13 @@ import type {
   RecipeDocumentPopulated,
 } from "./recipe.model.js";
 
+export type RecipeStatsDelta = {
+  favoritesCount?: number;
+  commentsCount?: number;
+  ratingCount?: number;
+  ratingSum?: number;
+};
+
 export type RecipeCreateInput = RequireKeys<
   CreateInput<RecipeDocument>,
   | "title"
@@ -74,11 +81,161 @@ export class RecipeRepository extends BaseRepository<
     return result[0];
   }
 
+  async applyFavoritesDelta(
+    recipeId: string,
+    delta: 1 | -1,
+  ): Promise<RecipeDocument | null> {
+    return this.applyStatsDelta(recipeId, {
+      favoritesCount: delta,
+    });
+  }
+
+  async applyCommentsDelta(
+    recipeId: string,
+    delta: 1 | -1,
+  ): Promise<RecipeDocument | null> {
+    return this.applyStatsDelta(recipeId, {
+      commentsCount: delta,
+    });
+  }
+
+  async applyRatingCreated(
+    recipeId: string,
+    value: number,
+  ): Promise<RecipeDocument | null> {
+    return this.applyStatsDelta(recipeId, {
+      ratingCount: 1,
+      ratingSum: value,
+    });
+  }
+
+  async applyRatingUpdated(
+    recipeId: string,
+    previousValue: number,
+    nextValue: number,
+  ): Promise<RecipeDocument | null> {
+    return this.applyStatsDelta(recipeId, {
+      ratingSum: nextValue - previousValue,
+    });
+  }
+
+  async applyRatingDeleted(
+    recipeId: string,
+    value: number,
+  ): Promise<RecipeDocument | null> {
+    return this.applyStatsDelta(recipeId, {
+      ratingCount: -1,
+      ratingSum: -value,
+    });
+  }
+
   protected override getDefaultPopulate() {
     return [
       { path: "author", select: "name email" },
       { path: "category", select: "name slug image" },
     ];
+  }
+
+  private async applyStatsDelta(
+    recipeId: string,
+    delta: RecipeStatsDelta,
+  ): Promise<RecipeDocument | null> {
+    const favoritesDelta = delta.favoritesCount ?? 0;
+    const commentsDelta = delta.commentsCount ?? 0;
+    const ratingCountDelta = delta.ratingCount ?? 0;
+    const ratingSumDelta = delta.ratingSum ?? 0;
+
+    return this.model
+      .findOneAndUpdate(
+        { _id: toObjectId(recipeId) },
+        [
+          {
+            $set: {
+              "stats.favoritesCount": {
+                $max: [
+                  0,
+                  {
+                    $add: [
+                      { $ifNull: ["$stats.favoritesCount", 0] },
+                      favoritesDelta,
+                    ],
+                  },
+                ],
+              },
+              "stats.commentsCount": {
+                $max: [
+                  0,
+                  {
+                    $add: [
+                      { $ifNull: ["$stats.commentsCount", 0] },
+                      commentsDelta,
+                    ],
+                  },
+                ],
+              },
+              "stats.ratingCount": {
+                $max: [
+                  0,
+                  {
+                    $add: [
+                      { $ifNull: ["$stats.ratingCount", 0] },
+                      ratingCountDelta,
+                    ],
+                  },
+                ],
+              },
+              "stats.ratingSum": {
+                $max: [
+                  0,
+                  {
+                    $add: [
+                      { $ifNull: ["$stats.ratingSum", 0] },
+                      ratingSumDelta,
+                    ],
+                  },
+                ],
+              },
+            },
+          },
+          {
+            $set: {
+              "stats.averageRating": {
+                $cond: [
+                  { $gt: ["$stats.ratingCount", 0] },
+                  {
+                    $round: [
+                      {
+                        $divide: ["$stats.ratingSum", "$stats.ratingCount"],
+                      },
+                      1,
+                    ],
+                  },
+                  null,
+                ],
+              },
+            },
+          },
+          {
+            $set: {
+              "stats.popularity": {
+                $add: [
+                  { $multiply: ["$stats.favoritesCount", 3] },
+                  { $multiply: ["$stats.commentsCount", 2] },
+                  "$stats.ratingCount",
+                  {
+                    $multiply: [{ $ifNull: ["$stats.averageRating", 0] }, 5],
+                  },
+                ],
+              },
+            },
+          },
+        ],
+        {
+          returnDocument: "after",
+          updatePipeline: true,
+        },
+      )
+      .lean();
   }
 }
 

--- a/apps/backend/src/modules/recipes/recipe.repository.ts
+++ b/apps/backend/src/modules/recipes/recipe.repository.ts
@@ -70,9 +70,39 @@ export class RecipeRepository extends BaseRepository<
   }: QueryMethodParams<RecipeQuery>): Promise<
     [Array<RecipeDocumentPopulated & RecipeComputed>, number]
   > {
-    const result = await this.aggregate<
-      PaginatedStageResult<RecipeDocumentPopulated & RecipeComputed>
-    >(buildSearchPipeline({ query, initiator }));
+    const { page, limit, sort, isFavorited, search, categoryId, difficulty } =
+      query;
+
+    const pipeline = [
+      stages.match<RecipeDocument>({
+        ...byVisibility(initiator),
+        ...(search && { $text: { $search: search } }),
+        ...(categoryId && { category: toObjectId(categoryId) }),
+        ...(difficulty && { difficulty }),
+      }),
+      stages.unset<RecipeDocument>("__v"),
+
+      withFavorited(initiator.id),
+      withUserRating(initiator.id),
+      stages.match<RecipeDocument>({
+        ...(isFavorited !== undefined && { isFavorited }),
+      }),
+
+      stages.paginated(
+        {
+          sort,
+          page,
+          limit,
+        },
+        ...withCategories(),
+        ...withAuthor(),
+      ),
+    ].flat();
+
+    const result =
+      await this.aggregate<
+        PaginatedStageResult<RecipeDocumentPopulated & RecipeComputed>
+      >(pipeline);
 
     return extractPaginatedResult(result);
   }
@@ -81,9 +111,21 @@ export class RecipeRepository extends BaseRepository<
     id: string,
     { initiator }: InitiatedMethodParams<OptionalInitiator>,
   ): Promise<(RecipeDocumentPopulated & RecipeComputed) | undefined> {
+    const pipeline = [
+      stages.match<RecipeDocument>({
+        _id: toObjectId(id),
+        ...byVisibility(initiator),
+      }),
+      { $unset: "__v" },
+      withCategories(),
+      withAuthor(),
+      withFavorited(initiator.id),
+      withUserRating(initiator.id),
+    ].flat();
+
     const result = await this.aggregate<
       RecipeDocumentPopulated & RecipeComputed
-    >(buildFindByIdPipeline(id, { initiator }));
+    >(pipeline);
 
     return result[0];
   }
@@ -218,55 +260,4 @@ export class RecipeRepository extends BaseRepository<
       )
       .lean();
   }
-}
-
-export function buildSearchPipeline({
-  query,
-  initiator,
-}: QueryMethodParams<RecipeQuery>) {
-  const { page, limit, sort, isFavorited, search, categoryId, difficulty } =
-    query;
-
-  return [
-    stages.match<RecipeDocument>({
-      ...byVisibility(initiator),
-      ...(search && { $text: { $search: search } }),
-      ...(categoryId && { category: toObjectId(categoryId) }),
-      ...(difficulty && { difficulty }),
-    }),
-    stages.unset<RecipeDocument>("__v"),
-
-    withFavorited(initiator.id),
-    withUserRating(initiator.id),
-    stages.match<RecipeDocument>({
-      ...(isFavorited !== undefined && { isFavorited }),
-    }),
-
-    stages.paginated(
-      {
-        sort,
-        page,
-        limit,
-      },
-      ...withCategories(),
-      ...withAuthor(),
-    ),
-  ].flat();
-}
-
-export function buildFindByIdPipeline(
-  id: string,
-  { initiator }: InitiatedMethodParams<OptionalInitiator>,
-): PipelineStage[] {
-  return [
-    stages.match<RecipeDocument>({
-      _id: toObjectId(id),
-      ...byVisibility(initiator),
-    }),
-    { $unset: "__v" },
-    withCategories(),
-    withAuthor(),
-    withFavorited(initiator.id),
-    withUserRating(initiator.id),
-  ].flat();
 }

--- a/apps/backend/src/modules/recipes/recipe.repository.ts
+++ b/apps/backend/src/modules/recipes/recipe.repository.ts
@@ -24,6 +24,13 @@ import type {
   RecipeDocumentPopulated,
 } from "./recipe.model.js";
 
+export const RECIPE_POPULARITY_WEIGHTS = {
+  favorites: 3,
+  comments: 2,
+  ratings: 1,
+  averageRating: 5,
+} as const;
+
 export type RecipeStatsDelta = {
   favoritesCount?: number;
   commentsCount?: number;
@@ -139,10 +146,30 @@ export class RecipeRepository extends BaseRepository<
   private buildPopularityExpression() {
     return {
       $add: [
-        { $multiply: [{ $ifNull: ["$stats.favoritesCount", 0] }, 3] },
-        { $multiply: [{ $ifNull: ["$stats.commentsCount", 0] }, 2] },
-        { $ifNull: ["$stats.ratingCount", 0] },
-        { $multiply: [{ $ifNull: ["$stats.averageRating", 0] }, 5] },
+        {
+          $multiply: [
+            { $ifNull: ["$stats.favoritesCount", 0] },
+            RECIPE_POPULARITY_WEIGHTS.favorites,
+          ],
+        },
+        {
+          $multiply: [
+            { $ifNull: ["$stats.commentsCount", 0] },
+            RECIPE_POPULARITY_WEIGHTS.comments,
+          ],
+        },
+        {
+          $multiply: [
+            { $ifNull: ["$stats.ratingCount", 0] },
+            RECIPE_POPULARITY_WEIGHTS.ratings,
+          ],
+        },
+        {
+          $multiply: [
+            { $ifNull: ["$stats.averageRating", 0] },
+            RECIPE_POPULARITY_WEIGHTS.averageRating,
+          ],
+        },
       ],
     };
   }

--- a/apps/backend/src/modules/recipes/recipe.routes.test.ts
+++ b/apps/backend/src/modules/recipes/recipe.routes.test.ts
@@ -56,10 +56,16 @@ describe("recipeRoutes", () => {
       url: "https://example.com/image.jpg",
       alt: "Test Recipe",
     },
+    stats: {
+      favoritesCount: 0,
+      commentsCount: 0,
+      ratingCount: 0,
+      ratingSum: 0,
+      averageRating: null,
+      popularity: 0,
+    },
     isFavorited: false,
     userRating: null,
-    averageRating: null,
-    ratingCount: 0,
   };
 
   const paginatedResult = {

--- a/apps/backend/src/modules/recipes/recipe.service.test.ts
+++ b/apps/backend/src/modules/recipes/recipe.service.test.ts
@@ -357,6 +357,42 @@ describe("recipeService", () => {
         }),
       ).rejects.toThrow(NotFoundError);
     });
+
+    it("should return recipe with default stats when created", async () => {
+      mockCategoryRepository.exists.mockResolvedValue(true);
+      mockUserRepository.exists.mockResolvedValue(true);
+
+      const authorId = createObjectId();
+      const categoryId = createObjectId();
+      const populated = populateRecipeDoc(
+        createRecipeDoc({ title: "New Recipe" }),
+        {
+          author: { _id: authorId, name: "Chef", email: "chef@test.com" },
+          category: {
+            _id: categoryId,
+            name: "Italian",
+            slug: "italian",
+            image: { url: "https://example.com/italian.jpg" },
+          },
+        },
+      );
+
+      mockRecipeRepository.create.mockResolvedValue(populated);
+
+      const result = await service.create({
+        data: { ...createData, category: categoryId.toString() },
+        initiator: initiator(authorId.toString()),
+      });
+
+      expect(result.stats).toEqual({
+        favoritesCount: 0,
+        commentsCount: 0,
+        ratingCount: 0,
+        ratingSum: 0,
+        averageRating: null,
+        popularity: 0,
+      });
+    });
   });
 
   describe("update", () => {
@@ -453,6 +489,42 @@ describe("recipeService", () => {
           initiator: initiator(createObjectId().toString()),
         }),
       ).rejects.toThrow(ForbiddenError);
+    });
+
+    it("should preserve existing stats when updating only title", async () => {
+      const authorId = createObjectId();
+      const recipe = createMockRecipe(authorId);
+      mockRecipeRepository.findDocumentById.mockResolvedValue(recipe);
+      mockFavoriteRepository.exists.mockResolvedValue(false);
+      mockRecipeRepository.save.mockResolvedValue(
+        populateRecipeDoc(createRecipeDoc({ author: authorId }), {
+          title: "Updated",
+          stats: {
+            favoritesCount: 5,
+            commentsCount: 3,
+            ratingCount: 10,
+            ratingSum: 45,
+            averageRating: 4.5,
+            popularity: 42,
+          },
+        }),
+      );
+
+      const id = createObjectId().toString();
+      const result = await service.update(id, {
+        data: { title: "Updated" },
+        initiator: initiator(authorId.toString()),
+      });
+
+      expect(result.title).toBe("Updated");
+      expect(result.stats).toEqual({
+        favoritesCount: 5,
+        commentsCount: 3,
+        ratingCount: 10,
+        ratingSum: 45,
+        averageRating: 4.5,
+        popularity: 42,
+      });
     });
   });
 

--- a/apps/backend/src/modules/recipes/recipe.service.test.ts
+++ b/apps/backend/src/modules/recipes/recipe.service.test.ts
@@ -135,8 +135,14 @@ describe("recipeService", () => {
     it("should return rating data from aggregation", async () => {
       const populated = populateRecipeDoc(createRecipeDoc(), {
         userRating: 4,
-        averageRating: 4.2,
-        ratingCount: 15,
+        stats: {
+          favoritesCount: 0,
+          commentsCount: 0,
+          ratingCount: 15,
+          ratingSum: 63,
+          averageRating: 4.2,
+          popularity: 0,
+        },
       });
       mockRecipeRepository.aggregateSearch.mockResolvedValue([[populated], 1]);
 
@@ -151,8 +157,8 @@ describe("recipeService", () => {
       });
 
       expect(result.items[0]?.userRating).toBe(4);
-      expect(result.items[0]?.averageRating).toBe(4.2);
-      expect(result.items[0]?.ratingCount).toBe(15);
+      expect(result.items[0]?.stats.averageRating).toBe(4.2);
+      expect(result.items[0]?.stats.ratingCount).toBe(15);
     });
 
     it("should return null ratings when recipe has no ratings", async () => {
@@ -170,8 +176,8 @@ describe("recipeService", () => {
       });
 
       expect(result.items[0]?.userRating).toBeNull();
-      expect(result.items[0]?.averageRating).toBeNull();
-      expect(result.items[0]?.ratingCount).toBe(0);
+      expect(result.items[0]?.stats.averageRating).toBeNull();
+      expect(result.items[0]?.stats.ratingCount).toBe(0);
     });
   });
 
@@ -233,8 +239,14 @@ describe("recipeService", () => {
     it("should return rating data from aggregation", async () => {
       const populated = populateRecipeDoc(createRecipeDoc(), {
         userRating: 5,
-        averageRating: 3.8,
-        ratingCount: 42,
+        stats: {
+          favoritesCount: 0,
+          commentsCount: 0,
+          ratingCount: 42,
+          ratingSum: 160,
+          averageRating: 3.8,
+          popularity: 0,
+        },
       });
       mockRecipeRepository.aggregateById.mockResolvedValue(populated);
 
@@ -244,8 +256,8 @@ describe("recipeService", () => {
       });
 
       expect(result.userRating).toBe(5);
-      expect(result.averageRating).toBe(3.8);
-      expect(result.ratingCount).toBe(42);
+      expect(result.stats.averageRating).toBe(3.8);
+      expect(result.stats.ratingCount).toBe(42);
     });
   });
 
@@ -295,8 +307,8 @@ describe("recipeService", () => {
       });
       expect(result.title).toBe("New Recipe");
       expect(result.userRating).toBeNull();
-      expect(result.averageRating).toBeNull();
-      expect(result.ratingCount).toBe(0);
+      expect(result.stats.averageRating).toBeNull();
+      expect(result.stats.ratingCount).toBe(0);
       expect(mockCache.deletePattern).toHaveBeenCalledWith(
         recipeCache.keys.listPattern(),
       );
@@ -373,8 +385,8 @@ describe("recipeService", () => {
       });
       expect(result.title).toBe("Updated");
       expect(result.userRating).toBeNull();
-      expect(result.averageRating).toBeNull();
-      expect(result.ratingCount).toBe(0);
+      expect(result.stats.averageRating).toBeNull();
+      expect(result.stats.ratingCount).toBe(0);
       expect(mockCache.delete).toHaveBeenCalledWith(recipeCache.keys.byId(id));
       expect(mockCache.deletePattern).toHaveBeenCalledWith(
         recipeCache.keys.listPattern(),

--- a/apps/backend/src/seed/index.ts
+++ b/apps/backend/src/seed/index.ts
@@ -10,6 +10,7 @@ import { CommentModel } from "@/modules/comments/comment.model.js";
 import { FavoriteModel } from "@/modules/favorites/favorite.model.js";
 import { RecipeRatingModel } from "@/modules/recipe-ratings/recipe-rating.model.js";
 import { RecipeModel } from "@/modules/recipes/recipe.model.js";
+import { rebuildRecipeStats } from "@/modules/recipes/recipe-stats.service.js";
 import { ReviewModel } from "@/modules/reviews/review.model.js";
 import { UserModel } from "@/modules/users/user.model.js";
 import {
@@ -232,6 +233,12 @@ async function seed(): Promise<void> {
 async function main(): Promise<void> {
   try {
     await seed();
+    await rebuildRecipeStats(
+      RecipeModel,
+      FavoriteModel,
+      CommentModel,
+      RecipeRatingModel,
+    );
   } catch (err) {
     logger.error(err, "Seed failed");
     process.exitCode = 1;

--- a/packages/shared/src/recipes/recipe.schema.ts
+++ b/packages/shared/src/recipes/recipe.schema.ts
@@ -28,6 +28,15 @@ export const createRecipeSchema = z.object({
 
 export const updateRecipeSchema = createRecipeSchema.partial();
 
+export const recipeStatsSchema = z.object({
+  favoritesCount: z.number().int().nonnegative(),
+  commentsCount: z.number().int().nonnegative(),
+  ratingCount: z.number().int().nonnegative(),
+  ratingSum: z.number().int().nonnegative(),
+  averageRating: z.number().nullable(),
+  popularity: z.number().int().nonnegative(),
+});
+
 export const recipeSchema = createRecipeSchema
   // add persistence fields
   .extend({
@@ -38,6 +47,7 @@ export const recipeSchema = createRecipeSchema
   // add new fields
   .extend({
     author: userSummarySchema,
+    stats: recipeStatsSchema,
   })
   // rewrite fields
   .extend({
@@ -47,8 +57,8 @@ export const recipeSchema = createRecipeSchema
 export const recipeComputedSchema = z.object({
   isFavorited: z.boolean(),
   userRating: z.number().int().min(1).max(5).nullable(),
-  averageRating: z.number().nullable(),
-  ratingCount: z.number().int().nonnegative(),
+  // averageRating: z.number().nullable(),
+  // ratingCount: z.number().int().nonnegative(),
 });
 
 export const recipeSummarySchema = recipeSchema.pick({
@@ -58,7 +68,9 @@ export const recipeSummarySchema = recipeSchema.pick({
 
 export const recipeQuerySchema = z
   .object({
-    sort: createSortSchema(["createdAt", "cookingTime"]).default("-createdAt"),
+    sort: createSortSchema(["createdAt", "cookingTime", "popularity"]).default(
+      "-createdAt",
+    ),
     categoryId: z.string().optional(),
     difficulty: difficultySchema.optional(),
     isFavorited: z.stringbool().optional(),

--- a/packages/shared/src/recipes/recipe.schema.ts
+++ b/packages/shared/src/recipes/recipe.schema.ts
@@ -34,7 +34,7 @@ export const recipeStatsSchema = z.object({
   ratingCount: z.number().int().nonnegative(),
   ratingSum: z.number().int().nonnegative(),
   averageRating: z.number().nullable(),
-  popularity: z.number().int().nonnegative(),
+  popularity: z.number().nonnegative(),
 });
 
 export const recipeSchema = createRecipeSchema

--- a/packages/shared/src/recipes/recipe.types.ts
+++ b/packages/shared/src/recipes/recipe.types.ts
@@ -7,6 +7,7 @@ import type {
   recipeComputedSchema,
   recipeQuerySchema,
   recipeSchema,
+  recipeStatsSchema,
   recipeSummarySchema,
   secondsSchema,
   updateRecipeSchema,
@@ -19,6 +20,7 @@ export type Difficulty = z.infer<typeof difficultySchema>;
 export type CreateRecipeBody = z.infer<typeof createRecipeSchema>;
 export type UpdateRecipeBody = z.infer<typeof updateRecipeSchema>;
 export type Recipe = z.infer<typeof recipeSchema>;
+export type RecipeStats = z.infer<typeof recipeStatsSchema>;
 export type RecipeSummary = z.infer<typeof recipeSummarySchema>;
 export type RecipeComputed = z.infer<typeof recipeComputedSchema>;
 


### PR DESCRIPTION
## Related Issues

<!-- Link related issues: Closes #123, Refs #456 -->

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [x] Tests
- [ ] Other

## Description

This PR introduces **recipe popularity statistics** to support the "Featured Recipes" section on the frontend.

### Key Changes

1. **Recipe Stats Model** — Added `stats` subdocument to `RecipeDocument` with fields:
   - `favoritesCount`, `commentsCount`, `ratingCount`, `ratingSum`
   - `averageRating` (computed from ratings)
   - `popularity` (computed composite score)

2. **Automatic Stats Synchronization** — Event-driven delta updates:
   - Favorites: `+1/-1` on favorite/unfavorite
   - Comments: `+1/-1` on comment add/delete
   - Ratings: create/update/delete with proper sum/average recalculation
   - All updates use atomic MongoDB aggregation pipelines (`$max` for zero floor protection)

3. **Popularity Sorting** — Added `sort=popularity` / `sort=-popularity` to recipe list queries
   - Formula: `favorites*3 + comments*2 + ratings*1 + avgRating*5`
   - Weights defined as `RECIPE_POPULARITY_WEIGHTS` constant

4. **Full Rebuild** — `rebuildRecipeStats()` utility for seeding/background tasks using `bulkWrite`

5. **Tests** — Comprehensive coverage:
   - Model unit tests (default stats, custom stats)
   - Mapper unit tests (missing/partial stats fallback)
   - Service unit tests (create/update preserve stats)
   - Repository integration tests (all delta methods, popularity recalculation)
   - Stats service unit tests (`computePopularity`, `computeAverageRating`, `rebuildRecipeStats`)
   - Sorting integration tests (asc/desc by popularity)

## Screenshots

<!-- If applicable, add screenshots or recordings of the changes -->

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Added/updated tests for new functionality
- [ ] Updated documentation (if needed)