### PR TITLE
feat: add cache status headers and refactor to getOrSet pattern

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -33,6 +33,7 @@
     "bcryptjs": "^3.0.3",
     "dotenv": "^16.6.1",
     "fastify": "^5.8.4",
+    "fastify-plugin": "^5.1.0",
     "fastify-type-provider-zod": "^6.1.0",
     "ioredis": "^5.10.1",
     "jsonwebtoken": "^9.0.3",

--- a/apps/backend/src/__tests__/build-test-app.ts
+++ b/apps/backend/src/__tests__/build-test-app.ts
@@ -3,14 +3,16 @@ import {
   serializerCompiler,
   validatorCompiler,
 } from "fastify-type-provider-zod";
+import cacheHeadersPlugin from "@/common/cache/cache-headers.plugin.js";
 import { errorHandler } from "@/common/middleware/errorHandler.js";
 import type { JwtPayload } from "@/common/utils/jwt.js";
 
-export function createTestApp() {
+export async function createTestApp() {
   const app = Fastify({ logger: false });
   app.setValidatorCompiler(validatorCompiler);
   app.setSerializerCompiler(serializerCompiler);
   app.setErrorHandler(errorHandler);
+  await app.register(cacheHeadersPlugin);
   return app;
 }
 

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -9,6 +9,7 @@ import {
   serializerCompiler,
   validatorCompiler,
 } from "fastify-type-provider-zod";
+import cacheHeadersPlugin from "@/common/cache/cache-headers.plugin.js";
 import { createCacheService } from "@/common/cache/create-cache.service.js";
 import { createEventBus } from "@/common/events.js";
 import type { Logger } from "@/common/logger.js";
@@ -60,6 +61,9 @@ export async function buildApp(log: Logger) {
   // Swagger
   app.register(fastifySwagger, swaggerOptions);
   app.register(fastifySwaggerUi, swaggerUiOptions);
+
+  // Cache headers helpers
+  app.register(cacheHeadersPlugin);
 
   // Health check
   app.get("/health", async () => ({ status: "ok" }));

--- a/apps/backend/src/common/cache/cache-headers.plugin.ts
+++ b/apps/backend/src/common/cache/cache-headers.plugin.ts
@@ -1,0 +1,36 @@
+import type { FastifyPluginAsync } from "fastify";
+import fp from "fastify-plugin";
+import type { CacheMeta } from "./cache.service.js";
+
+declare module "fastify" {
+  interface FastifyReply {
+    applyCacheHeaders(cache: CacheMeta): FastifyReply;
+  }
+}
+
+const cacheHeaders: FastifyPluginAsync = async (fastify) => {
+  fastify.decorateReply("applyCacheHeaders", function (cache: CacheMeta) {
+    this.header("X-Cache", cache.status.toUpperCase());
+
+    if (cache.status === "bypass") {
+      this.headers({
+        "X-Cache-Bypass": cache.reason,
+        "Cache-Control": "no-store",
+      });
+      return this;
+    }
+
+    this.headers({
+      "X-Cache-Key": cache.key,
+      "X-Cache-TTL": String(cache.ttl),
+      "Cache-Control": "public, max-age=0, must-revalidate",
+    });
+
+    return this;
+  });
+};
+
+export default fp(cacheHeaders, {
+  fastify: "5.x",
+  name: "cache-headers",
+});

--- a/apps/backend/src/common/cache/cache.service.ts
+++ b/apps/backend/src/common/cache/cache.service.ts
@@ -17,7 +17,7 @@ export interface CacheService {
    * Sets the value of the entry with the given key.
    *
    * @param key - The key of the entry to set.
-   * @param ttlSeconds - The time-to-live (TTL) in seconds for the entry. If not provided, the entry will not expire. If the cache service has a default TTL value set, that value will be used. If both parameters are specified, this parameter will be used.
+   * @param ttlSeconds - The time-to-live (TTL) in seconds for the entry. If not provided, the entry will not expire.
    */
   set<T extends {}>(key: string, value: T, ttlSeconds?: number): Promise<void>;
 

--- a/apps/backend/src/common/cache/cache.service.ts
+++ b/apps/backend/src/common/cache/cache.service.ts
@@ -33,7 +33,7 @@ export interface CacheService {
     key: string,
     factory: () => Promise<T>,
     ttlSeconds?: number,
-  ): Promise<CacheGetResult<T>>;
+  ): Promise<CachedGetResult<T>>;
 
   /**
    * Deletes the entry with the given key.
@@ -58,22 +58,33 @@ export interface CacheService {
   close(): Promise<void>;
 }
 
-export type CacheGetResult<T> = {
-  value: T;
-  hit: boolean;
+export type CacheHitMeta = {
+  status: "hit";
   key: string;
   ttl: number;
 };
+export type CacheMissMeta = {
+  status: "miss";
+  key: string;
+  ttl: number;
+};
+export type CacheBypassReason =
+  | "authenticated"
+  | "personalized"
+  | "disabled"
+  | "not-applicable";
+export type CacheBypassMeta = {
+  status: "bypass";
+  reason: CacheBypassReason;
+};
+export type CacheMeta = CacheHitMeta | CacheMissMeta | CacheBypassMeta;
 
-export function isCacheGetResult<T>(
-  value: unknown,
-): value is CacheGetResult<T> {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "value" in value &&
-    "hit" in value &&
-    "key" in value &&
-    "ttl" in value
-  );
-}
+export type CachedResult<T> = {
+  value: T;
+  cache: CacheMeta;
+};
+
+export type CachedGetResult<T> = {
+  value: T;
+  cache: Exclude<CacheMeta, CacheBypassMeta>;
+};

--- a/apps/backend/src/common/cache/cache.service.ts
+++ b/apps/backend/src/common/cache/cache.service.ts
@@ -22,6 +22,20 @@ export interface CacheService {
   set<T extends {}>(key: string, value: T, ttlSeconds?: number): Promise<void>;
 
   /**
+   * Gets the value of the entry with the given key, or sets it using the provided factory function if it doesn't exist.
+   *
+   * @param key - The key of the entry to get or set.
+   * @param factory - The function to use to set the value if it doesn't exist.
+   * @param ttlSeconds - The time-to-live (TTL) in seconds for the entry. If not provided, the entry will not expire.
+   * @returns The value of the entry with the given key, or the result of the factory function.
+   */
+  getOrSet<T extends {}>(
+    key: string,
+    factory: () => Promise<T>,
+    ttlSeconds?: number,
+  ): Promise<CacheGetResult<T>>;
+
+  /**
    * Deletes the entry with the given key.
    */
   delete(key: string): Promise<void>;
@@ -43,3 +57,8 @@ export interface CacheService {
    */
   close(): Promise<void>;
 }
+
+export type CacheGetResult<T> = {
+  value: T;
+  hit: boolean;
+};

--- a/apps/backend/src/common/cache/cache.service.ts
+++ b/apps/backend/src/common/cache/cache.service.ts
@@ -61,4 +61,19 @@ export interface CacheService {
 export type CacheGetResult<T> = {
   value: T;
   hit: boolean;
+  key: string;
+  ttl: number;
 };
+
+export function isCacheGetResult<T>(
+  value: unknown,
+): value is CacheGetResult<T> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "value" in value &&
+    "hit" in value &&
+    "key" in value &&
+    "ttl" in value
+  );
+}

--- a/apps/backend/src/common/cache/memory-cache.service.ts
+++ b/apps/backend/src/common/cache/memory-cache.service.ts
@@ -22,15 +22,11 @@ export function createMemoryCache(
   });
 
   return {
-    async get<T extends {}>(key: string): Promise<T | undefined> {
+    async get<T extends {}>(key: string) {
       return cache.get(key) as T | undefined;
     },
 
-    async set<T extends {}>(
-      key: string,
-      value: T,
-      ttlSeconds?: number,
-    ): Promise<void> {
+    async set<T extends {}>(key: string, value: T, ttlSeconds?: number) {
       if (ttlSeconds) {
         cache.set(key, value, { ttl: ttlSeconds * 1000 });
         return;
@@ -39,11 +35,27 @@ export function createMemoryCache(
       cache.set(key, value);
     },
 
-    async delete(key: string): Promise<void> {
+    async getOrSet<T extends {}>(
+      key: string,
+      factory: () => Promise<T>,
+      ttlSeconds?: number,
+    ) {
+      const cached = await this.get<T>(key);
+      if (cached !== undefined) {
+        return { value: cached, hit: true };
+      }
+
+      const value = await factory();
+
+      await this.set(key, value, ttlSeconds);
+      return { value, hit: false };
+    },
+
+    async delete(key: string) {
       cache.delete(key);
     },
 
-    async deletePattern(pattern: string): Promise<void> {
+    async deletePattern(pattern: string) {
       const regex = new RegExp(
         `^${pattern.replace(/\*/g, ".*").replace(/\?/g, ".")}$`,
       );
@@ -54,11 +66,11 @@ export function createMemoryCache(
       }
     },
 
-    async flush(): Promise<void> {
+    async flush() {
       cache.clear();
     },
 
-    async close(): Promise<void> {
+    async close() {
       await this.flush();
       // Nothing to close for in-memory cache
     },

--- a/apps/backend/src/common/cache/memory-cache.service.ts
+++ b/apps/backend/src/common/cache/memory-cache.service.ts
@@ -42,13 +42,27 @@ export function createMemoryCache(
     ) {
       const cached = await this.get<T>(key);
       if (cached !== undefined) {
-        return { value: cached, hit: true, key, ttl: ttlSeconds ?? 0 };
+        return {
+          value: cached,
+          cache: {
+            status: "hit",
+            key,
+            ttl: ttlSeconds ?? 0,
+          },
+        };
       }
 
       const value = await factory();
 
       await this.set(key, value, ttlSeconds);
-      return { value, hit: false, key, ttl: ttlSeconds ?? 0 };
+      return {
+        value,
+        cache: {
+          status: "miss",
+          key,
+          ttl: ttlSeconds ?? 0,
+        },
+      };
     },
 
     async delete(key: string) {

--- a/apps/backend/src/common/cache/memory-cache.service.ts
+++ b/apps/backend/src/common/cache/memory-cache.service.ts
@@ -42,13 +42,13 @@ export function createMemoryCache(
     ) {
       const cached = await this.get<T>(key);
       if (cached !== undefined) {
-        return { value: cached, hit: true };
+        return { value: cached, hit: true, key, ttl: ttlSeconds ?? 0 };
       }
 
       const value = await factory();
 
       await this.set(key, value, ttlSeconds);
-      return { value, hit: false };
+      return { value, hit: false, key, ttl: ttlSeconds ?? 0 };
     },
 
     async delete(key: string) {

--- a/apps/backend/src/common/cache/memory-cache.service.ts
+++ b/apps/backend/src/common/cache/memory-cache.service.ts
@@ -3,24 +3,21 @@ import type { CacheService } from "./cache.service.js";
 
 export interface MemoryCacheOptions {
   maxSize?: number;
-  defaultTTL?: number;
 }
 
 /**
  * Creates a new memory cache service.
  *
  * @param options.maxSize - The maximum number of items in the cache. Defaults to 1000.
- * @param options.defaultTTL - The default TTL for cache items in seconds. If not set, items do not expire.
  * @returns A new memory cache service.
  */
 export function createMemoryCache(
   options: MemoryCacheOptions = {},
 ): CacheService {
-  const { maxSize = 1000, defaultTTL } = options;
+  const { maxSize = 1000 } = options;
 
   const cache = new LRUCache<string, NonNullable<unknown>>({
     max: maxSize,
-    ttl: (defaultTTL ?? 0) * 1000,
     updateAgeOnGet: true,
   });
 
@@ -36,9 +33,6 @@ export function createMemoryCache(
     ): Promise<void> {
       if (ttlSeconds) {
         cache.set(key, value, { ttl: ttlSeconds * 1000 });
-        return;
-      } else if (defaultTTL) {
-        cache.set(key, value, { ttl: defaultTTL * 1000 });
         return;
       }
 

--- a/apps/backend/src/common/cache/namespaced-cache.ts
+++ b/apps/backend/src/common/cache/namespaced-cache.ts
@@ -5,23 +5,27 @@ export function createNamespacedCache(
   cache: CacheService,
 ): CacheService {
   return {
-    async get<T extends {}>(key: string): Promise<T | undefined> {
+    async get<T extends {}>(key: string) {
       return cache.get<T>(`${prefix}:${key}`);
     },
 
-    async set<T extends {}>(
-      key: string,
-      value: T,
-      ttlSeconds?: number,
-    ): Promise<void> {
+    async set<T extends {}>(key: string, value: T, ttlSeconds?: number) {
       return cache.set(`${prefix}:${key}`, value, ttlSeconds);
     },
 
-    async delete(key: string): Promise<void> {
+    async getOrSet<T extends {}>(
+      key: string,
+      factory: () => Promise<T>,
+      ttlSeconds?: number,
+    ) {
+      return cache.getOrSet(`${prefix}:${key}`, factory, ttlSeconds);
+    },
+
+    async delete(key: string) {
       return cache.delete(`${prefix}:${key}`);
     },
 
-    async deletePattern(pattern: string): Promise<void> {
+    async deletePattern(pattern: string) {
       return cache.deletePattern(`${prefix}:${pattern}`);
     },
 

--- a/apps/backend/src/common/cache/redis-cache.service.ts
+++ b/apps/backend/src/common/cache/redis-cache.service.ts
@@ -57,13 +57,27 @@ export function createRedisCache(
     ) {
       const cached = await this.get<T>(key);
       if (cached !== undefined) {
-        return { value: cached, hit: true, key, ttl: ttlSeconds ?? 0 };
+        return {
+          value: cached,
+          cache: {
+            status: "hit",
+            key,
+            ttl: ttlSeconds ?? 0,
+          },
+        };
       }
 
       const value = await factory();
 
       await this.set(key, value, ttlSeconds);
-      return { value, hit: false, key, ttl: ttlSeconds ?? 0 };
+      return {
+        value,
+        cache: {
+          status: "miss",
+          key,
+          ttl: ttlSeconds ?? 0,
+        },
+      };
     },
 
     async delete(key: string) {

--- a/apps/backend/src/common/cache/redis-cache.service.ts
+++ b/apps/backend/src/common/cache/redis-cache.service.ts
@@ -57,13 +57,13 @@ export function createRedisCache(
     ) {
       const cached = await this.get<T>(key);
       if (cached !== undefined) {
-        return { value: cached, hit: true };
+        return { value: cached, hit: true, key, ttl: ttlSeconds ?? 0 };
       }
 
       const value = await factory();
 
       await this.set(key, value, ttlSeconds);
-      return { value, hit: false };
+      return { value, hit: false, key, ttl: ttlSeconds ?? 0 };
     },
 
     async delete(key: string) {

--- a/apps/backend/src/common/cache/redis-cache.service.ts
+++ b/apps/backend/src/common/cache/redis-cache.service.ts
@@ -35,17 +35,13 @@ export function createRedisCache(
   }
 
   return {
-    async get<T extends {}>(key: string): Promise<T | undefined> {
+    async get<T extends {}>(key: string) {
       const raw = await redis.get(prefixed(key));
       if (raw === null) return undefined;
       return JSON.parse(raw) as T;
     },
 
-    async set<T extends {}>(
-      key: string,
-      value: T,
-      ttlSeconds?: number,
-    ): Promise<void> {
+    async set<T extends {}>(key: string, value: T, ttlSeconds?: number) {
       if (ttlSeconds) {
         await redis.setex(prefixed(key), ttlSeconds, JSON.stringify(value));
         return;
@@ -54,11 +50,27 @@ export function createRedisCache(
       await redis.set(prefixed(key), JSON.stringify(value));
     },
 
-    async delete(key: string): Promise<void> {
+    async getOrSet<T extends {}>(
+      key: string,
+      factory: () => Promise<T>,
+      ttlSeconds?: number,
+    ) {
+      const cached = await this.get<T>(key);
+      if (cached !== undefined) {
+        return { value: cached, hit: true };
+      }
+
+      const value = await factory();
+
+      await this.set(key, value, ttlSeconds);
+      return { value, hit: false };
+    },
+
+    async delete(key: string) {
       await redis.del(prefixed(key));
     },
 
-    async deletePattern(pattern: string): Promise<void> {
+    async deletePattern(pattern: string) {
       const fullPattern = prefixed(pattern);
       let cursor = "0";
 

--- a/apps/backend/src/common/cache/redis-cache.service.ts
+++ b/apps/backend/src/common/cache/redis-cache.service.ts
@@ -4,7 +4,6 @@ import type { CacheService } from "./cache.service.js";
 
 export interface RedisCacheOptions {
   url: string;
-  defaultTTL?: number;
   keyPrefix?: string;
 }
 
@@ -12,7 +11,7 @@ export function createRedisCache(
   options: RedisCacheOptions,
   log: Logger,
 ): CacheService {
-  const { url, defaultTTL, keyPrefix = "" } = options;
+  const { url, keyPrefix = "" } = options;
 
   const redis = new Redis(url, {
     maxRetriesPerRequest: 3,
@@ -49,9 +48,6 @@ export function createRedisCache(
     ): Promise<void> {
       if (ttlSeconds) {
         await redis.setex(prefixed(key), ttlSeconds, JSON.stringify(value));
-        return;
-      } else if (defaultTTL) {
-        await redis.setex(prefixed(key), defaultTTL, JSON.stringify(value));
         return;
       }
 

--- a/apps/backend/src/modules/auth/auth.routes.test.ts
+++ b/apps/backend/src/modules/auth/auth.routes.test.ts
@@ -20,7 +20,7 @@ describe("authRoutes", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
-    app = createTestApp();
+    app = await createTestApp();
     await app.register(authRoutes, {
       service: mockAuthService,
       prefix: "/api/auth",

--- a/apps/backend/src/modules/categories/category.routes.test.ts
+++ b/apps/backend/src/modules/categories/category.routes.test.ts
@@ -48,7 +48,7 @@ describe("categoryRoutes", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
-    app = createTestApp();
+    app = await createTestApp();
     await app.register(categoryRoutes, {
       service: mockCategoryService,
       prefix: "/api/categories",
@@ -69,9 +69,11 @@ describe("categoryRoutes", () => {
             hasPrev: false,
           },
         },
-        hit: false,
-        key: "categories:list:sort=name:page=1:limit=10",
-        ttl: 3600,
+        cache: {
+          status: "miss",
+          key: "categories:list:sort=name:page=1:limit=10",
+          ttl: 3600,
+        },
       });
 
       const response = await app.inject({

--- a/apps/backend/src/modules/categories/category.routes.test.ts
+++ b/apps/backend/src/modules/categories/category.routes.test.ts
@@ -58,15 +58,20 @@ describe("categoryRoutes", () => {
   describe("GET /api/categories", () => {
     it("should return paginated categories", async () => {
       mockCategoryService.findAll.mockResolvedValue({
-        items: [{ ...validCategory, recipeCount: 5 }],
-        pagination: {
-          page: 1,
-          limit: 10,
-          total: 1,
-          totalPages: 1,
-          hasNext: false,
-          hasPrev: false,
+        value: {
+          items: [{ ...validCategory, recipeCount: 5 }],
+          pagination: {
+            page: 1,
+            limit: 10,
+            total: 1,
+            totalPages: 1,
+            hasNext: false,
+            hasPrev: false,
+          },
         },
+        hit: false,
+        key: "categories:list:sort=name:page=1:limit=10",
+        ttl: 3600,
       });
 
       const response = await app.inject({
@@ -78,6 +83,8 @@ describe("categoryRoutes", () => {
       const body = JSON.parse(response.payload);
       expect(body.items).toHaveLength(1);
       expect(body.items[0].name).toBe("Desserts");
+      expect(response.headers["x-cache"]).toBe("MISS");
+      expect(response.headers["x-cache-ttl"]).toBe("3600");
     });
 
     it("should return 400 for invalid query", async () => {

--- a/apps/backend/src/modules/categories/category.routes.ts
+++ b/apps/backend/src/modules/categories/category.routes.ts
@@ -45,13 +45,7 @@ export const categoryRoutes: FastifyPluginAsync<CategoryModuleOptions> = async (
           initiator: { id: request.user?.userId, role: request.user?.role },
         });
 
-        reply.headers({
-          "Cache-Control": "public, max-age=0, must-revalidate",
-          "X-Cache": cache.status.toUpperCase(),
-          "X-Cache-Key": cache.key,
-          "X-Cache-TTL": cache.ttl,
-        });
-
+        reply.applyCacheHeaders(cache);
         return reply.send(value);
       },
     )

--- a/apps/backend/src/modules/categories/category.routes.ts
+++ b/apps/backend/src/modules/categories/category.routes.ts
@@ -44,7 +44,15 @@ export const categoryRoutes: FastifyPluginAsync<CategoryModuleOptions> = async (
           query: request.query,
           initiator: { id: request.user?.userId, role: request.user?.role },
         });
-        return reply.send(result);
+
+        reply.headers({
+          "Cache-Control": "public, max-age=0, must-revalidate",
+          "X-Cache": result.hit ? "HIT" : "MISS",
+          "X-Cache-Key": result.key,
+          "X-Cache-TTL": result.ttl,
+        });
+
+        return reply.send(result.value);
       },
     )
     .post(

--- a/apps/backend/src/modules/categories/category.routes.ts
+++ b/apps/backend/src/modules/categories/category.routes.ts
@@ -40,19 +40,19 @@ export const categoryRoutes: FastifyPluginAsync<CategoryModuleOptions> = async (
         },
       },
       async (request, reply) => {
-        const result = await service.findAll({
+        const { value, cache } = await service.findAll({
           query: request.query,
           initiator: { id: request.user?.userId, role: request.user?.role },
         });
 
         reply.headers({
           "Cache-Control": "public, max-age=0, must-revalidate",
-          "X-Cache": result.hit ? "HIT" : "MISS",
-          "X-Cache-Key": result.key,
-          "X-Cache-TTL": result.ttl,
+          "X-Cache": cache.status.toUpperCase(),
+          "X-Cache-Key": cache.key,
+          "X-Cache-TTL": cache.ttl,
         });
 
-        return reply.send(result.value);
+        return reply.send(value);
       },
     )
     .post(

--- a/apps/backend/src/modules/categories/category.service.test.ts
+++ b/apps/backend/src/modules/categories/category.service.test.ts
@@ -6,6 +6,7 @@ import {
   initiator,
   noInitiator,
 } from "@/__tests__/helpers.js";
+import type { CachedGetResult } from "@/common/cache/cache.service.js";
 import { ConflictError, NotFoundError } from "@/common/errors.js";
 import { categoryCache } from "@/modules/categories/category.cache.js";
 import { createCategoryService } from "@/modules/categories/category.service.js";
@@ -20,12 +21,17 @@ describe("categoryService", () => {
     count: vi.fn(),
   };
   const mockCache = {
-    getOrSet: vi.fn(async (key, factory, ttl) => ({
-      value: await factory(),
-      hit: false,
-      key,
-      ttl: ttl ?? 0,
-    })),
+    getOrSet: vi.fn(
+      // biome-ignore lint/suspicious/noExplicitAny: test
+      async (key, factory, ttl): Promise<CachedGetResult<any>> => ({
+        value: await factory(),
+        cache: {
+          status: "miss",
+          key,
+          ttl: ttl ?? 0,
+        },
+      }),
+    ),
     deletePattern: vi.fn(),
   };
   const mockBus = {
@@ -68,7 +74,7 @@ describe("categoryService", () => {
       expect(result.value.items[0]?.recipeCount).toBe(5);
       expect(result.value.items[1]?.recipeCount).toBe(0);
       expect(result.value.pagination.total).toBe(2);
-      expect(result.hit).toBe(false);
+      expect(result.cache.status).toBe("miss");
       expect(mockCache.getOrSet).toHaveBeenCalledWith(
         categoryCache.keys.list(query),
         expect.any(Function),
@@ -87,7 +93,7 @@ describe("categoryService", () => {
 
       expect(result.value.items).toEqual([]);
       expect(result.value.pagination.total).toBe(0);
-      expect(result.hit).toBe(false);
+      expect(result.cache.status).toBe("miss");
     });
 
     it("should return cached result on second call", async () => {
@@ -113,9 +119,11 @@ describe("categoryService", () => {
       vi.clearAllMocks();
       mockCache.getOrSet.mockResolvedValue({
         value: withPagination(docs, 1, 1, 10),
-        hit: true,
-        key: categoryCache.keys.list(query),
-        ttl: categoryCache.ttl.list,
+        cache: {
+          status: "hit",
+          key: categoryCache.keys.list(query),
+          ttl: categoryCache.ttl.list,
+        },
       });
 
       const result = await service.findAll({
@@ -126,7 +134,7 @@ describe("categoryService", () => {
       expect(mockCategoryRepository.findMany).not.toHaveBeenCalled();
       expect(result.value.items).toHaveLength(1);
       expect(result.value.pagination.total).toBe(1);
-      expect(result.hit).toBe(true);
+      expect(result.cache.status).toBe("hit");
       expect(mockCache.getOrSet).toHaveBeenCalledWith(
         categoryCache.keys.list(query),
         expect.any(Function),

--- a/apps/backend/src/modules/categories/category.service.test.ts
+++ b/apps/backend/src/modules/categories/category.service.test.ts
@@ -20,8 +20,12 @@ describe("categoryService", () => {
     count: vi.fn(),
   };
   const mockCache = {
-    get: vi.fn(),
-    set: vi.fn(),
+    getOrSet: vi.fn(async (key, factory, ttl) => ({
+      value: await factory(),
+      hit: false,
+      key,
+      ttl: ttl ?? 0,
+    })),
     deletePattern: vi.fn(),
   };
   const mockBus = {
@@ -59,13 +63,16 @@ describe("categoryService", () => {
       });
 
       expect(mockCategoryRepository.findMany).toHaveBeenCalledWith(query);
-      expect(result.items).toHaveLength(2);
-      expect(result.items[0]?.name).toBe("Desserts");
-      expect(result.items[0]?.recipeCount).toBe(5);
-      expect(result.items[1]?.recipeCount).toBe(0);
-      expect(result.pagination.total).toBe(2);
-      expect(mockCache.get).toHaveBeenCalledWith(
+      expect(result.value.items).toHaveLength(2);
+      expect(result.value.items[0]?.name).toBe("Desserts");
+      expect(result.value.items[0]?.recipeCount).toBe(5);
+      expect(result.value.items[1]?.recipeCount).toBe(0);
+      expect(result.value.pagination.total).toBe(2);
+      expect(result.hit).toBe(false);
+      expect(mockCache.getOrSet).toHaveBeenCalledWith(
         categoryCache.keys.list(query),
+        expect.any(Function),
+        categoryCache.ttl.list,
       );
     });
 
@@ -78,8 +85,9 @@ describe("categoryService", () => {
         initiator: noInitiator(),
       });
 
-      expect(result.items).toEqual([]);
-      expect(result.pagination.total).toBe(0);
+      expect(result.value.items).toEqual([]);
+      expect(result.value.pagination.total).toBe(0);
+      expect(result.hit).toBe(false);
     });
 
     it("should return cached result on second call", async () => {
@@ -96,11 +104,19 @@ describe("categoryService", () => {
         query,
         initiator: noInitiator(),
       });
-      expect(mockCache.get).toHaveBeenCalledWith(
+      expect(mockCache.getOrSet).toHaveBeenCalledWith(
         categoryCache.keys.list(query),
+        expect.any(Function),
+        categoryCache.ttl.list,
       );
+
       vi.clearAllMocks();
-      mockCache.get.mockResolvedValue(withPagination(docs, 1, 1, 10));
+      mockCache.getOrSet.mockResolvedValue({
+        value: withPagination(docs, 1, 1, 10),
+        hit: true,
+        key: categoryCache.keys.list(query),
+        ttl: categoryCache.ttl.list,
+      });
 
       const result = await service.findAll({
         query,
@@ -108,10 +124,13 @@ describe("categoryService", () => {
       });
 
       expect(mockCategoryRepository.findMany).not.toHaveBeenCalled();
-      expect(result.items).toHaveLength(1);
-      expect(result.pagination.total).toBe(1);
-      expect(mockCache.get).toHaveBeenCalledWith(
+      expect(result.value.items).toHaveLength(1);
+      expect(result.value.pagination.total).toBe(1);
+      expect(result.hit).toBe(true);
+      expect(mockCache.getOrSet).toHaveBeenCalledWith(
         categoryCache.keys.list(query),
+        expect.any(Function),
+        categoryCache.ttl.list,
       );
     });
   });

--- a/apps/backend/src/modules/categories/category.service.ts
+++ b/apps/backend/src/modules/categories/category.service.ts
@@ -6,7 +6,10 @@ import type {
   Paginated,
 } from "@recipes/shared";
 import { withPagination } from "@recipes/shared";
-import type { CacheService } from "@/common/cache/cache.service.js";
+import type {
+  CacheGetResult,
+  CacheService,
+} from "@/common/cache/cache.service.js";
 import { ConflictError, NotFoundError } from "@/common/errors.js";
 import type { TypedEmitter } from "@/common/events.js";
 import type {
@@ -22,7 +25,7 @@ import { toCategory } from "./category.mapper.js";
 export interface CategoryService {
   findAll(
     params: QueryMethodParams<CategoryQuery>,
-  ): Promise<Paginated<CategoryWithComputed>>;
+  ): Promise<CacheGetResult<Paginated<CategoryWithComputed>>>;
   create(params: CreateMethodParams<CreateCategoryBody>): Promise<Category>;
   deleteById(id: string, params: DeleteMethodParams): Promise<void>;
 }
@@ -32,7 +35,7 @@ type CategoryRepositoryPort = Pick<
   "findMany" | "create" | "delete"
 >;
 type RecipeRepositoryPort = Pick<RecipeRepository, "count">;
-type CacheServicePort = Pick<CacheService, "get" | "set" | "deletePattern">;
+type CacheServicePort = Pick<CacheService, "getOrSet" | "deletePattern">;
 type TypedEmitterPort = Pick<TypedEmitter, "emit">;
 
 export function createCategoryService(
@@ -45,22 +48,20 @@ export function createCategoryService(
     findAll: async ({ query }) => {
       const cacheKey = categoryCache.keys.list(query);
 
-      const cached = await cache.get<Paginated<CategoryWithComputed>>(cacheKey);
-      if (cached !== undefined) {
-        return cached;
-      }
+      return cache.getOrSet<Paginated<CategoryWithComputed>>(
+        cacheKey,
+        async () => {
+          const [categories, total] = await repository.findMany(query);
 
-      const [categories, total] = await repository.findMany(query);
-      const result = withPagination(
-        categories.map(toCategory),
-        total,
-        query.page,
-        query.limit,
+          return withPagination(
+            categories.map(toCategory),
+            total,
+            query.page,
+            query.limit,
+          );
+        },
+        categoryCache.ttl.list,
       );
-
-      await cache.set(cacheKey, result, categoryCache.ttl.list);
-
-      return result;
     },
 
     create: async ({ data }) => {

--- a/apps/backend/src/modules/categories/category.service.ts
+++ b/apps/backend/src/modules/categories/category.service.ts
@@ -7,7 +7,7 @@ import type {
 } from "@recipes/shared";
 import { withPagination } from "@recipes/shared";
 import type {
-  CacheGetResult,
+  CachedGetResult,
   CacheService,
 } from "@/common/cache/cache.service.js";
 import { ConflictError, NotFoundError } from "@/common/errors.js";
@@ -25,7 +25,7 @@ import { toCategory } from "./category.mapper.js";
 export interface CategoryService {
   findAll(
     params: QueryMethodParams<CategoryQuery>,
-  ): Promise<CacheGetResult<Paginated<CategoryWithComputed>>>;
+  ): Promise<CachedGetResult<Paginated<CategoryWithComputed>>>;
   create(params: CreateMethodParams<CreateCategoryBody>): Promise<Category>;
   deleteById(id: string, params: DeleteMethodParams): Promise<void>;
 }

--- a/apps/backend/src/modules/favorites/favorite.routes.test.ts
+++ b/apps/backend/src/modules/favorites/favorite.routes.test.ts
@@ -30,7 +30,7 @@ describe("favoriteRoutes", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
-    app = createTestApp();
+    app = await createTestApp();
     await app.register(favoriteRoutes, {
       service: mockFavoriteService,
       prefix: "/api/recipes",

--- a/apps/backend/src/modules/recipe-ratings/recipe-rating.routes.test.ts
+++ b/apps/backend/src/modules/recipe-ratings/recipe-rating.routes.test.ts
@@ -28,7 +28,7 @@ describe("recipeRatingRoutes", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
-    app = createTestApp();
+    app = await createTestApp();
     await app.register(recipeRatingRoutes, {
       service: mockRecipeRatingService,
       prefix: "/api/recipes",

--- a/apps/backend/src/modules/recipes/recipe.routes.test.ts
+++ b/apps/backend/src/modules/recipes/recipe.routes.test.ts
@@ -90,7 +90,7 @@ describe("recipeRoutes", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
-    app = createTestApp();
+    app = await createTestApp();
     await app.register(recipeRoutes, {
       service: mockRecipeService,
       commentService: mockCommentService,
@@ -100,7 +100,14 @@ describe("recipeRoutes", () => {
 
   describe("GET /api/recipes", () => {
     it("should return paginated recipes for unauthenticated user", async () => {
-      mockRecipeService.findAll.mockResolvedValue(paginatedResult);
+      mockRecipeService.findAll.mockResolvedValue({
+        value: paginatedResult,
+        cache: {
+          status: "miss",
+          key: "recipes:list:page=1:limit=10:sort=-createdAt",
+          ttl: 120,
+        },
+      });
 
       const page = 1;
       const limit = 10;
@@ -116,11 +123,19 @@ describe("recipeRoutes", () => {
       });
       const body = JSON.parse(response.payload);
       expect(body.items).toHaveLength(paginatedResult.items.length);
+      expect(response.headers["x-cache"]).toBe("MISS");
+      expect(response.headers["x-cache-ttl"]).toBe("120");
     });
 
     it("should return paginated recipes for authenticated user", async () => {
       verifyToken.mockReturnValue(testJwtPayload);
-      mockRecipeService.findAll.mockResolvedValue(paginatedResult);
+      mockRecipeService.findAll.mockResolvedValue({
+        value: paginatedResult,
+        cache: {
+          status: "bypass",
+          reason: "authenticated",
+        },
+      });
 
       const response = await app.inject({
         method: "GET",
@@ -136,6 +151,9 @@ describe("recipeRoutes", () => {
           role: testJwtPayload.role,
         },
       });
+      expect(response.headers["x-cache"]).toBe("BYPASS");
+      expect(response.headers["x-cache-bypass"]).toBe("authenticated");
+      expect(response.headers["cache-control"]).toBe("no-store");
     });
 
     it("should return 400 for invalid query params", async () => {
@@ -152,7 +170,14 @@ describe("recipeRoutes", () => {
 
   describe("GET /api/recipes/:id", () => {
     it("should return recipe by id", async () => {
-      mockRecipeService.findById.mockResolvedValue(validRecipe);
+      mockRecipeService.findById.mockResolvedValue({
+        value: validRecipe,
+        cache: {
+          status: "miss",
+          key: `recipes:id:${recipeId}`,
+          ttl: 600,
+        },
+      });
 
       const response = await app.inject({
         method: "GET",
@@ -165,6 +190,8 @@ describe("recipeRoutes", () => {
       });
       const body = JSON.parse(response.payload);
       expect(body.title).toBe("Test Recipe");
+      expect(response.headers["x-cache"]).toBe("MISS");
+      expect(response.headers["x-cache-ttl"]).toBe("600");
     });
 
     it("should return 400 for invalid id", async () => {

--- a/apps/backend/src/modules/recipes/recipe.routes.ts
+++ b/apps/backend/src/modules/recipes/recipe.routes.ts
@@ -48,11 +48,13 @@ export const recipeRoutes: FastifyPluginAsync<RecipeModuleOptions> = async (
         onRequest: optionalAuth,
       },
       async (request, reply) => {
-        const result = await service.findAll({
+        const { value, cache } = await service.findAll({
           query: request.query,
           initiator: { id: request.user?.userId, role: request.user?.role },
         });
-        return reply.send(result);
+
+        reply.applyCacheHeaders(cache);
+        return reply.send(value);
       },
     )
     .get(
@@ -69,10 +71,12 @@ export const recipeRoutes: FastifyPluginAsync<RecipeModuleOptions> = async (
         onRequest: optionalAuth,
       },
       async (request, reply) => {
-        const recipe = await service.findById(request.params.id, {
+        const { value, cache } = await service.findById(request.params.id, {
           initiator: { id: request.user?.userId, role: request.user?.role },
         });
-        return reply.send(recipe);
+
+        reply.applyCacheHeaders(cache);
+        return reply.send(value);
       },
     )
     .post(

--- a/apps/backend/src/modules/recipes/recipe.service.test.ts
+++ b/apps/backend/src/modules/recipes/recipe.service.test.ts
@@ -55,8 +55,7 @@ describe("recipeService", () => {
     modelName: "Category",
   };
   const mockCache = {
-    get: vi.fn(),
-    set: vi.fn(),
+    getOrSet: vi.fn(),
     delete: vi.fn(),
     deletePattern: vi.fn(),
   };
@@ -78,6 +77,17 @@ describe("recipeService", () => {
   });
 
   describe("findAll", () => {
+    beforeEach(() => {
+      mockCache.getOrSet.mockImplementation(async (key, factory, ttl) => ({
+        value: await factory(),
+        cache: {
+          status: "miss" as const,
+          key,
+          ttl: ttl ?? 0,
+        },
+      }));
+    });
+
     it("should return paginated recipes", async () => {
       const populated = populateRecipeDoc(createRecipeDoc());
       mockRecipeRepository.aggregateSearch.mockResolvedValue([[populated], 1]);
@@ -92,10 +102,15 @@ describe("recipeService", () => {
         initiator: noInitiator(),
       });
 
-      expect(result.items).toHaveLength(1);
-      expect(result.items[0]?.title).toBe("Test Recipe");
-      expect(result.pagination.total).toBe(1);
-      expect(mockCache.get).toHaveBeenCalledWith(recipeCache.keys.list(query));
+      expect(result.value.items).toHaveLength(1);
+      expect(result.value.items[0]?.title).toBe("Test Recipe");
+      expect(result.value.pagination.total).toBe(1);
+      expect(result.cache.status).toBe("miss");
+      expect(mockCache.getOrSet).toHaveBeenCalledWith(
+        recipeCache.keys.list(query),
+        expect.any(Function),
+        recipeCache.ttl.list,
+      );
     });
 
     it("should return empty when aggregate returns empty result", async () => {
@@ -111,8 +126,9 @@ describe("recipeService", () => {
         initiator: noInitiator(),
       });
 
-      expect(result.items).toEqual([]);
-      expect(result.pagination.total).toBe(0);
+      expect(result.value.items).toEqual([]);
+      expect(result.value.pagination.total).toBe(0);
+      expect(result.cache.status).toBe("miss");
     });
 
     it("should return empty when isFavorited filter is set but no initiator", async () => {
@@ -127,9 +143,13 @@ describe("recipeService", () => {
         initiator: noInitiator(),
       });
 
-      expect(result.items).toEqual([]);
+      expect(result.value.items).toEqual([]);
+      expect(result.cache.status).toBe("bypass");
+      if (result.cache.status === "bypass") {
+        expect(result.cache.reason).toBe("not-applicable");
+      }
       expect(mockRecipeRepository.aggregateSearch).not.toHaveBeenCalled();
-      expect(mockCache.get).not.toHaveBeenCalled();
+      expect(mockCache.getOrSet).not.toHaveBeenCalled();
     });
 
     it("should return rating data from aggregation", async () => {
@@ -156,9 +176,9 @@ describe("recipeService", () => {
         initiator: noInitiator(),
       });
 
-      expect(result.items[0]?.userRating).toBe(4);
-      expect(result.items[0]?.stats.averageRating).toBe(4.2);
-      expect(result.items[0]?.stats.ratingCount).toBe(15);
+      expect(result.value.items[0]?.userRating).toBe(4);
+      expect(result.value.items[0]?.stats.averageRating).toBe(4.2);
+      expect(result.value.items[0]?.stats.ratingCount).toBe(15);
     });
 
     it("should return null ratings when recipe has no ratings", async () => {
@@ -175,13 +195,24 @@ describe("recipeService", () => {
         initiator: noInitiator(),
       });
 
-      expect(result.items[0]?.userRating).toBeNull();
-      expect(result.items[0]?.stats.averageRating).toBeNull();
-      expect(result.items[0]?.stats.ratingCount).toBe(0);
+      expect(result.value.items[0]?.userRating).toBeNull();
+      expect(result.value.items[0]?.stats.averageRating).toBeNull();
+      expect(result.value.items[0]?.stats.ratingCount).toBe(0);
     });
   });
 
   describe("findById", () => {
+    beforeEach(() => {
+      mockCache.getOrSet.mockImplementation(async (key, factory, ttl) => ({
+        value: await factory(),
+        cache: {
+          status: "miss" as const,
+          key,
+          ttl: ttl ?? 0,
+        },
+      }));
+    });
+
     it("should return recipe by ID", async () => {
       const populated = populateRecipeDoc(createRecipeDoc());
       mockRecipeRepository.aggregateById.mockResolvedValue(populated);
@@ -191,8 +222,13 @@ describe("recipeService", () => {
         initiator: noInitiator(),
       });
 
-      expect(result.title).toBe("Test Recipe");
-      expect(mockCache.get).toHaveBeenCalledWith(recipeCache.keys.byId(id));
+      expect(result.value.title).toBe("Test Recipe");
+      expect(result.cache.status).toBe("miss");
+      expect(mockCache.getOrSet).toHaveBeenCalledWith(
+        recipeCache.keys.byId(id),
+        expect.any(Function),
+        recipeCache.ttl.byId,
+      );
     });
 
     it("should return cached recipe on second call for unauthenticated user", async () => {
@@ -201,18 +237,34 @@ describe("recipeService", () => {
 
       const id = createObjectId().toString();
       await service.findById(id, { initiator: noInitiator() });
-      expect(mockCache.get).toHaveBeenCalledWith(recipeCache.keys.byId(id));
+      expect(mockCache.getOrSet).toHaveBeenCalledWith(
+        recipeCache.keys.byId(id),
+        expect.any(Function),
+        recipeCache.ttl.byId,
+      );
 
       vi.clearAllMocks();
-      mockCache.get.mockResolvedValue(populated);
+      mockCache.getOrSet.mockResolvedValue({
+        value: populated,
+        cache: {
+          status: "hit" as const,
+          key: recipeCache.keys.byId(id),
+          ttl: recipeCache.ttl.byId,
+        },
+      });
 
       const result = await service.findById(id, {
         initiator: noInitiator(),
       });
 
       expect(mockRecipeRepository.aggregateById).not.toHaveBeenCalled();
-      expect(result.title).toBe("Test Recipe");
-      expect(mockCache.get).toHaveBeenCalledWith(recipeCache.keys.byId(id));
+      expect(result.value.title).toBe("Test Recipe");
+      expect(result.cache.status).toBe("hit");
+      expect(mockCache.getOrSet).toHaveBeenCalledWith(
+        recipeCache.keys.byId(id),
+        expect.any(Function),
+        recipeCache.ttl.byId,
+      );
     });
 
     it("should throw BadRequestError for invalid ID", async () => {
@@ -225,7 +277,6 @@ describe("recipeService", () => {
 
     it("should throw NotFoundError when recipe not found", async () => {
       mockRecipeRepository.aggregateById.mockResolvedValue(undefined);
-      mockCache.get.mockResolvedValue(undefined);
 
       const id = createObjectId().toString();
       await expect(
@@ -233,7 +284,11 @@ describe("recipeService", () => {
           initiator: noInitiator(),
         }),
       ).rejects.toThrow(NotFoundError);
-      expect(mockCache.get).toHaveBeenCalledWith(recipeCache.keys.byId(id));
+      expect(mockCache.getOrSet).toHaveBeenCalledWith(
+        recipeCache.keys.byId(id),
+        expect.any(Function),
+        recipeCache.ttl.byId,
+      );
     });
 
     it("should return rating data from aggregation", async () => {
@@ -255,9 +310,9 @@ describe("recipeService", () => {
         initiator: noInitiator(),
       });
 
-      expect(result.userRating).toBe(5);
-      expect(result.stats.averageRating).toBe(3.8);
-      expect(result.stats.ratingCount).toBe(42);
+      expect(result.value.userRating).toBe(5);
+      expect(result.value.stats.averageRating).toBe(3.8);
+      expect(result.value.stats.ratingCount).toBe(42);
     });
   });
 

--- a/apps/backend/src/modules/recipes/recipe.service.ts
+++ b/apps/backend/src/modules/recipes/recipe.service.ts
@@ -7,7 +7,10 @@ import type {
 } from "@recipes/shared";
 import { withPagination } from "@recipes/shared";
 import type { EmptyObject } from "@/common/base.repository.js";
-import type { CacheService } from "@/common/cache/cache.service.js";
+import type {
+  CachedResult,
+  CacheService,
+} from "@/common/cache/cache.service.js";
 import { ForbiddenError, NotFoundError } from "@/common/errors.js";
 import type { TypedEmitter } from "@/common/events.js";
 import type {
@@ -29,11 +32,11 @@ import type { RecipeRepository } from "./recipe.repository.js";
 export interface RecipeService {
   findAll(
     params: QueryMethodParams<RecipeQuery>,
-  ): Promise<Paginated<RecipeWithComputed>>;
+  ): Promise<CachedResult<Paginated<RecipeWithComputed>>>;
   findById(
     id: string,
     params: InitiatedMethodParams<OptionalInitiator>,
-  ): Promise<RecipeWithComputed>;
+  ): Promise<CachedResult<RecipeWithComputed>>;
   create(
     params: CreateMethodParams<CreateRecipeBody>,
   ): Promise<RecipeWithComputed>;
@@ -58,7 +61,7 @@ type FavoriteRepositoryPort = Pick<FavoriteRepository, "exists">;
 type CategoryRepositoryPort = Pick<CategoryRepository, "exists" | "modelName">;
 type CacheServicePort = Pick<
   CacheService,
-  "get" | "set" | "delete" | "deletePattern"
+  "getOrSet" | "delete" | "deletePattern"
 >;
 type TypedEmitterPort = Pick<TypedEmitter, "emit">;
 
@@ -72,71 +75,82 @@ export function createRecipeService(
 ): RecipeService {
   return {
     findAll: async ({ query, initiator }) => {
-      const { page, limit, isFavorited } = query;
-
-      if (isFavorited && !initiator.id) {
-        return withPagination([], 0, page, limit);
+      if (query.isFavorited === true && !initiator.id) {
+        return {
+          value: withPagination([], 0, query.page, query.limit),
+          cache: {
+            status: "bypass",
+            reason: "not-applicable",
+          },
+        };
       }
 
-      const isAuthenticated = !!initiator.id;
+      const canUseSharedCache = !initiator.id;
+      const cacheKey = recipeCache.keys.list(query);
 
-      if (!isAuthenticated) {
-        const cacheKey = recipeCache.keys.list(query);
+      const load = async () => {
+        const [recipes, total] = await repository.aggregateSearch({
+          query,
+          initiator,
+        });
 
-        const cached = await cache.get<Paginated<RecipeWithComputed>>(cacheKey);
-        if (cached !== undefined) {
-          return cached;
-        }
+        return withPagination(
+          recipes.map((recipe) => toRecipe(recipe, recipe.isFavorited)),
+          total,
+          query.page,
+          query.limit,
+        );
+      };
+
+      if (!canUseSharedCache) {
+        return {
+          value: await load(),
+          cache: {
+            status: "bypass",
+            reason: "authenticated",
+          },
+        };
       }
 
-      const [recipes, total] = await repository.aggregateSearch({
-        query,
-        initiator,
-      });
-
-      const result = withPagination(
-        recipes.map((recipe) => toRecipe(recipe, recipe.isFavorited)),
-        total,
-        page,
-        limit,
+      return cache.getOrSet<Paginated<RecipeWithComputed>>(
+        cacheKey,
+        load,
+        recipeCache.ttl.list,
       );
-
-      if (!isAuthenticated) {
-        const cacheKey = recipeCache.keys.list(query);
-        await cache.set(cacheKey, result, recipeCache.ttl.list);
-      }
-
-      return result;
     },
 
     findById: async (id, { initiator }) => {
       assertValidId(id, "Recipe");
 
-      const isAuthenticated = !!initiator.id;
+      const canUseSharedCache = !initiator.id;
+      const cacheKey = recipeCache.keys.byId(id);
 
-      if (!isAuthenticated) {
-        const cacheKey = recipeCache.keys.byId(id);
-        const cached = await cache.get<RecipeWithComputed>(cacheKey);
-        if (cached !== undefined) {
-          return cached;
+      const load = async () => {
+        const recipe = await repository.aggregateById(id, {
+          initiator,
+        });
+        if (!recipe) {
+          throw new NotFoundError("Recipe not found");
         }
+
+        return toRecipe(recipe, recipe.isFavorited);
+      };
+
+      if (!canUseSharedCache) {
+        return {
+          value: await load(),
+          cache: {
+            status: "bypass",
+            reason: "authenticated",
+          },
+        };
       }
 
-      const recipe = await repository.aggregateById(id, {
-        initiator,
-      });
-      if (!recipe) {
-        throw new NotFoundError("Recipe not found");
-      }
-
-      const result = toRecipe(recipe, recipe.isFavorited);
-
-      if (!isAuthenticated) {
-        const cacheKey = recipeCache.keys.byId(id);
-        await cache.set(cacheKey, result, recipeCache.ttl.byId);
-      }
-
-      return result;
+      return cache.getOrSet<RecipeWithComputed>(
+        cacheKey,
+        load,
+        recipeCache.ttl.byId,
+      );
     },
 
     create: async ({ data, initiator }) => {

--- a/apps/backend/src/modules/reviews/review.routes.test.ts
+++ b/apps/backend/src/modules/reviews/review.routes.test.ts
@@ -44,7 +44,7 @@ describe("reviewRoutes", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
-    app = createTestApp();
+    app = await createTestApp();
     await app.register(reviewRoutes, {
       service: mockReviewService,
       prefix: "/api/reviews",

--- a/apps/backend/src/modules/users/user.routes.test.ts
+++ b/apps/backend/src/modules/users/user.routes.test.ts
@@ -28,7 +28,7 @@ describe("userRoutes", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
-    app = createTestApp();
+    app = await createTestApp();
     await app.register(userRoutes, {
       service: mockUserService,
       prefix: "/api/users",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       fastify:
         specifier: ^5.8.4
         version: 5.8.4
+      fastify-plugin:
+        specifier: ^5.1.0
+        version: 5.1.0
       fastify-type-provider-zod:
         specifier: ^6.1.0
         version: 6.1.0(@fastify/swagger@9.7.0)(fastify@5.8.4)(openapi-types@12.1.3)(zod@4.3.6)


### PR DESCRIPTION
## Related Issues

<!-- No linked issue — internal improvement -->

## PR Type

- [ ] Bugfix
- [x] Feature
- [x] Refactoring
- [x] Tests
- [ ] Other

## Description

This PR adds HTTP cache-status headers (`X-Cache`, `X-Cache-Key`, `X-Cache-TTL`, `Cache-Control`) to all cached endpoints and refactors the cache layer to use a `getOrSet` pattern with rich metadata.

### Changes

#### Cache layer
- Introduced `getOrSet<T>(key, factory, ttl)` method on `CacheService` that returns `CachedGetResult<T>` with metadata (`status: "hit" | "miss"`, `key`, `ttl`).
- Added discriminated union `CacheMeta` (`CacheHitMeta | CacheMissMeta | CacheBypassMeta`) to express why a request bypassed the cache (`authenticated`, `not-applicable`, etc.).
- Added `CachedResult<T>` used by service interfaces when bypass is possible.
- Updated both `memory-cache` and `redis-cache` backends.
- Namespaced cache transparently delegates `getOrSet`.

#### Cache headers plugin
- Created `cache-headers.plugin.ts` — a Fastify plugin that decorates `reply` with `applyCacheHeaders(cache: CacheMeta)`.
- Hit/Miss → sets `Cache-Control: public, max-age=0, must-revalidate`, `X-Cache-Key`, `X-Cache-TTL`.
- Bypass → sets `Cache-Control: no-store`, `X-Cache-Bypass: <reason>`.

#### Services
- **Categories** (`findAll`): replaced manual `get`/`set` pair with `getOrSet`. Interface returns `CachedGetResult<Paginated<CategoryWithComputed>>`.
- **Recipes** (`findAll` & `findById`): same `getOrSet` refactor. Service interface returns `CachedResult<T>` because both methods support bypass (authenticated users skip shared cache; `isFavorited=true` without initiator is `not-applicable`).

#### Routes
- `GET /api/categories` — `reply.applyCacheHeaders(cache)`.
- `GET /api/recipes` and `GET /api/recipes/:id` — `reply.applyCacheHeaders(cache)`.

#### Tests
- Updated `category.service.test.ts` and `category.routes.test.ts` for `getOrSet` + `CachedGetResult`.
- Updated `recipe.service.test.ts` and `recipe.routes.test.ts` for `getOrSet` + `CachedResult` + bypass assertions.
- Made `createTestApp()` async so it registers the cache-headers plugin; updated all 7 route test suites.

### Why
- Previously there was no visibility into whether a response came from cache or not.
- Manual `get`/`set` was duplicated and error-prone. `getOrSet` removes duplication and makes cache logic atomic.

## Screenshots

<!-- Not applicable -->

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Added/updated tests for new functionality
- [ ] Updated documentation (if needed)