### PR TITLE
feat(frontend): add login and register pages with PrimeVue Forms

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Monorepo managed by **pnpm workspaces** with TypeScript throughout.
 ```
 apps/
   backend/          # Node.js + Fastify + Mongoose (MongoDB)
-  frontend/         # Placeholder — not yet configured
+  frontend/         # Vue3 + Vite + Vue Query
 packages/
   shared/           # Zod schemas, domain types, utilities
 ```

--- a/apps/frontend/components.d.ts
+++ b/apps/frontend/components.d.ts
@@ -12,8 +12,16 @@ export {}
 declare module 'vue' {
   export interface GlobalComponents {
     Button: typeof import('primevue/button')['default']
+    Form: typeof import('@primevue/forms/form')['default']
+    FormField: typeof import('@primevue/forms/formfield')['default']
+    IconField: typeof import('primevue/iconfield')['default']
+    InputIcon: typeof import('primevue/inputicon')['default']
+    InputText: typeof import('primevue/inputtext')['default']
+    Message: typeof import('primevue/message')['default']
+    Password: typeof import('primevue/password')['default']
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
     Skeleton: typeof import('primevue/skeleton')['default']
+    Toast: typeof import('primevue/toast')['default']
   }
 }

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@primeuix/themes": "^2.0.3",
+    "@primevue/forms": "^4.5.5",
     "@recipes/shared": "workspace:*",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/vue-query": "^5.99.0",

--- a/apps/frontend/src/app/main.ts
+++ b/apps/frontend/src/app/main.ts
@@ -4,6 +4,7 @@ import { definePreset } from "@primeuix/themes";
 import Aura from "@primeuix/themes/aura";
 import { VueQueryPlugin } from "@tanstack/vue-query";
 import { createPinia } from "pinia";
+import { ToastService } from "primevue";
 import PrimeVue from "primevue/config";
 import { createApp } from "vue";
 import App from "./App.vue";
@@ -11,7 +12,40 @@ import router from "./router";
 
 const app = createApp(App);
 
-const preset = definePreset(Aura);
+const preset = definePreset(Aura, {
+  primitive: {
+    borderRadius: {
+      none: "0",
+      xs: "0.125rem",
+      sm: "0.25rem",
+      md: "0.375rem",
+      lg: "0.5rem",
+      xl: "0.75rem",
+    },
+  },
+  semantic: {
+    formField: {
+      borderRadius: "{borderRadius.xl}",
+      paddingY: "0.50rem",
+      focusRing: {
+        width: "2px",
+        style: "solid",
+        color:
+          "color-mix(in oklab, var(--color-terracotta) /* #c27a54 */ 20%, transparent);",
+      },
+    },
+    colorScheme: {
+      light: {
+        formField: {
+          background: "#ffffff",
+          borderColor: "{stone.200}",
+          hoverBorderColor: "var(--color-terracotta-light)",
+          focusBorderColor: "var(--color-terracotta)",
+        },
+      },
+    },
+  },
+});
 
 app.use(PrimeVue, {
   theme: {
@@ -21,6 +55,7 @@ app.use(PrimeVue, {
     },
   },
 });
+app.use(ToastService);
 app.use(VueQueryPlugin);
 app.use(createPinia());
 app.use(router);

--- a/apps/frontend/src/app/main.ts
+++ b/apps/frontend/src/app/main.ts
@@ -21,9 +21,24 @@ const preset = definePreset(Aura, {
       md: "0.375rem",
       lg: "0.5rem",
       xl: "0.75rem",
+      "2xl": "1rem",
     },
   },
   semantic: {
+    primary: {
+      0: "#ffffff",
+      50: "var(--color-terracotta-50)",
+      100: "var(--color-terracotta-100)",
+      200: "var(--color-terracotta-200)",
+      300: "var(--color-terracotta-300)",
+      400: "var(--color-terracotta-400)",
+      500: "var(--color-terracotta-500)",
+      600: "var(--color-terracotta-600)",
+      700: "var(--color-terracotta-700)",
+      800: "var(--color-terracotta-800)",
+      900: "var(--color-terracotta-900)",
+      950: "var(--color-terracotta-950)",
+    },
     formField: {
       borderRadius: "{borderRadius.xl}",
       paddingY: "0.50rem",
@@ -31,16 +46,34 @@ const preset = definePreset(Aura, {
         width: "2px",
         style: "solid",
         color:
-          "color-mix(in oklab, var(--color-terracotta) /* #c27a54 */ 20%, transparent);",
+          "color-mix(in oklab, var(--color-terracotta) /* #c27a54 */ 20%, transparent)",
       },
     },
     colorScheme: {
       light: {
+        primary: {
+          color: "var(--color-terracotta-500)",
+          hoverColor: "var(--color-terracotta-600)",
+          activeColor: "var(--color-terracotta-700)",
+        },
         formField: {
           background: "#ffffff",
           borderColor: "{stone.200}",
           hoverBorderColor: "var(--color-terracotta-light)",
           focusBorderColor: "var(--color-terracotta)",
+        },
+      },
+    },
+  },
+  components: {
+    button: {
+      root: {
+        borderRadius: "{borderRadius.2xl}",
+        paddingX: "1rem",
+        paddingY: "0.75rem",
+        sm: {
+          paddingX: "0.75rem",
+          paddingY: "0.5rem",
         },
       },
     },

--- a/apps/frontend/src/assets/main.css
+++ b/apps/frontend/src/assets/main.css
@@ -8,9 +8,21 @@
   --font-display: "Cormorant Garamond", Georgia, serif;
   --font-body: "DM Sans", system-ui, sans-serif;
 
-  --color-terracotta: #c27a54;
-  --color-terracotta-dark: #a8643f;
   --color-terracotta-light: #d99a78;
+  --color-terracotta: oklch(0.6475 0.1044 48.07); /*     #c27a54 */
+  --color-terracotta-dark: #a8643f;
+
+  --color-terracotta-50: #fcf8f6;
+  --color-terracotta-100: #f0dfd6;
+  --color-terracotta-200: #e5c6b5;
+  --color-terracotta-300: #d9ad95;
+  --color-terracotta-400: #ce9374;
+  --color-terracotta-500: oklch(0.6475 0.1044 48.07); /* #c27a54 */
+  --color-terracotta-600: oklch(0.5962 0.0916 48.67); /* #ac6e4d */
+  --color-terracotta-700: oklch(0.5207 0.0784 47.39); /* #8e5b41 */
+  --color-terracotta-800: oklch(0.4272 0.0645 48.12); /* #6c442f */
+  --color-terracotta-900: #4e3122;
+  --color-terracotta-950: #311f15;
 }
 
 button {

--- a/apps/frontend/src/assets/main.css
+++ b/apps/frontend/src/assets/main.css
@@ -12,3 +12,7 @@
   --color-terracotta-dark: #a8643f;
   --color-terracotta-light: #d99a78;
 }
+
+button {
+  @apply cursor-pointer;
+}

--- a/apps/frontend/src/features/auth/ui/AuthPageShell.vue
+++ b/apps/frontend/src/features/auth/ui/AuthPageShell.vue
@@ -1,0 +1,101 @@
+<script setup lang="ts">
+import { APP_NAME } from "@/shared/constants";
+import AppLogo from "@/shared/ui/AppLogo.vue";
+
+const {
+  title,
+  description,
+  imageSrc,
+  imageAlt,
+  asideTitle,
+  asideText,
+  brandName = APP_NAME,
+  asideDecorative = false,
+} = defineProps<{
+  title: string;
+  description?: string;
+  imageSrc: string;
+  imageAlt?: string;
+  asideTitle?: string;
+  asideText?: string;
+  brandName?: string;
+  asideDecorative?: boolean;
+}>();
+</script>
+<template>
+  <main class="flex min-h-screen bg-stone-50">
+    <aside
+      v-if="imageSrc || asideTitle || asideText"
+      class="relative hidden min-h-screen w-1/3 sm:block lg:w-1/2"
+      :aria-hidden="asideDecorative ? 'true' : undefined"
+    >
+      <img
+        :src="imageSrc"
+        :alt="asideDecorative ? '' : imageAlt"
+        class="absolute inset-0 h-full w-full object-cover"
+      />
+      <div class="absolute inset-0 bg-stone-900/50" />
+
+      <div class="relative flex h-full flex-col justify-between p-8 lg:p-12">
+        <AppLogo theme="dark" />
+
+        <section v-if="asideTitle || asideText" class="max-w-md">
+          <h2
+            v-if="asideTitle"
+            class="font-display text-3xl leading-tight font-bold text-white lg:text-4xl"
+          >
+            {{ asideTitle }}
+          </h2>
+
+          <p
+            v-if="asideText"
+            class="mt-4 max-w-xs text-base leading-relaxed text-white/80 lg:text-lg"
+          >
+            {{ asideText }}
+          </p>
+        </section>
+
+        <p class="text-sm text-white/60">
+          &copy; {{ new Date().getFullYear() }} {{ brandName }}
+        </p>
+      </div>
+    </aside>
+
+    <section
+      class="flex min-h-screen w-full items-center justify-center px-6 py-10 sm:w-2/3 sm:px-10 md:px-12 lg:w-1/2 lg:px-16 xl:px-24"
+      aria-labelledby="auth-page-title"
+    >
+      <div class="w-full max-w-md">
+        <header class="mb-8">
+          <h1
+            id="auth-page-title"
+            class="font-display text-3xl font-bold tracking-tight text-stone-900"
+          >
+            {{ title }}
+          </h1>
+
+          <p
+            v-if="description"
+            class="mt-2 text-sm leading-6 text-stone-600 sm:text-base"
+          >
+            {{ description }}
+          </p>
+        </header>
+
+        <slot />
+
+        <slot name="bottom-nav">
+          <div class="mt-8">
+            <RouterLink
+              to="/"
+              class="inline-flex items-center gap-2 text-sm font-medium text-stone-500 transition-colors hover:text-stone-800"
+            >
+              <i class="pi pi-arrow-left" aria-hidden="true" />
+              Back to home
+            </RouterLink>
+          </div>
+        </slot>
+      </div>
+    </section>
+  </main>
+</template>

--- a/apps/frontend/src/pages/login.vue
+++ b/apps/frontend/src/pages/login.vue
@@ -1,5 +1,10 @@
 <script setup lang="ts">
-import { ref } from "vue";
+import type { FormSubmitEvent } from "@primevue/forms";
+import { zodResolver } from "@primevue/forms/resolvers/zod";
+import type { LoginInput } from "@recipes/shared";
+import { loginInputSchema } from "@recipes/shared";
+import { useToast } from "primevue";
+import { reactive, ref } from "vue";
 import AuthPageShell from "@/features/auth/ui/AuthPageShell.vue";
 
 definePage({
@@ -8,16 +13,30 @@ definePage({
   },
 });
 
-const email = ref("");
-const password = ref("");
-const showPassword = ref(false);
-const isLoading = ref(false);
+const toast = useToast();
 
-function onSubmit() {
+const isLoading = ref(false);
+const initialValues = reactive<LoginInput>({
+  email: "",
+  password: "",
+});
+const resolver = zodResolver(loginInputSchema);
+
+function onSubmit({ valid, values }: FormSubmitEvent) {
+  if (!valid) return;
+
+  console.log(values);
+
   // TODO: integrate login mutation
   isLoading.value = true;
   setTimeout(() => {
     isLoading.value = false;
+    toast.add({
+      severity: "success",
+      summary: "Success",
+      detail: "You have successfully logged in.",
+      life: 3000,
+    });
   }, 1200);
 }
 </script>
@@ -31,8 +50,10 @@ function onSubmit() {
     image-src="https://plus.unsplash.com/premium_photo-1672153937750-9ea567e94026?q=80&w=987&auto=format&fit=crop"
     image-alt="A cooking scene with ingredients and kitchen tools"
   >
-    <form class="space-y-5" @submit.prevent="onSubmit">
-      <div>
+    <Toast />
+
+    <Form :resolver :initial-values class="space-y-5" @submit="onSubmit">
+      <FormField v-slot="$field" name="email" class="flex flex-col">
         <label
           for="login-email"
           class="mb-1.5 block text-sm font-medium text-stone-700"
@@ -40,24 +61,29 @@ function onSubmit() {
           Email
         </label>
 
-        <div class="relative">
-          <i
-            class="pi pi-envelope absolute top-1/2 left-3 -translate-y-1/2 text-stone-400"
-            aria-hidden="true"
-          />
-          <input
+        <IconField>
+          <InputIcon class="pi pi-envelope text-stone-400" />
+          <InputText
             id="login-email"
-            v-model="email"
             type="email"
-            required
             autocomplete="email"
             placeholder="you@example.com"
-            class="focus:border-terracotta focus:ring-terracotta/20 w-full rounded-xl border border-stone-200 bg-white py-3 pr-4 pl-10 text-sm text-stone-900 transition-all outline-none placeholder:text-stone-400 focus:ring-2"
+            fluid
           />
-        </div>
-      </div>
+        </IconField>
 
-      <div>
+        <Message
+          v-if="$field?.invalid"
+          severity="error"
+          size="small"
+          variant="simple"
+          class="pt-1"
+        >
+          {{ $field.error?.message }}
+        </Message>
+      </FormField>
+
+      <FormField v-slot="$field" name="password" class="flex flex-col">
         <label
           for="login-password"
           class="mb-1.5 block text-sm font-medium text-stone-700"
@@ -65,35 +91,33 @@ function onSubmit() {
           Password
         </label>
 
-        <div class="relative">
-          <i
-            class="pi pi-lock absolute top-1/2 left-3 -translate-y-1/2 text-stone-400"
-            aria-hidden="true"
-          />
-          <input
-            id="login-password"
-            v-model="password"
-            :type="showPassword ? 'text' : 'password'"
-            required
-            minlength="6"
-            autocomplete="current-password"
+        <IconField>
+          <InputIcon class="pi pi-lock text-stone-400" />
+          <Password
             placeholder="••••••••"
-            class="focus:border-terracotta focus:ring-terracotta/20 w-full rounded-xl border border-stone-200 bg-white py-3 pr-10 pl-10 text-sm text-stone-900 transition-all outline-none placeholder:text-stone-400 focus:ring-2"
+            :feedback="false"
+            toggle-mask
+            fluid
+            :input-props="{
+              id: 'login-password',
+              autocomplete: 'current-password',
+            }"
           />
-          <button
-            type="button"
-            class="absolute top-1/2 right-3 inline-flex -translate-y-1/2 items-center justify-center text-stone-400 hover:text-stone-600"
-            :aria-pressed="showPassword"
-            :aria-label="showPassword ? 'Hide password' : 'Show password'"
-            @click="showPassword = !showPassword"
+        </IconField>
+
+        <template v-if="$field?.invalid">
+          <Message
+            v-for="(error, index) in $field.errors"
+            :key="index"
+            severity="error"
+            size="small"
+            variant="simple"
+            class="pt-1"
           >
-            <i
-              :class="showPassword ? 'pi pi-eye-slash' : 'pi pi-eye'"
-              aria-hidden="true"
-            />
-          </button>
-        </div>
-      </div>
+            {{ error.message }}
+          </Message>
+        </template>
+      </FormField>
 
       <div class="flex items-center justify-between">
         <label class="flex cursor-pointer items-center gap-2">
@@ -120,7 +144,7 @@ function onSubmit() {
         <i v-if="isLoading" class="pi pi-spinner pi-spin" aria-hidden="true" />
         <span>{{ isLoading ? "Signing in..." : "Sign In" }}</span>
       </button>
-    </form>
+    </Form>
 
     <p class="mt-8 text-center text-sm text-stone-500">
       Don't have an account?

--- a/apps/frontend/src/pages/login.vue
+++ b/apps/frontend/src/pages/login.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref } from "vue";
-import AppLogo from "@/shared/ui/AppLogo.vue";
+import AuthPageShell from "@/features/auth/ui/AuthPageShell.vue";
 
 definePage({
   meta: {
@@ -23,147 +23,113 @@ function onSubmit() {
 </script>
 
 <template>
-  <main class="flex min-h-screen bg-stone-50">
-    <!-- Left side: image & brand -->
-    <div class="relative hidden w-1/3 sm:block lg:w-1/2">
-      <img
-        src="https://images.unsplash.com/photo-1518779578993-ec3579fee39f?q=80&w=1035&auto=format&fit=crop"
-        alt="Cooking"
-        class="absolute inset-0 h-full w-full object-cover"
-      />
-      <div class="absolute inset-0 bg-stone-900/50" />
-      <div class="relative flex h-full flex-col justify-between p-12">
-        <AppLogo theme="dark" />
-        <div>
-          <h2 class="font-display text-4xl leading-tight font-bold text-white">
-            Welcome back,<br />chef!
-          </h2>
-          <p class="mt-4 max-w-xs text-lg leading-relaxed text-white/80">
-            Continue your culinary journey with step-by-step recipes and
-            inspiration.
-          </p>
+  <AuthPageShell
+    title="Sign in"
+    description="Welcome back! Please enter your details."
+    aside-title="Welcome back, chef!"
+    aside-text="Continue your culinary journey with step-by-step recipes and inspiration."
+    image-src="https://plus.unsplash.com/premium_photo-1672153937750-9ea567e94026?q=80&w=987&auto=format&fit=crop"
+    image-alt="A cooking scene with ingredients and kitchen tools"
+  >
+    <form class="space-y-5" @submit.prevent="onSubmit">
+      <div>
+        <label
+          for="login-email"
+          class="mb-1.5 block text-sm font-medium text-stone-700"
+        >
+          Email
+        </label>
+
+        <div class="relative">
+          <i
+            class="pi pi-envelope absolute top-1/2 left-3 -translate-y-1/2 text-stone-400"
+            aria-hidden="true"
+          />
+          <input
+            id="login-email"
+            v-model="email"
+            type="email"
+            required
+            autocomplete="email"
+            placeholder="you@example.com"
+            class="focus:border-terracotta focus:ring-terracotta/20 w-full rounded-xl border border-stone-200 bg-white py-3 pr-4 pl-10 text-sm text-stone-900 transition-all outline-none placeholder:text-stone-400 focus:ring-2"
+          />
         </div>
-        <p class="text-sm text-white/60">
-          &copy; {{ new Date().getFullYear() }} Savory
-        </p>
       </div>
-    </div>
 
-    <!-- Right side: form -->
-    <div
-      class="flex w-full flex-col justify-center px-6 py-12 sm:w-2/3 sm:px-10 md:px-12 lg:w-1/2 lg:px-16 xl:px-24"
-    >
-      <div class="mx-auto w-full max-w-sm">
-        <div class="mb-8">
-          <h1
-            class="font-display text-3xl font-bold tracking-tight text-stone-900"
-          >
-            Sign in
-          </h1>
-          <p class="mt-2 text-stone-500">
-            Welcome back! Please enter your details.
-          </p>
-        </div>
+      <div>
+        <label
+          for="login-password"
+          class="mb-1.5 block text-sm font-medium text-stone-700"
+        >
+          Password
+        </label>
 
-        <form class="space-y-5" @submit.prevent="onSubmit">
-          <div>
-            <label
-              for="login-email"
-              class="mb-1.5 block text-sm font-medium text-stone-700"
-            >
-              Email
-            </label>
-            <div class="relative">
-              <i
-                class="pi pi-envelope absolute top-1/2 left-3 -translate-y-1/2 text-stone-400"
-              />
-              <input
-                id="login-email"
-                v-model="email"
-                type="email"
-                required
-                placeholder="you@example.com"
-                class="focus:border-terracotta focus:ring-terracotta/20 w-full rounded-xl border border-stone-200 bg-white py-3 pr-4 pl-10 text-sm text-stone-900 transition-all outline-none placeholder:text-stone-400 focus:ring-2"
-              />
-            </div>
-          </div>
-
-          <div>
-            <label
-              for="login-password"
-              class="mb-1.5 block text-sm font-medium text-stone-700"
-            >
-              Password
-            </label>
-            <div class="relative">
-              <i
-                class="pi pi-lock absolute top-1/2 left-3 -translate-y-1/2 text-stone-400"
-              />
-              <input
-                id="login-password"
-                v-model="password"
-                :type="showPassword ? 'text' : 'password'"
-                required
-                minlength="6"
-                placeholder="••••••••"
-                class="focus:border-terracotta focus:ring-terracotta/20 w-full rounded-xl border border-stone-200 bg-white py-3 pr-10 pl-10 text-sm text-stone-900 transition-all outline-none placeholder:text-stone-400 focus:ring-2"
-              />
-              <button
-                type="button"
-                class="absolute top-1/2 right-3 -translate-y-1/2 text-stone-400 hover:text-stone-600"
-                @click="showPassword = !showPassword"
-              >
-                <i :class="showPassword ? 'pi pi-eye-slash' : 'pi pi-eye'" />
-              </button>
-            </div>
-          </div>
-
-          <div class="flex items-center justify-between">
-            <label class="flex cursor-pointer items-center gap-2">
-              <input
-                type="checkbox"
-                class="text-terracotta accent-terracotta focus:ring-terracotta h-4 w-4 rounded border-stone-300"
-              />
-              <span class="text-sm text-stone-600">Remember me</span>
-            </label>
-            <RouterLink
-              to="#"
-              class="text-terracotta hover:text-terracotta-dark text-sm font-medium transition-colors"
-            >
-              Forgot password?
-            </RouterLink>
-          </div>
-
+        <div class="relative">
+          <i
+            class="pi pi-lock absolute top-1/2 left-3 -translate-y-1/2 text-stone-400"
+            aria-hidden="true"
+          />
+          <input
+            id="login-password"
+            v-model="password"
+            :type="showPassword ? 'text' : 'password'"
+            required
+            minlength="6"
+            autocomplete="current-password"
+            placeholder="••••••••"
+            class="focus:border-terracotta focus:ring-terracotta/20 w-full rounded-xl border border-stone-200 bg-white py-3 pr-10 pl-10 text-sm text-stone-900 transition-all outline-none placeholder:text-stone-400 focus:ring-2"
+          />
           <button
-            type="submit"
-            :disabled="isLoading"
-            class="bg-terracotta shadow-terracotta/25 hover:bg-terracotta-dark flex w-full items-center justify-center gap-2 rounded-2xl px-4 py-3.5 text-sm font-semibold text-white shadow-lg transition-all hover:shadow-xl disabled:opacity-60"
+            type="button"
+            class="absolute top-1/2 right-3 inline-flex -translate-y-1/2 items-center justify-center text-stone-400 hover:text-stone-600"
+            :aria-pressed="showPassword"
+            :aria-label="showPassword ? 'Hide password' : 'Show password'"
+            @click="showPassword = !showPassword"
           >
-            <i v-if="isLoading" class="pi pi-spinner pi-spin" />
-            <span>{{ isLoading ? "Signing in..." : "Sign In" }}</span>
+            <i
+              :class="showPassword ? 'pi pi-eye-slash' : 'pi pi-eye'"
+              aria-hidden="true"
+            />
           </button>
-        </form>
-
-        <p class="mt-8 text-center text-sm text-stone-500">
-          Don't have an account?
-          <RouterLink
-            to="/register"
-            class="text-terracotta hover:text-terracotta-dark font-semibold transition-colors"
-          >
-            Sign up
-          </RouterLink>
-        </p>
-
-        <div class="mt-8">
-          <RouterLink
-            to="/"
-            class="inline-flex items-center gap-2 text-sm font-medium text-stone-500 transition-colors hover:text-stone-800"
-          >
-            <i class="pi pi-arrow-left" />
-            Back to home
-          </RouterLink>
         </div>
       </div>
-    </div>
-  </main>
+
+      <div class="flex items-center justify-between">
+        <label class="flex cursor-pointer items-center gap-2">
+          <input
+            type="checkbox"
+            class="text-terracotta accent-terracotta focus:ring-terracotta h-4 w-4 rounded border-stone-300"
+          />
+          <span class="text-sm text-stone-600">Remember me</span>
+        </label>
+
+        <RouterLink
+          to="#"
+          class="text-terracotta hover:text-terracotta-dark text-sm font-medium transition-colors"
+        >
+          Forgot password?
+        </RouterLink>
+      </div>
+
+      <button
+        type="submit"
+        :disabled="isLoading"
+        class="bg-terracotta shadow-terracotta/25 hover:bg-terracotta-dark flex w-full items-center justify-center gap-2 rounded-2xl px-4 py-3.5 text-sm font-semibold text-white shadow-lg transition-all hover:shadow-xl disabled:opacity-60"
+      >
+        <i v-if="isLoading" class="pi pi-spinner pi-spin" aria-hidden="true" />
+        <span>{{ isLoading ? "Signing in..." : "Sign In" }}</span>
+      </button>
+    </form>
+
+    <p class="mt-8 text-center text-sm text-stone-500">
+      Don't have an account?
+      <RouterLink
+        to="/register"
+        class="text-terracotta hover:text-terracotta-dark font-semibold transition-colors"
+      >
+        Sign up
+      </RouterLink>
+    </p>
+  </AuthPageShell>
 </template>

--- a/apps/frontend/src/pages/login.vue
+++ b/apps/frontend/src/pages/login.vue
@@ -136,14 +136,14 @@ function onSubmit({ valid, values }: FormSubmitEvent) {
         </RouterLink>
       </div>
 
-      <button
+      <Button
         type="submit"
+        :label="isLoading ? 'Signing in...' : 'Sign In'"
+        :loading="isLoading"
         :disabled="isLoading"
-        class="bg-terracotta shadow-terracotta/25 hover:bg-terracotta-dark flex w-full items-center justify-center gap-2 rounded-2xl px-4 py-3.5 text-sm font-semibold text-white shadow-lg transition-all hover:shadow-xl disabled:opacity-60"
-      >
-        <i v-if="isLoading" class="pi pi-spinner pi-spin" aria-hidden="true" />
-        <span>{{ isLoading ? "Signing in..." : "Sign In" }}</span>
-      </button>
+        class="font-semibold"
+        fluid
+      />
     </Form>
 
     <p class="mt-8 text-center text-sm text-stone-500">

--- a/apps/frontend/src/pages/login.vue
+++ b/apps/frontend/src/pages/login.vue
@@ -1,0 +1,169 @@
+<script setup lang="ts">
+import { ref } from "vue";
+import AppLogo from "@/shared/ui/AppLogo.vue";
+
+definePage({
+  meta: {
+    layout: "no-layout",
+  },
+});
+
+const email = ref("");
+const password = ref("");
+const showPassword = ref(false);
+const isLoading = ref(false);
+
+function onSubmit() {
+  // TODO: integrate login mutation
+  isLoading.value = true;
+  setTimeout(() => {
+    isLoading.value = false;
+  }, 1200);
+}
+</script>
+
+<template>
+  <main class="flex min-h-screen bg-stone-50">
+    <!-- Left side: image & brand -->
+    <div class="relative hidden w-1/3 sm:block lg:w-1/2">
+      <img
+        src="https://images.unsplash.com/photo-1518779578993-ec3579fee39f?q=80&w=1035&auto=format&fit=crop"
+        alt="Cooking"
+        class="absolute inset-0 h-full w-full object-cover"
+      />
+      <div class="absolute inset-0 bg-stone-900/50" />
+      <div class="relative flex h-full flex-col justify-between p-12">
+        <AppLogo theme="dark" />
+        <div>
+          <h2 class="font-display text-4xl leading-tight font-bold text-white">
+            Welcome back,<br />chef!
+          </h2>
+          <p class="mt-4 max-w-xs text-lg leading-relaxed text-white/80">
+            Continue your culinary journey with step-by-step recipes and
+            inspiration.
+          </p>
+        </div>
+        <p class="text-sm text-white/60">
+          &copy; {{ new Date().getFullYear() }} Savory
+        </p>
+      </div>
+    </div>
+
+    <!-- Right side: form -->
+    <div
+      class="flex w-full flex-col justify-center px-6 py-12 sm:w-2/3 sm:px-10 md:px-12 lg:w-1/2 lg:px-16 xl:px-24"
+    >
+      <div class="mx-auto w-full max-w-sm">
+        <div class="mb-8">
+          <h1
+            class="font-display text-3xl font-bold tracking-tight text-stone-900"
+          >
+            Sign in
+          </h1>
+          <p class="mt-2 text-stone-500">
+            Welcome back! Please enter your details.
+          </p>
+        </div>
+
+        <form class="space-y-5" @submit.prevent="onSubmit">
+          <div>
+            <label
+              for="login-email"
+              class="mb-1.5 block text-sm font-medium text-stone-700"
+            >
+              Email
+            </label>
+            <div class="relative">
+              <i
+                class="pi pi-envelope absolute top-1/2 left-3 -translate-y-1/2 text-stone-400"
+              />
+              <input
+                id="login-email"
+                v-model="email"
+                type="email"
+                required
+                placeholder="you@example.com"
+                class="focus:border-terracotta focus:ring-terracotta/20 w-full rounded-xl border border-stone-200 bg-white py-3 pr-4 pl-10 text-sm text-stone-900 transition-all outline-none placeholder:text-stone-400 focus:ring-2"
+              />
+            </div>
+          </div>
+
+          <div>
+            <label
+              for="login-password"
+              class="mb-1.5 block text-sm font-medium text-stone-700"
+            >
+              Password
+            </label>
+            <div class="relative">
+              <i
+                class="pi pi-lock absolute top-1/2 left-3 -translate-y-1/2 text-stone-400"
+              />
+              <input
+                id="login-password"
+                v-model="password"
+                :type="showPassword ? 'text' : 'password'"
+                required
+                minlength="6"
+                placeholder="••••••••"
+                class="focus:border-terracotta focus:ring-terracotta/20 w-full rounded-xl border border-stone-200 bg-white py-3 pr-10 pl-10 text-sm text-stone-900 transition-all outline-none placeholder:text-stone-400 focus:ring-2"
+              />
+              <button
+                type="button"
+                class="absolute top-1/2 right-3 -translate-y-1/2 text-stone-400 hover:text-stone-600"
+                @click="showPassword = !showPassword"
+              >
+                <i :class="showPassword ? 'pi pi-eye-slash' : 'pi pi-eye'" />
+              </button>
+            </div>
+          </div>
+
+          <div class="flex items-center justify-between">
+            <label class="flex cursor-pointer items-center gap-2">
+              <input
+                type="checkbox"
+                class="text-terracotta accent-terracotta focus:ring-terracotta h-4 w-4 rounded border-stone-300"
+              />
+              <span class="text-sm text-stone-600">Remember me</span>
+            </label>
+            <RouterLink
+              to="#"
+              class="text-terracotta hover:text-terracotta-dark text-sm font-medium transition-colors"
+            >
+              Forgot password?
+            </RouterLink>
+          </div>
+
+          <button
+            type="submit"
+            :disabled="isLoading"
+            class="bg-terracotta shadow-terracotta/25 hover:bg-terracotta-dark flex w-full items-center justify-center gap-2 rounded-2xl px-4 py-3.5 text-sm font-semibold text-white shadow-lg transition-all hover:shadow-xl disabled:opacity-60"
+          >
+            <i v-if="isLoading" class="pi pi-spinner pi-spin" />
+            <span>{{ isLoading ? "Signing in..." : "Sign In" }}</span>
+          </button>
+        </form>
+
+        <p class="mt-8 text-center text-sm text-stone-500">
+          Don't have an account?
+          <RouterLink
+            to="/register"
+            class="text-terracotta hover:text-terracotta-dark font-semibold transition-colors"
+          >
+            Sign up
+          </RouterLink>
+        </p>
+
+        <div class="mt-8">
+          <RouterLink
+            to="/"
+            class="inline-flex items-center gap-2 text-sm font-medium text-stone-500 transition-colors hover:text-stone-800"
+          >
+            <i class="pi pi-arrow-left" />
+            Back to home
+          </RouterLink>
+        </div>
+      </div>
+    </div>
+  </main>
+</template>

--- a/apps/frontend/src/pages/register.vue
+++ b/apps/frontend/src/pages/register.vue
@@ -158,16 +158,14 @@ function onSubmit({ valid, values }: FormSubmitEvent) {
         </template>
       </FormField>
 
-      <button
+      <Button
         type="submit"
+        :label="isLoading ? 'Creating account...' : 'Create Account'"
+        :loading="isLoading"
         :disabled="isLoading"
-        class="bg-terracotta shadow-terracotta/25 hover:bg-terracotta-dark flex w-full items-center justify-center gap-2 rounded-2xl px-4 py-3.5 text-sm font-semibold text-white shadow-lg transition-all hover:shadow-xl disabled:opacity-60"
-      >
-        <i v-if="isLoading" class="pi pi-spinner pi-spin" aria-hidden="true" />
-        <span>
-          {{ isLoading ? "Creating account..." : "Create Account" }}
-        </span>
-      </button>
+        class="font-semibold"
+        fluid
+      />
     </Form>
 
     <p class="mt-8 text-center text-sm text-stone-500">

--- a/apps/frontend/src/pages/register.vue
+++ b/apps/frontend/src/pages/register.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref } from "vue";
-import AppLogo from "@/shared/ui/AppLogo.vue";
+import AuthPageShell from "@/features/auth/ui/AuthPageShell.vue";
 
 definePage({
   meta: {
@@ -24,159 +24,128 @@ function onSubmit() {
 </script>
 
 <template>
-  <main class="flex min-h-screen bg-stone-50">
-    <!-- Left side: image & brand -->
-    <div class="relative hidden w-1/3 sm:block lg:w-1/2">
-      <img
-        src="https://images.unsplash.com/photo-1482049016688-2d3e1b311543?q=80&w=1010&auto=format&fit=crop"
-        alt="Food"
-        class="absolute inset-0 h-full w-full object-cover"
-      />
-      <div class="absolute inset-0 bg-stone-900/50" />
-      <div class="relative flex h-full flex-col justify-between p-12">
-        <AppLogo theme="dark" />
-        <div>
-          <h2 class="font-display text-4xl leading-tight font-bold text-white">
-            Start your<br />cooking journey
-          </h2>
-          <p class="mt-4 max-w-xs text-lg leading-relaxed text-white/80">
-            Join thousands of home cooks discovering new recipes every day.
-          </p>
+  <AuthPageShell
+    title="Create account"
+    description="Let's get you started with your new account."
+    aside-title="Start your cooking journey"
+    aside-text="Join thousands of home cooks discovering new recipes every day."
+    image-src="https://images.unsplash.com/photo-1482049016688-2d3e1b311543?q=80&w=1010&auto=format&fit=crop"
+    image-alt="Avocado and Egg Toast"
+  >
+    <form class="space-y-5" @submit.prevent="onSubmit">
+      <div>
+        <label
+          for="register-name"
+          class="mb-1.5 block text-sm font-medium text-stone-700"
+        >
+          Full Name
+        </label>
+
+        <div class="relative">
+          <i
+            class="pi pi-user absolute top-1/2 left-3 -translate-y-1/2 text-stone-400"
+            aria-hidden="true"
+          />
+          <input
+            id="register-name"
+            v-model="name"
+            type="text"
+            required
+            minlength="2"
+            maxlength="100"
+            autocomplete="name"
+            placeholder="Jane Doe"
+            class="focus:border-terracotta focus:ring-terracotta/20 w-full rounded-xl border border-stone-200 bg-white py-3 pr-4 pl-10 text-sm text-stone-900 transition-all outline-none placeholder:text-stone-400 focus:ring-2"
+          />
         </div>
-        <p class="text-sm text-white/60">
-          &copy; {{ new Date().getFullYear() }} Savory
-        </p>
       </div>
-    </div>
 
-    <!-- Right side: form -->
-    <div
-      class="flex w-full flex-col justify-center px-6 py-12 sm:w-2/3 sm:px-10 md:px-12 lg:w-1/2 lg:px-16 xl:px-24"
-    >
-      <div class="mx-auto w-full max-w-sm">
-        <div class="mb-8">
-          <h1
-            class="font-display text-3xl font-bold tracking-tight text-stone-900"
-          >
-            Create account
-          </h1>
-          <p class="mt-2 text-stone-500">
-            Let's get you started with your new account.
-          </p>
+      <div>
+        <label
+          for="register-email"
+          class="mb-1.5 block text-sm font-medium text-stone-700"
+        >
+          Email
+        </label>
+
+        <div class="relative">
+          <i
+            class="pi pi-envelope absolute top-1/2 left-3 -translate-y-1/2 text-stone-400"
+            aria-hidden="true"
+          />
+          <input
+            id="register-email"
+            v-model="email"
+            type="email"
+            required
+            autocomplete="email"
+            placeholder="you@example.com"
+            class="focus:border-terracotta focus:ring-terracotta/20 w-full rounded-xl border border-stone-200 bg-white py-3 pr-4 pl-10 text-sm text-stone-900 transition-all outline-none placeholder:text-stone-400 focus:ring-2"
+          />
         </div>
+      </div>
 
-        <form class="space-y-5" @submit.prevent="onSubmit">
-          <div>
-            <label
-              for="register-name"
-              class="mb-1.5 block text-sm font-medium text-stone-700"
-            >
-              Full Name
-            </label>
-            <div class="relative">
-              <i
-                class="pi pi-user absolute top-1/2 left-3 -translate-y-1/2 text-stone-400"
-              />
-              <input
-                id="register-name"
-                v-model="name"
-                type="text"
-                required
-                minlength="2"
-                maxlength="100"
-                placeholder="Jane Doe"
-                class="focus:border-terracotta focus:ring-terracotta/20 w-full rounded-xl border border-stone-200 bg-white py-3 pr-4 pl-10 text-sm text-stone-900 transition-all outline-none placeholder:text-stone-400 focus:ring-2"
-              />
-            </div>
-          </div>
+      <div>
+        <label
+          for="register-password"
+          class="mb-1.5 block text-sm font-medium text-stone-700"
+        >
+          Password
+        </label>
 
-          <div>
-            <label
-              for="register-email"
-              class="mb-1.5 block text-sm font-medium text-stone-700"
-            >
-              Email
-            </label>
-            <div class="relative">
-              <i
-                class="pi pi-envelope absolute top-1/2 left-3 -translate-y-1/2 text-stone-400"
-              />
-              <input
-                id="register-email"
-                v-model="email"
-                type="email"
-                required
-                placeholder="you@example.com"
-                class="focus:border-terracotta focus:ring-terracotta/20 w-full rounded-xl border border-stone-200 bg-white py-3 pr-4 pl-10 text-sm text-stone-900 transition-all outline-none placeholder:text-stone-400 focus:ring-2"
-              />
-            </div>
-          </div>
-
-          <div>
-            <label
-              for="register-password"
-              class="mb-1.5 block text-sm font-medium text-stone-700"
-            >
-              Password
-            </label>
-            <div class="relative">
-              <i
-                class="pi pi-lock absolute top-1/2 left-3 -translate-y-1/2 text-stone-400"
-              />
-              <input
-                id="register-password"
-                v-model="password"
-                :type="showPassword ? 'text' : 'password'"
-                required
-                minlength="6"
-                placeholder="••••••••"
-                class="focus:border-terracotta focus:ring-terracotta/20 w-full rounded-xl border border-stone-200 bg-white py-3 pr-10 pl-10 text-sm text-stone-900 transition-all outline-none placeholder:text-stone-400 focus:ring-2"
-              />
-              <button
-                type="button"
-                class="absolute top-1/2 right-3 -translate-y-1/2 text-stone-400 hover:text-stone-600"
-                @click="showPassword = !showPassword"
-              >
-                <i :class="showPassword ? 'pi pi-eye-slash' : 'pi pi-eye'" />
-              </button>
-            </div>
-            <p class="mt-1.5 text-xs text-stone-500">
-              Must be at least 6 characters
-            </p>
-          </div>
-
+        <div class="relative">
+          <i
+            class="pi pi-lock absolute top-1/2 left-3 -translate-y-1/2 text-stone-400"
+            aria-hidden="true"
+          />
+          <input
+            id="register-password"
+            v-model="password"
+            :type="showPassword ? 'text' : 'password'"
+            required
+            minlength="6"
+            autocomplete="new-password"
+            placeholder="••••••••"
+            class="focus:border-terracotta focus:ring-terracotta/20 w-full rounded-xl border border-stone-200 bg-white py-3 pr-10 pl-10 text-sm text-stone-900 transition-all outline-none placeholder:text-stone-400 focus:ring-2"
+          />
           <button
-            type="submit"
-            :disabled="isLoading"
-            class="bg-terracotta shadow-terracotta/25 hover:bg-terracotta-dark flex w-full items-center justify-center gap-2 rounded-2xl px-4 py-3.5 text-sm font-semibold text-white shadow-lg transition-all hover:shadow-xl disabled:opacity-60"
+            type="button"
+            class="absolute top-1/2 right-3 -translate-y-1/2 text-stone-400 hover:text-stone-600"
+            :aria-pressed="showPassword"
+            :aria-label="showPassword ? 'Hide password' : 'Show password'"
+            @click="showPassword = !showPassword"
           >
-            <i v-if="isLoading" class="pi pi-spinner pi-spin" />
-            <span>
-              {{ isLoading ? "Creating account..." : "Create Account" }}
-            </span>
+            <i
+              :class="showPassword ? 'pi pi-eye-slash' : 'pi pi-eye'"
+              aria-hidden="true"
+            />
           </button>
-        </form>
-
-        <p class="mt-8 text-center text-sm text-stone-500">
-          Already have an account?
-          <RouterLink
-            to="/login"
-            class="text-terracotta hover:text-terracotta-dark font-semibold transition-colors"
-          >
-            Sign in
-          </RouterLink>
-        </p>
-
-        <div class="mt-8">
-          <RouterLink
-            to="/"
-            class="inline-flex items-center gap-2 text-sm font-medium text-stone-500 transition-colors hover:text-stone-800"
-          >
-            <i class="pi pi-arrow-left" />
-            Back to home
-          </RouterLink>
         </div>
+        <p class="mt-1.5 text-xs text-stone-500">
+          Must be at least 6 characters
+        </p>
       </div>
-    </div>
-  </main>
+
+      <button
+        type="submit"
+        :disabled="isLoading"
+        class="bg-terracotta shadow-terracotta/25 hover:bg-terracotta-dark flex w-full items-center justify-center gap-2 rounded-2xl px-4 py-3.5 text-sm font-semibold text-white shadow-lg transition-all hover:shadow-xl disabled:opacity-60"
+      >
+        <i v-if="isLoading" class="pi pi-spinner pi-spin" aria-hidden="true" />
+        <span>
+          {{ isLoading ? "Creating account..." : "Create Account" }}
+        </span>
+      </button>
+    </form>
+
+    <p class="mt-8 text-center text-sm text-stone-500">
+      Already have an account?
+      <RouterLink
+        to="/login"
+        class="text-terracotta hover:text-terracotta-dark font-semibold transition-colors"
+      >
+        Sign in
+      </RouterLink>
+    </p>
+  </AuthPageShell>
 </template>

--- a/apps/frontend/src/pages/register.vue
+++ b/apps/frontend/src/pages/register.vue
@@ -1,0 +1,182 @@
+<script setup lang="ts">
+import { ref } from "vue";
+import AppLogo from "@/shared/ui/AppLogo.vue";
+
+definePage({
+  meta: {
+    layout: "no-layout",
+  },
+});
+
+const name = ref("");
+const email = ref("");
+const password = ref("");
+const showPassword = ref(false);
+const isLoading = ref(false);
+
+function onSubmit() {
+  // TODO: integrate register mutation
+  isLoading.value = true;
+  setTimeout(() => {
+    isLoading.value = false;
+  }, 1200);
+}
+</script>
+
+<template>
+  <main class="flex min-h-screen bg-stone-50">
+    <!-- Left side: image & brand -->
+    <div class="relative hidden w-1/3 sm:block lg:w-1/2">
+      <img
+        src="https://images.unsplash.com/photo-1482049016688-2d3e1b311543?q=80&w=1010&auto=format&fit=crop"
+        alt="Food"
+        class="absolute inset-0 h-full w-full object-cover"
+      />
+      <div class="absolute inset-0 bg-stone-900/50" />
+      <div class="relative flex h-full flex-col justify-between p-12">
+        <AppLogo theme="dark" />
+        <div>
+          <h2 class="font-display text-4xl leading-tight font-bold text-white">
+            Start your<br />cooking journey
+          </h2>
+          <p class="mt-4 max-w-xs text-lg leading-relaxed text-white/80">
+            Join thousands of home cooks discovering new recipes every day.
+          </p>
+        </div>
+        <p class="text-sm text-white/60">
+          &copy; {{ new Date().getFullYear() }} Savory
+        </p>
+      </div>
+    </div>
+
+    <!-- Right side: form -->
+    <div
+      class="flex w-full flex-col justify-center px-6 py-12 sm:w-2/3 sm:px-10 md:px-12 lg:w-1/2 lg:px-16 xl:px-24"
+    >
+      <div class="mx-auto w-full max-w-sm">
+        <div class="mb-8">
+          <h1
+            class="font-display text-3xl font-bold tracking-tight text-stone-900"
+          >
+            Create account
+          </h1>
+          <p class="mt-2 text-stone-500">
+            Let's get you started with your new account.
+          </p>
+        </div>
+
+        <form class="space-y-5" @submit.prevent="onSubmit">
+          <div>
+            <label
+              for="register-name"
+              class="mb-1.5 block text-sm font-medium text-stone-700"
+            >
+              Full Name
+            </label>
+            <div class="relative">
+              <i
+                class="pi pi-user absolute top-1/2 left-3 -translate-y-1/2 text-stone-400"
+              />
+              <input
+                id="register-name"
+                v-model="name"
+                type="text"
+                required
+                minlength="2"
+                maxlength="100"
+                placeholder="Jane Doe"
+                class="focus:border-terracotta focus:ring-terracotta/20 w-full rounded-xl border border-stone-200 bg-white py-3 pr-4 pl-10 text-sm text-stone-900 transition-all outline-none placeholder:text-stone-400 focus:ring-2"
+              />
+            </div>
+          </div>
+
+          <div>
+            <label
+              for="register-email"
+              class="mb-1.5 block text-sm font-medium text-stone-700"
+            >
+              Email
+            </label>
+            <div class="relative">
+              <i
+                class="pi pi-envelope absolute top-1/2 left-3 -translate-y-1/2 text-stone-400"
+              />
+              <input
+                id="register-email"
+                v-model="email"
+                type="email"
+                required
+                placeholder="you@example.com"
+                class="focus:border-terracotta focus:ring-terracotta/20 w-full rounded-xl border border-stone-200 bg-white py-3 pr-4 pl-10 text-sm text-stone-900 transition-all outline-none placeholder:text-stone-400 focus:ring-2"
+              />
+            </div>
+          </div>
+
+          <div>
+            <label
+              for="register-password"
+              class="mb-1.5 block text-sm font-medium text-stone-700"
+            >
+              Password
+            </label>
+            <div class="relative">
+              <i
+                class="pi pi-lock absolute top-1/2 left-3 -translate-y-1/2 text-stone-400"
+              />
+              <input
+                id="register-password"
+                v-model="password"
+                :type="showPassword ? 'text' : 'password'"
+                required
+                minlength="6"
+                placeholder="••••••••"
+                class="focus:border-terracotta focus:ring-terracotta/20 w-full rounded-xl border border-stone-200 bg-white py-3 pr-10 pl-10 text-sm text-stone-900 transition-all outline-none placeholder:text-stone-400 focus:ring-2"
+              />
+              <button
+                type="button"
+                class="absolute top-1/2 right-3 -translate-y-1/2 text-stone-400 hover:text-stone-600"
+                @click="showPassword = !showPassword"
+              >
+                <i :class="showPassword ? 'pi pi-eye-slash' : 'pi pi-eye'" />
+              </button>
+            </div>
+            <p class="mt-1.5 text-xs text-stone-500">
+              Must be at least 6 characters
+            </p>
+          </div>
+
+          <button
+            type="submit"
+            :disabled="isLoading"
+            class="bg-terracotta shadow-terracotta/25 hover:bg-terracotta-dark flex w-full items-center justify-center gap-2 rounded-2xl px-4 py-3.5 text-sm font-semibold text-white shadow-lg transition-all hover:shadow-xl disabled:opacity-60"
+          >
+            <i v-if="isLoading" class="pi pi-spinner pi-spin" />
+            <span>
+              {{ isLoading ? "Creating account..." : "Create Account" }}
+            </span>
+          </button>
+        </form>
+
+        <p class="mt-8 text-center text-sm text-stone-500">
+          Already have an account?
+          <RouterLink
+            to="/login"
+            class="text-terracotta hover:text-terracotta-dark font-semibold transition-colors"
+          >
+            Sign in
+          </RouterLink>
+        </p>
+
+        <div class="mt-8">
+          <RouterLink
+            to="/"
+            class="inline-flex items-center gap-2 text-sm font-medium text-stone-500 transition-colors hover:text-stone-800"
+          >
+            <i class="pi pi-arrow-left" />
+            Back to home
+          </RouterLink>
+        </div>
+      </div>
+    </div>
+  </main>
+</template>

--- a/apps/frontend/src/pages/register.vue
+++ b/apps/frontend/src/pages/register.vue
@@ -1,5 +1,10 @@
 <script setup lang="ts">
-import { ref } from "vue";
+import type { FormSubmitEvent } from "@primevue/forms";
+import { zodResolver } from "@primevue/forms/resolvers/zod";
+import type { RegisterInput } from "@recipes/shared";
+import { registerInputSchema } from "@recipes/shared";
+import { useToast } from "primevue";
+import { reactive, ref } from "vue";
 import AuthPageShell from "@/features/auth/ui/AuthPageShell.vue";
 
 definePage({
@@ -8,17 +13,31 @@ definePage({
   },
 });
 
-const name = ref("");
-const email = ref("");
-const password = ref("");
-const showPassword = ref(false);
-const isLoading = ref(false);
+const toast = useToast();
 
-function onSubmit() {
+const isLoading = ref(false);
+const initialValues = reactive<RegisterInput>({
+  email: "",
+  password: "",
+  name: "",
+});
+const resolver = zodResolver(registerInputSchema);
+
+function onSubmit({ valid, values }: FormSubmitEvent) {
+  if (!valid) return;
+
+  console.log(values);
+
   // TODO: integrate register mutation
   isLoading.value = true;
   setTimeout(() => {
     isLoading.value = false;
+    toast.add({
+      severity: "success",
+      summary: "Success",
+      detail: "You have successfully registered.",
+      life: 3000,
+    });
   }, 1200);
 }
 </script>
@@ -32,8 +51,8 @@ function onSubmit() {
     image-src="https://images.unsplash.com/photo-1482049016688-2d3e1b311543?q=80&w=1010&auto=format&fit=crop"
     image-alt="Avocado and Egg Toast"
   >
-    <form class="space-y-5" @submit.prevent="onSubmit">
-      <div>
+    <Form :resolver :initial-values class="space-y-5" @submit="onSubmit">
+      <FormField v-slot="$field" name="name" class="flex flex-col">
         <label
           for="register-name"
           class="mb-1.5 block text-sm font-medium text-stone-700"
@@ -41,26 +60,29 @@ function onSubmit() {
           Full Name
         </label>
 
-        <div class="relative">
-          <i
-            class="pi pi-user absolute top-1/2 left-3 -translate-y-1/2 text-stone-400"
-            aria-hidden="true"
-          />
-          <input
+        <IconField>
+          <InputIcon class="pi pi-user text-stone-400" />
+          <InputText
             id="register-name"
-            v-model="name"
             type="text"
-            required
-            minlength="2"
-            maxlength="100"
             autocomplete="name"
             placeholder="Jane Doe"
-            class="focus:border-terracotta focus:ring-terracotta/20 w-full rounded-xl border border-stone-200 bg-white py-3 pr-4 pl-10 text-sm text-stone-900 transition-all outline-none placeholder:text-stone-400 focus:ring-2"
+            fluid
           />
-        </div>
-      </div>
+        </IconField>
 
-      <div>
+        <Message
+          v-if="$field?.invalid"
+          severity="error"
+          size="small"
+          variant="simple"
+          class="pt-1"
+        >
+          {{ $field.error?.message }}
+        </Message>
+      </FormField>
+
+      <FormField v-slot="$field" name="email" class="flex flex-col">
         <label
           for="register-email"
           class="mb-1.5 block text-sm font-medium text-stone-700"
@@ -68,24 +90,29 @@ function onSubmit() {
           Email
         </label>
 
-        <div class="relative">
-          <i
-            class="pi pi-envelope absolute top-1/2 left-3 -translate-y-1/2 text-stone-400"
-            aria-hidden="true"
-          />
-          <input
+        <IconField>
+          <InputIcon class="pi pi-envelope text-stone-400" />
+          <InputText
             id="register-email"
-            v-model="email"
             type="email"
-            required
             autocomplete="email"
             placeholder="you@example.com"
-            class="focus:border-terracotta focus:ring-terracotta/20 w-full rounded-xl border border-stone-200 bg-white py-3 pr-4 pl-10 text-sm text-stone-900 transition-all outline-none placeholder:text-stone-400 focus:ring-2"
+            fluid
           />
-        </div>
-      </div>
+        </IconField>
 
-      <div>
+        <Message
+          v-if="$field?.invalid"
+          severity="error"
+          size="small"
+          variant="simple"
+          class="pt-1"
+        >
+          {{ $field.error?.message }}
+        </Message>
+      </FormField>
+
+      <FormField v-slot="$field" name="password" class="flex flex-col">
         <label
           for="register-password"
           class="mb-1.5 block text-sm font-medium text-stone-700"
@@ -93,38 +120,43 @@ function onSubmit() {
           Password
         </label>
 
-        <div class="relative">
-          <i
-            class="pi pi-lock absolute top-1/2 left-3 -translate-y-1/2 text-stone-400"
-            aria-hidden="true"
-          />
-          <input
-            id="register-password"
-            v-model="password"
-            :type="showPassword ? 'text' : 'password'"
-            required
-            minlength="6"
-            autocomplete="new-password"
+        <IconField>
+          <InputIcon class="pi pi-lock text-stone-400" />
+          <Password
             placeholder="••••••••"
-            class="focus:border-terracotta focus:ring-terracotta/20 w-full rounded-xl border border-stone-200 bg-white py-3 pr-10 pl-10 text-sm text-stone-900 transition-all outline-none placeholder:text-stone-400 focus:ring-2"
+            :feedback="false"
+            toggle-mask
+            fluid
+            :input-props="{
+              id: 'register-password',
+              autocomplete: 'new-password',
+            }"
           />
-          <button
-            type="button"
-            class="absolute top-1/2 right-3 -translate-y-1/2 text-stone-400 hover:text-stone-600"
-            :aria-pressed="showPassword"
-            :aria-label="showPassword ? 'Hide password' : 'Show password'"
-            @click="showPassword = !showPassword"
-          >
-            <i
-              :class="showPassword ? 'pi pi-eye-slash' : 'pi pi-eye'"
-              aria-hidden="true"
-            />
-          </button>
-        </div>
-        <p class="mt-1.5 text-xs text-stone-500">
+        </IconField>
+
+        <Message
+          v-if="!$field?.invalid"
+          size="small"
+          severity="secondary"
+          variant="simple"
+          class="pt-1"
+        >
           Must be at least 6 characters
-        </p>
-      </div>
+        </Message>
+
+        <template v-if="$field?.invalid">
+          <Message
+            v-for="(error, index) in $field.errors"
+            :key="index"
+            severity="error"
+            size="small"
+            variant="simple"
+            class="pt-1"
+          >
+            {{ error.message }}
+          </Message>
+        </template>
+      </FormField>
 
       <button
         type="submit"
@@ -136,7 +168,7 @@ function onSubmit() {
           {{ isLoading ? "Creating account..." : "Create Account" }}
         </span>
       </button>
-    </form>
+    </Form>
 
     <p class="mt-8 text-center text-sm text-stone-500">
       Already have an account?

--- a/apps/frontend/src/widgets/header/Header.vue
+++ b/apps/frontend/src/widgets/header/Header.vue
@@ -40,12 +40,12 @@ import AppLogo from "@/shared/ui/AppLogo.vue";
         </nav>
 
         <div class="flex items-center gap-3">
-          <button
-            type="button"
+          <RouterLink
+            to="/login"
             class="rounded-xl border border-stone-200 bg-white px-4 py-2 text-sm font-medium text-stone-700 shadow-sm transition-all hover:border-stone-300 hover:shadow-md"
           >
             Sign In
-          </button>
+          </RouterLink>
           <button
             type="button"
             class="bg-terracotta shadow-terracotta/25 hover:bg-terracotta-dark hover:shadow-terracotta/30 rounded-xl px-4 py-2 text-sm font-medium text-white shadow-lg transition-all hover:shadow-xl"

--- a/apps/frontend/typed-router.d.ts
+++ b/apps/frontend/typed-router.d.ts
@@ -34,6 +34,20 @@ declare module 'vue-router/auto-routes' {
       Record<never, never>,
       | never
     >,
+    '/login': RouteRecordInfo<
+      '/login',
+      '/login',
+      Record<never, never>,
+      Record<never, never>,
+      | never
+    >,
+    '/register': RouteRecordInfo<
+      '/register',
+      '/register',
+      Record<never, never>,
+      Record<never, never>,
+      | never
+    >,
   }
 
   /**
@@ -50,6 +64,18 @@ declare module 'vue-router/auto-routes' {
     'src/pages/index.vue': {
       routes:
         | '/'
+      views:
+        | never
+    }
+    'src/pages/login.vue': {
+      routes:
+        | '/login'
+      views:
+        | never
+    }
+    'src/pages/register.vue': {
+      routes:
+        | '/register'
       views:
         | never
     }

--- a/packages/shared/src/auth/auth.input.schema.ts
+++ b/packages/shared/src/auth/auth.input.schema.ts
@@ -1,14 +1,23 @@
 import { z } from "zod";
 
+export const passwordInputSchema = z
+  .string()
+  .trim()
+  .min(6, { message: "Password must be at least 6 characters" });
+
 export const registerInputSchema = z.object({
   email: z.email().trim(),
-  password: z.string().trim().min(6),
-  name: z.string().trim().min(2).max(100),
+  password: passwordInputSchema,
+  name: z
+    .string()
+    .trim()
+    .min(2, { message: "Name must be at least 2 characters" })
+    .max(100, { message: "Name must be at most 100 characters" }),
 });
 
 export const loginInputSchema = z.object({
   email: z.email().trim(),
-  password: z.string().trim(),
+  password: passwordInputSchema,
 });
 
 export type RegisterInput = z.infer<typeof registerInputSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,9 @@ importers:
       '@primeuix/themes':
         specifier: ^2.0.3
         version: 2.0.3
+      '@primevue/forms':
+        specifier: ^4.5.5
+        version: 4.5.5(vue@3.5.32(typescript@6.0.2))
       '@recipes/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -772,6 +775,10 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
+  '@primeuix/forms@0.1.0':
+    resolution: {integrity: sha512-LctcQidb+B5PuvAFWH24YH/SIzmHlOabLHpaTeGY/k51iBv1WyCp+5w9JMYuMB/BplSvV0ZGySxQVkN5Azr/aQ==}
+    engines: {node: '>=12.11.0'}
+
   '@primeuix/styled@0.7.4':
     resolution: {integrity: sha512-QSO/NpOQg8e9BONWRBx9y8VGMCMYz0J/uKfNJEya/RGEu7ARx0oYW0ugI1N3/KB1AAvyGxzKBzGImbwg0KUiOQ==}
     engines: {node: '>=12.11.0'}
@@ -795,6 +802,10 @@ packages:
     engines: {node: '>=12.11.0'}
     peerDependencies:
       vue: ^3.5.0
+
+  '@primevue/forms@4.5.5':
+    resolution: {integrity: sha512-LUeIt6oItwCZyBreQ7ycErE8aEjPmBWOTq1VPLhyaATcnzMBOZRIiwclaYk8s/tf5VYMqN9N4B80XnXoO7OdvQ==}
+    engines: {node: '>=12.11.0'}
 
   '@primevue/icons@4.5.5':
     resolution: {integrity: sha512-eteOhTdAOXEYE9qW1AOrBBgDxQ2szHJxSkEK1XVdV2TKxGM5FQf03Ovms0VDyZTc16XBIgvwYjXJQS0BPbhPaA==}
@@ -3835,6 +3846,10 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
+  '@primeuix/forms@0.1.0':
+    dependencies:
+      '@primeuix/utils': 0.6.4
+
   '@primeuix/styled@0.7.4':
     dependencies:
       '@primeuix/utils': 0.6.4
@@ -3858,6 +3873,14 @@ snapshots:
       '@primeuix/styled': 0.7.4
       '@primeuix/utils': 0.6.4
       vue: 3.5.32(typescript@6.0.2)
+
+  '@primevue/forms@4.5.5(vue@3.5.32(typescript@6.0.2))':
+    dependencies:
+      '@primeuix/forms': 0.1.0
+      '@primeuix/utils': 0.6.4
+      '@primevue/core': 4.5.5(vue@3.5.32(typescript@6.0.2))
+    transitivePeerDependencies:
+      - vue
 
   '@primevue/icons@4.5.5(vue@3.5.32(typescript@6.0.2))':
     dependencies:


### PR DESCRIPTION
## Related Issues

<!-- Link related issues: Closes #123, Refs #456 -->

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Tests
- [ ] Other

## Description

This PR introduces new `/login` and `/register` pages for the recipe platform.  
Key highlights:

- **Split-screen layout**: a shared `AuthPageShell` component renders a responsive left-side image panel (with branding) and a right-side form panel.
- **PrimeVue Forms integration**: both pages use `@primevue/forms` with `zodResolver` and our existing Zod schemas (`loginInputSchema`, `registerInputSchema`) for client-side validation.
- **PrimeVue UI components**: replaced native inputs with `InputText`, `Password`, `IconField`, `InputIcon`, `Message`, `Button`, and `Toast`.
- **Custom theming**: extended the Aura preset in `main.ts` to map `terracotta` colors to `semantic.primary`, `formField` focus rings, and `button` border-radius, keeping the design consistent with the rest of the app.
- **No logic yet**: form submission is stubbed with a loading state and a toast.  Integration with `useMutation` from Vue Query will follow in a later PR.

## Screenshots

<!-- If applicable, add screenshots or recordings of the changes -->

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [ ] Added/updated tests for new functionality
- [ ] Updated documentation (if needed)