### PR TITLE
feat(reviews): add cache for testimonials and stats

### DIFF
--- a/apps/backend/src/app.services.ts
+++ b/apps/backend/src/app.services.ts
@@ -50,6 +50,7 @@ export interface AppServices {
 
   recipeCache: CacheService;
   categoryCache: CacheService;
+  reviewCache: CacheService;
 
   log: Logger;
 }
@@ -69,6 +70,7 @@ export function createServices(
 
   const recipeCache = createNamespacedCache("recipes", cache);
   const categoryCache = createNamespacedCache("categories", cache);
+  const reviewCache = createNamespacedCache("reviews", cache);
 
   const passwordService = createBcryptPasswordService(env.BCRYPT_SALT_ROUNDS);
 
@@ -110,7 +112,11 @@ export function createServices(
     bus,
   );
   const recipeStatsService = createRecipeStatsService(recipeRepository);
-  const reviewService = createReviewService(reviewRepository, userRepository);
+  const reviewService = createReviewService(
+    reviewRepository,
+    userRepository,
+    reviewCache,
+  );
   const authService = createAuthService(userRepository, passwordService, log);
 
   return {
@@ -126,6 +132,7 @@ export function createServices(
 
     recipeCache,
     categoryCache,
+    reviewCache,
 
     log,
   };

--- a/apps/backend/src/modules/reviews/review.cache.ts
+++ b/apps/backend/src/modules/reviews/review.cache.ts
@@ -1,0 +1,11 @@
+export const reviewCache = {
+  keys: {
+    featured: () => "featured",
+    stats: () => "stats",
+    allPattern: () => "*",
+  },
+  ttl: {
+    featured: 3600,
+    stats: 300,
+  },
+} as const;

--- a/apps/backend/src/modules/reviews/review.routes.test.ts
+++ b/apps/backend/src/modules/reviews/review.routes.test.ts
@@ -53,7 +53,14 @@ describe("reviewRoutes", () => {
 
   describe("GET /api/reviews/testimonials", () => {
     it("should return featured testimonials", async () => {
-      mockReviewService.findFeatured.mockResolvedValue([validReview]);
+      mockReviewService.findFeatured.mockResolvedValue({
+        value: [validReview],
+        cache: {
+          status: "miss",
+          key: "reviews:featured",
+          ttl: 3600,
+        },
+      });
 
       const response = await app.inject({
         method: "GET",
@@ -64,15 +71,24 @@ describe("reviewRoutes", () => {
       const body = JSON.parse(response.payload);
       expect(body).toHaveLength(1);
       expect(body[0].text).toBe("Great platform!");
+      expect(response.headers["x-cache"]).toBe("MISS");
+      expect(response.headers["x-cache-ttl"]).toBe("3600");
     });
   });
 
   describe("GET /api/reviews/stats", () => {
     it("should return review statistics", async () => {
       mockReviewService.getStats.mockResolvedValue({
-        totalReviews: 42,
-        averageRating: 4.5,
-        happyCooksCount: 38,
+        value: {
+          totalReviews: 42,
+          averageRating: 4.5,
+          happyCooksCount: 38,
+        },
+        cache: {
+          status: "miss",
+          key: "reviews:stats",
+          ttl: 300,
+        },
       });
 
       const response = await app.inject({
@@ -84,6 +100,8 @@ describe("reviewRoutes", () => {
       const body = JSON.parse(response.payload);
       expect(body.totalReviews).toBe(42);
       expect(body.averageRating).toBe(4.5);
+      expect(response.headers["x-cache"]).toBe("MISS");
+      expect(response.headers["x-cache-ttl"]).toBe("300");
     });
   });
 

--- a/apps/backend/src/modules/reviews/review.routes.ts
+++ b/apps/backend/src/modules/reviews/review.routes.ts
@@ -39,8 +39,9 @@ export const reviewRoutes: FastifyPluginAsync<ReviewModuleOptions> = async (
         },
       },
       async (_request, reply) => {
-        const testimonials = await service.findFeatured();
-        return reply.send(testimonials);
+        const { value, cache } = await service.findFeatured();
+        reply.applyCacheHeaders(cache);
+        return reply.send(value);
       },
     )
     .get(
@@ -55,8 +56,9 @@ export const reviewRoutes: FastifyPluginAsync<ReviewModuleOptions> = async (
         },
       },
       async (_request, reply) => {
-        const stats = await service.getStats();
-        return reply.send(stats);
+        const { value, cache } = await service.getStats();
+        reply.applyCacheHeaders(cache);
+        return reply.send(value);
       },
     )
     .post(

--- a/apps/backend/src/modules/reviews/review.service.test.ts
+++ b/apps/backend/src/modules/reviews/review.service.test.ts
@@ -27,8 +27,16 @@ describe("reviewService", () => {
     exists: vi.fn(),
     modelName: "User",
   };
+  const mockCache = {
+    getOrSet: vi.fn(),
+    deletePattern: vi.fn(),
+  };
 
-  const service = createReviewService(mockReviewRepository, mockUserRepository);
+  const service = createReviewService(
+    mockReviewRepository,
+    mockUserRepository,
+    mockCache,
+  );
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -63,6 +71,7 @@ describe("reviewService", () => {
       });
       expect(result.text).toBe("Love it!");
       expect(result.rating).toBe(5);
+      expect(mockCache.deletePattern).toHaveBeenCalledWith("*");
     });
 
     it("should throw ConflictError when user already has a review", async () => {
@@ -99,6 +108,17 @@ describe("reviewService", () => {
   });
 
   describe("findFeatured", () => {
+    beforeEach(() => {
+      mockCache.getOrSet.mockImplementation(async (key, factory, ttl) => ({
+        value: await factory(),
+        cache: {
+          status: "miss" as const,
+          key,
+          ttl: ttl ?? 0,
+        },
+      }));
+    });
+
     it("should return featured reviews", async () => {
       const authorId = createObjectId();
       const reviews = [
@@ -112,8 +132,9 @@ describe("reviewService", () => {
       const result = await service.findFeatured();
 
       expect(mockReviewRepository.findFeatured).toHaveBeenCalledWith(6);
-      expect(result).toHaveLength(1);
-      expect(result[0]?.author.name).toBe("Bob");
+      expect(result.value).toHaveLength(1);
+      expect(result.value[0]?.author.name).toBe("Bob");
+      expect(result.cache.status).toBe("miss");
     });
 
     it("should return empty array when no featured reviews", async () => {
@@ -121,7 +142,42 @@ describe("reviewService", () => {
 
       const result = await service.findFeatured();
 
-      expect(result).toEqual([]);
+      expect(result.value).toEqual([]);
+      expect(result.cache.status).toBe("miss");
+    });
+
+    it("should return cached result on second call", async () => {
+      const authorId = createObjectId();
+      const reviews = [
+        {
+          ...createReviewDoc({ author: authorId }),
+          author: { _id: authorId, name: "Bob", email: "bob@test.com" },
+        },
+      ];
+      mockReviewRepository.findFeatured.mockResolvedValue(reviews);
+
+      await service.findFeatured();
+      expect(mockCache.getOrSet).toHaveBeenCalledWith(
+        "featured",
+        expect.any(Function),
+        3600,
+      );
+
+      vi.clearAllMocks();
+      mockCache.getOrSet.mockResolvedValue({
+        value: reviews,
+        cache: {
+          status: "hit" as const,
+          key: "featured",
+          ttl: 3600,
+        },
+      });
+
+      const result = await service.findFeatured();
+
+      expect(mockReviewRepository.findFeatured).not.toHaveBeenCalled();
+      expect(result.value).toHaveLength(1);
+      expect(result.cache.status).toBe("hit");
     });
   });
 
@@ -166,6 +222,7 @@ describe("reviewService", () => {
         text: "Updated text",
       });
       expect(result.text).toBe("Updated text");
+      expect(mockCache.deletePattern).toHaveBeenCalledWith("*");
     });
 
     it("should allow admin to update any review", async () => {
@@ -185,6 +242,7 @@ describe("reviewService", () => {
       });
 
       expect(result.text).toBe("Admin update");
+      expect(mockCache.deletePattern).toHaveBeenCalledWith("*");
     });
 
     it("should throw BadRequestError for invalid review ID", async () => {
@@ -242,6 +300,7 @@ describe("reviewService", () => {
         isFeatured: true,
       });
       expect(result.isFeatured).toBe(true);
+      expect(mockCache.deletePattern).toHaveBeenCalledWith("*");
     });
 
     it("should throw ForbiddenError when not admin", async () => {
@@ -278,6 +337,7 @@ describe("reviewService", () => {
       });
 
       expect(mockReviewRepository.deleteDocument).toHaveBeenCalledWith(review);
+      expect(mockCache.deletePattern).toHaveBeenCalledWith("*");
     });
 
     it("should allow admin to delete any review", async () => {
@@ -289,6 +349,7 @@ describe("reviewService", () => {
       });
 
       expect(mockReviewRepository.deleteDocument).toHaveBeenCalledWith(review);
+      expect(mockCache.deletePattern).toHaveBeenCalledWith("*");
     });
 
     it("should throw BadRequestError for invalid review ID", async () => {
@@ -320,6 +381,17 @@ describe("reviewService", () => {
   });
 
   describe("getStats", () => {
+    beforeEach(() => {
+      mockCache.getOrSet.mockImplementation(async (key, factory, ttl) => ({
+        value: await factory(),
+        cache: {
+          status: "miss" as const,
+          key,
+          ttl: ttl ?? 0,
+        },
+      }));
+    });
+
     it("should return review statistics", async () => {
       const stats = {
         totalReviews: 42,
@@ -330,7 +402,45 @@ describe("reviewService", () => {
 
       const result = await service.getStats();
 
-      expect(result).toEqual(stats);
+      expect(result.value).toEqual(stats);
+      expect(result.cache.status).toBe("miss");
+      expect(mockCache.getOrSet).toHaveBeenCalledWith(
+        "stats",
+        expect.any(Function),
+        300,
+      );
+    });
+
+    it("should return cached stats on second call", async () => {
+      const stats = {
+        totalReviews: 10,
+        averageRating: 4.0,
+        happyCooksCount: 8,
+      };
+      mockReviewRepository.aggregateStats.mockResolvedValue(stats);
+
+      await service.getStats();
+      expect(mockCache.getOrSet).toHaveBeenCalledWith(
+        "stats",
+        expect.any(Function),
+        300,
+      );
+
+      vi.clearAllMocks();
+      mockCache.getOrSet.mockResolvedValue({
+        value: stats,
+        cache: {
+          status: "hit" as const,
+          key: "stats",
+          ttl: 300,
+        },
+      });
+
+      const result = await service.getStats();
+
+      expect(mockReviewRepository.aggregateStats).not.toHaveBeenCalled();
+      expect(result.value).toEqual(stats);
+      expect(result.cache.status).toBe("hit");
     });
   });
 });

--- a/apps/backend/src/modules/reviews/review.service.ts
+++ b/apps/backend/src/modules/reviews/review.service.ts
@@ -8,6 +8,10 @@ import type {
 } from "@recipes/shared";
 import { withPagination } from "@recipes/shared";
 import type { EmptyObject } from "@/common/base.repository.js";
+import type {
+  CachedGetResult,
+  CacheService,
+} from "@/common/cache/cache.service.js";
 import {
   ConflictError,
   ForbiddenError,
@@ -22,12 +26,13 @@ import type {
 } from "@/common/types/methods.js";
 import { assertExists, assertValidId } from "@/common/utils/validation.js";
 import type { UserRepository } from "@/modules/users/user.repository.js";
+import { reviewCache } from "./review.cache.js";
 import { toReview } from "./review.mapper.js";
 import type { ReviewRepository } from "./review.repository.js";
 
 export interface ReviewService {
   create(params: CreateMethodParams<CreateReviewBody>): Promise<Review>;
-  findFeatured(): Promise<Review[]>;
+  findFeatured(): Promise<CachedGetResult<Review[]>>;
   findAll(params: QueryMethodParams<ReviewQuery>): Promise<Paginated<Review>>;
   update(
     id: string,
@@ -39,7 +44,7 @@ export interface ReviewService {
     isFeatured: boolean,
   ): Promise<Review>;
   delete(id: string, params: DeleteMethodParams): Promise<void>;
-  getStats(): Promise<ReviewStats>;
+  getStats(): Promise<CachedGetResult<ReviewStats>>;
 }
 
 type ReviewRepositoryPort = Pick<
@@ -54,10 +59,12 @@ type ReviewRepositoryPort = Pick<
   | "aggregateStats"
 >;
 type UserRepositoryPort = Pick<UserRepository, "exists" | "modelName">;
+type CacheServicePort = Pick<CacheService, "getOrSet" | "deletePattern">;
 
 export function createReviewService(
   repository: ReviewRepositoryPort,
   userRepository: UserRepositoryPort,
+  cache: CacheServicePort,
 ): ReviewService {
   return {
     create: async ({ data, initiator }) => {
@@ -77,12 +84,20 @@ export function createReviewService(
         rating: data.rating,
       });
 
+      await cache.deletePattern(reviewCache.keys.allPattern());
+
       return toReview(review);
     },
 
     findFeatured: async () => {
-      const reviews = await repository.findFeatured(6);
-      return reviews.map(toReview);
+      return cache.getOrSet<Review[]>(
+        reviewCache.keys.featured(),
+        async () => {
+          const reviews = await repository.findFeatured(6);
+          return reviews.map(toReview);
+        },
+        reviewCache.ttl.featured,
+      );
     },
 
     findAll: async ({ query, initiator }) => {
@@ -114,6 +129,7 @@ export function createReviewService(
       }
 
       const updated = await repository.save(review, data);
+      await cache.deletePattern(reviewCache.keys.allPattern());
       return toReview(updated);
     },
 
@@ -132,6 +148,7 @@ export function createReviewService(
       }
 
       const updated = await repository.save(review, { isFeatured });
+      await cache.deletePattern(reviewCache.keys.allPattern());
       return toReview(updated);
     },
 
@@ -150,10 +167,15 @@ export function createReviewService(
       }
 
       await repository.deleteDocument(review);
+      await cache.deletePattern(reviewCache.keys.allPattern());
     },
 
     getStats: async () => {
-      return repository.aggregateStats();
+      return cache.getOrSet<ReviewStats>(
+        reviewCache.keys.stats(),
+        async () => repository.aggregateStats(),
+        reviewCache.ttl.stats,
+      );
     },
   };
 }


### PR DESCRIPTION
## Related Issues

<!-- No linked issue -->

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [x] Tests
- [ ] Other

## Description

Adds server-side caching for public review read endpoints.

### Changes

- **review.cache.ts**: New cache config with keys `featured` and `stats`, TTLs 3600s and 300s.
- **review.service.ts**:
  - `findFeatured()` — now uses `cache.getOrSet` with TTL 3600s (1 hour).
  - `getStats()` — now uses `cache.getOrSet` with TTL 300s (5 minutes).
  - `create`, `update`, `feature`, `delete` — invalidate all review cache entries on mutation.
- **review.routes.ts**: Added `reply.applyCacheHeaders(cache)` for `GET /testimonials` and `GET /stats`.
- **app.services.ts**: Wired `reviewCache` namespaced cache into `createReviewService`.
- **Tests**: Updated `review.service.test.ts` and `review.routes.test.ts` for `getOrSet`, `CachedGetResult`, cache headers assertions, and invalidation checks.

### Endpoints affected

| Endpoint | Cache Status |
|----------|-------------|
| `GET /api/reviews/testimonials` | ✅ Cached (1h) |
| `GET /api/reviews/stats` | ✅ Cached (5min) |
| `GET /api/reviews` (admin only) | ❌ Not cached (auth required) |
| `POST/PATCH/DELETE` | 🔁 Invalidates cache |

## Screenshots

<!-- Not applicable -->

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Added/updated tests for new functionality
- [ ] Updated documentation (if needed)