### PR TITLE
feat(auth): refresh token rotation with HTTP-only cookies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,25 @@
-# MongoDB
-MONGO_ADMIN_USER="admin"
-MONGO_ADMIN_PASS="adminpass"
-MONGO_HOST="localhost"
-MONGO_PORT=27019
-MONGO_DATABASE="recipes"
+NODE_ENV="development"
+PORT=3000
+HOST=0.0.0.0
+MONGO_URI="mongodb://admin:adminpass@localhost:27017/recipes-mfvn?authSource=admin"
 
-# Mongo Express UI
-MONGO_EXPRESS_USER="expressuser"
-MONGO_EXPRESS_PASS="expresspass"
+# AUTH
+JWT_SECRET="super-secret-change-me-in-production"
+JWT_EXPIRES_IN=15m
+SESSION_EXPIRES_IN_DAYS=7
+
+# RATE LIMITING
+RATE_LIMIT_AUTH_MAX=5
+RATE_LIMIT_AUTH_WINDOW="3 minutes"
+RATE_LIMIT_GLOBAL_MAX=100
+RATE_LIMIT_GLOBAL_WINDOW="1 minute"
+
+# MANAGEMENT
+ROOT_ADMIN_EMAIL="root@gmail.com"
+ROOT_ADMIN_PASSWORD="root0_Admin"
+
+# CACHE
+CACHE_BACKEND="redis"
+REDIS_URL="redis://localhost:6379"
+
+REBUILD_STATS_CRON="0 * * * *"

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -24,6 +24,7 @@
   "author": "Artem Levchenko",
   "license": "ISC",
   "dependencies": {
+    "@fastify/cookie": "^11.0.2",
     "@fastify/cors": "^10.1.0",
     "@fastify/helmet": "^13.0.2",
     "@fastify/rate-limit": "^10.3.0",

--- a/apps/backend/src/__tests__/build-test-app.ts
+++ b/apps/backend/src/__tests__/build-test-app.ts
@@ -17,5 +17,5 @@ export async function createTestApp() {
 }
 
 export function authHeader(payload: JwtPayload): { authorization: string } {
-  return { authorization: `Bearer fake-token-${payload.userId}` };
+  return { authorization: `Bearer fake-token-${payload.id}` };
 }

--- a/apps/backend/src/__tests__/build-test-app.ts
+++ b/apps/backend/src/__tests__/build-test-app.ts
@@ -1,3 +1,4 @@
+import fastifyCookie from "@fastify/cookie";
 import Fastify from "fastify";
 import {
   serializerCompiler,
@@ -13,6 +14,7 @@ export async function createTestApp() {
   app.setSerializerCompiler(serializerCompiler);
   app.setErrorHandler(errorHandler);
   await app.register(cacheHeadersPlugin);
+  await app.register(fastifyCookie);
   return app;
 }
 

--- a/apps/backend/src/__tests__/db-factories.ts
+++ b/apps/backend/src/__tests__/db-factories.ts
@@ -5,6 +5,7 @@ import { CommentModel } from "@/modules/comments/comment.model.js";
 import { FavoriteModel } from "@/modules/favorites/favorite.model.js";
 import { RecipeRatingModel } from "@/modules/recipe-ratings/recipe-rating.model.js";
 import { RecipeModel } from "@/modules/recipes/recipe.model.js";
+import { RefreshSessionModel } from "@/modules/auth/refresh-session.model.js";
 import { ReviewModel } from "@/modules/reviews/review.model.js";
 import { UserModel } from "@/modules/users/user.model.js";
 import { createObjectId } from "./helpers.js";
@@ -140,6 +141,32 @@ export async function createDbReview(
     text: "Amazing platform!",
     rating: 5,
     isFeatured: false,
+    ...overrides,
+  });
+}
+
+export async function createDbRefreshSession(
+  overrides: Partial<{
+    user: Types.ObjectId;
+    familyId: string;
+    tokenHash: string;
+    expiresAt: Date;
+    rotatedAt: Date | null;
+    replacedBy: string | null;
+    revokedAt: Date | null;
+    revokeReason: string | null;
+  }> = {},
+) {
+  return RefreshSessionModel.create({
+    user: overrides.user ?? createObjectId(),
+    familyId: overrides.familyId ?? `family-${unique("fam")}`,
+    tokenHash: overrides.tokenHash ?? `hash-${unique("hash")}`,
+    expiresAt:
+      overrides.expiresAt ?? new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+    rotatedAt: overrides.rotatedAt ?? null,
+    replacedBy: overrides.replacedBy ?? null,
+    revokedAt: overrides.revokedAt ?? null,
+    revokeReason: overrides.revokeReason ?? null,
     ...overrides,
   });
 }

--- a/apps/backend/src/__tests__/db-factories.ts
+++ b/apps/backend/src/__tests__/db-factories.ts
@@ -1,11 +1,11 @@
 import type { Minutes, RecipeStats } from "@recipes/shared";
 import type { Types } from "mongoose";
+import { RefreshSessionModel } from "@/modules/auth/refresh-session.model.js";
 import { CategoryModel } from "@/modules/categories/category.model.js";
 import { CommentModel } from "@/modules/comments/comment.model.js";
 import { FavoriteModel } from "@/modules/favorites/favorite.model.js";
 import { RecipeRatingModel } from "@/modules/recipe-ratings/recipe-rating.model.js";
 import { RecipeModel } from "@/modules/recipes/recipe.model.js";
-import { RefreshSessionModel } from "@/modules/auth/refresh-session.model.js";
 import { ReviewModel } from "@/modules/reviews/review.model.js";
 import { UserModel } from "@/modules/users/user.model.js";
 import { createObjectId } from "./helpers.js";

--- a/apps/backend/src/__tests__/helpers.ts
+++ b/apps/backend/src/__tests__/helpers.ts
@@ -3,6 +3,7 @@ import type { FastifyReply, FastifyRequest } from "fastify";
 import { Types } from "mongoose";
 import type { Mock } from "vitest";
 import { vi } from "vitest";
+import type { RefreshSessionDocument } from "@/modules/auth/refresh-session.model.js";
 import type { CategoryDocument } from "@/modules/categories/category.model.js";
 import type { CommentDocument } from "@/modules/comments/comment.model.js";
 import type {
@@ -179,6 +180,29 @@ export function createReviewDoc(
     isFeatured: false,
     createdAt: new Date("2024-01-01"),
     updatedAt: new Date("2024-01-01"),
+    ...overrides,
+  };
+}
+
+export function createRefreshSessionDoc(
+  overrides: Partial<RefreshSessionDocument> = {},
+): RefreshSessionDocument {
+  return {
+    _id: createObjectId(),
+    user: createObjectId(),
+    familyId: "test-family",
+    tokenHash: "test-token-hash",
+    expiresAt: new Date(
+      new Date("2024-01-01").getTime() + 7 * 24 * 60 * 60 * 1000,
+    ),
+    createdAt: new Date("2024-01-01"),
+    lastUsedAt: null,
+    rotatedAt: null,
+    replacedBy: null,
+    revokedAt: null,
+    revokeReason: null,
+    ip: null,
+    userAgent: null,
     ...overrides,
   };
 }

--- a/apps/backend/src/app.services.ts
+++ b/apps/backend/src/app.services.ts
@@ -127,6 +127,7 @@ export function createServices(
   );
   const refreshSessionService = createRefreshSessionService(
     refreshSessionRepository,
+    userRepository,
   );
   const authService = createAuthService(userRepository, passwordService, log);
 

--- a/apps/backend/src/app.services.ts
+++ b/apps/backend/src/app.services.ts
@@ -6,6 +6,10 @@ import { createBcryptPasswordService } from "@/common/passwords/bcrypt.service.j
 import { env } from "@/config/env.js";
 import type { AuthService } from "@/modules/auth/auth.service.js";
 import { createAuthService } from "@/modules/auth/auth.service.js";
+import { RefreshSessionModel } from "@/modules/auth/refresh-session.model.js";
+import { RefreshSessionRepository } from "@/modules/auth/refresh-session.repository.js";
+import type { RefreshSessionService } from "@/modules/auth/refresh-session.service.js";
+import { createRefreshSessionService } from "@/modules/auth/refresh-session.service.js";
 import { CategoryModel } from "@/modules/categories/category.model.js";
 import { CategoryRepository } from "@/modules/categories/category.repository.js";
 import type { CategoryService } from "@/modules/categories/category.service.js";
@@ -47,6 +51,7 @@ export interface AppServices {
   recipeRating: RecipeRatingService;
   category: CategoryService;
   review: ReviewService;
+  refreshSession: RefreshSessionService;
 
   recipeCache: CacheService;
   categoryCache: CacheService;
@@ -67,6 +72,9 @@ export function createServices(
   const userRepository = new UserRepository(UserModel);
   const recipeRepository = new RecipeRepository(RecipeModel);
   const reviewRepository = new ReviewRepository(ReviewModel);
+  const refreshSessionRepository = new RefreshSessionRepository(
+    RefreshSessionModel,
+  );
 
   const recipeCache = createNamespacedCache("recipes", cache);
   const categoryCache = createNamespacedCache("categories", cache);
@@ -117,6 +125,9 @@ export function createServices(
     userRepository,
     reviewCache,
   );
+  const refreshSessionService = createRefreshSessionService(
+    refreshSessionRepository,
+  );
   const authService = createAuthService(userRepository, passwordService, log);
 
   return {
@@ -129,6 +140,7 @@ export function createServices(
     recipeRating: recipeRatingService,
     category: categoryService,
     review: reviewService,
+    refreshSession: refreshSessionService,
 
     recipeCache,
     categoryCache,

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -1,4 +1,5 @@
 import "dotenv/config";
+import fastifyCookie from "@fastify/cookie";
 import fastifyCors from "@fastify/cors";
 import fastifyHelmet from "@fastify/helmet";
 import fastifyRateLimit from "@fastify/rate-limit";
@@ -57,12 +58,15 @@ export async function buildApp(log: Logger) {
   app.setErrorHandler(errorHandler);
 
   // CORS
-  app.register(fastifyCors, { origin: true });
+  app.register(fastifyCors, { origin: true, credentials: true });
 
   // Security headers
   app.register(fastifyHelmet, {
     contentSecurityPolicy: false,
   });
+
+  // Cookies
+  app.register(fastifyCookie);
 
   // Rate limiting
   app.register(fastifyRateLimit, createRateLimitOptions());
@@ -109,6 +113,7 @@ export async function buildApp(log: Logger) {
   // Routes
   app.register(authRoutes, {
     service: services.auth,
+    refreshSession: services.refreshSession,
     prefix: "/api/auth",
   });
   app.register(userRoutes, {

--- a/apps/backend/src/common/middleware/auth.guard.test.ts
+++ b/apps/backend/src/common/middleware/auth.guard.test.ts
@@ -65,7 +65,7 @@ describe("auth.guard", () => {
   describe("assertAuthenticated", () => {
     it("should not throw when user is present", () => {
       const request = createMockRequest({
-        user: { userId: "123", email: "test@test.com", role: "user" },
+        user: { id: "123", email: "test@test.com", role: "user" },
       });
 
       expect(() => assertAuthenticated(request)).not.toThrow();
@@ -81,7 +81,7 @@ describe("auth.guard", () => {
   describe("authGuard", () => {
     it("should set request.user on valid token", async () => {
       const payload = {
-        userId: "123",
+        id: "123",
         email: "test@test.com",
         role: "user",
       } satisfies JwtPayload;
@@ -129,7 +129,7 @@ describe("auth.guard", () => {
 
     it("should call authGuard when authorization header is present", async () => {
       const payload = {
-        userId: "123",
+        id: "123",
         email: "test@test.com",
         role: "user",
       } satisfies JwtPayload;

--- a/apps/backend/src/common/middleware/role.guard.test.ts
+++ b/apps/backend/src/common/middleware/role.guard.test.ts
@@ -18,7 +18,7 @@ describe("rolesGuard", () => {
   it("should pass when user has the required role", async () => {
     const request = createMockRequest();
     request.user = {
-      userId: "123",
+      id: "123",
       email: "admin@test.com",
       role: "admin",
     };
@@ -32,7 +32,7 @@ describe("rolesGuard", () => {
   it("should throw ForbiddenError when user lacks the required role", async () => {
     const request = createMockRequest({
       user: {
-        userId: "123",
+        id: "123",
         email: "user@test.com",
         role: "user",
       },
@@ -48,7 +48,7 @@ describe("rolesGuard", () => {
   it("should pass when user has any of multiple allowed roles", async () => {
     const request = createMockRequest({
       user: {
-        userId: "123",
+        id: "123",
         email: "user@test.com",
         role: "user",
       },

--- a/apps/backend/src/common/utils/jwt.test.ts
+++ b/apps/backend/src/common/utils/jwt.test.ts
@@ -12,7 +12,7 @@ vi.mock("@/config/env.js", () => ({
 
 describe("jwt utils", () => {
   const payload = {
-    userId: "507f1f77bcf86cd799439011",
+    id: "507f1f77bcf86cd799439011",
     email: "test@example.com",
     role: "user",
   } satisfies JwtPayload;
@@ -21,7 +21,7 @@ describe("jwt utils", () => {
     it("should return a JWT string", () => {
       const token = signToken(payload);
 
-      expect(typeof token).toBe("string");
+      expect(token).toBeTypeOf("string");
       expect(token.split(".")).toHaveLength(3);
     });
 
@@ -38,7 +38,7 @@ describe("jwt utils", () => {
       const token = signToken(payload);
       const decoded = verifyToken(token);
 
-      expect(decoded.userId).toBe(payload.userId);
+      expect(decoded.id).toBe(payload.id);
       expect(decoded.email).toBe(payload.email);
       expect(decoded.role).toBe(payload.role);
     });

--- a/apps/backend/src/common/utils/jwt.ts
+++ b/apps/backend/src/common/utils/jwt.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import type { Prettify, UserRole } from "@recipes/shared";
 import type { JwtPayload as _JwtPayload } from "jsonwebtoken";
 import jwt from "jsonwebtoken";
@@ -22,4 +23,12 @@ export function verifyToken(token: string): JwtPayload {
   return jwt.verify(token, env.JWT_SECRET, {
     algorithms: ["HS256"],
   }) as JwtPayload;
+}
+
+export function generateOpaqueToken() {
+  return crypto.randomBytes(48).toString("base64url");
+}
+
+export function hashToken(token: string) {
+  return crypto.createHash("sha256").update(token).digest("hex");
 }

--- a/apps/backend/src/common/utils/jwt.ts
+++ b/apps/backend/src/common/utils/jwt.ts
@@ -1,20 +1,25 @@
-import type { UserRole } from "@recipes/shared";
+import type { Prettify, UserRole } from "@recipes/shared";
+import type { JwtPayload as _JwtPayload } from "jsonwebtoken";
 import jwt from "jsonwebtoken";
 import type { StringValue } from "ms";
 import { env } from "@/config/env.js";
 
-export interface JwtPayload {
-  userId: string;
+export type JwtPayload = Prettify<_JwtPayload> & {
+  id: string;
   email: string;
   role: UserRole;
-}
+};
 
 export function signToken(payload: JwtPayload): string {
-  return jwt.sign(payload, env.JWT_SECRET, {
+  return jwt.sign({ ...payload }, env.JWT_SECRET, {
+    algorithm: "HS256",
     expiresIn: env.JWT_EXPIRES_IN as StringValue,
+    subject: payload.id,
   });
 }
 
 export function verifyToken(token: string): JwtPayload {
-  return jwt.verify(token, env.JWT_SECRET) as JwtPayload;
+  return jwt.verify(token, env.JWT_SECRET, {
+    algorithms: ["HS256"],
+  }) as JwtPayload;
 }

--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -9,7 +9,8 @@ const envSchema = z
     HOST: z.string().default("0.0.0.0"),
     MONGO_URI: z.string(),
     JWT_SECRET: z.string(),
-    JWT_EXPIRES_IN: z.string().default("7d"),
+    JWT_EXPIRES_IN: z.string().default("15m"),
+    SESSION_EXPIRES_IN_DAYS: z.coerce.number().default(7),
     BCRYPT_SALT_ROUNDS: z.coerce.number().default(10),
     RATE_LIMIT_AUTH_MAX: z.coerce.number().default(5),
     RATE_LIMIT_AUTH_WINDOW: z.string().default("3 minutes"),
@@ -48,6 +49,22 @@ if (!parsed.success) {
     z.treeifyError(parsed.error),
   );
   process.exit(1);
+}
+
+export function getEnvKey<S extends z.ZodType, K extends keyof z.infer<S>>(
+  schema: S,
+  key: K,
+): z.infer<S>[K] {
+  const parsed = schema.safeParse(process.env);
+  if (!parsed.success) {
+    console.error(
+      "❌ Invalid environment variables:",
+      z.treeifyError(parsed.error),
+    );
+    process.exit(1);
+  }
+
+  return parsed.data[key];
 }
 
 export const env = parsed.data;

--- a/apps/backend/src/modules/auth/auth.routes.test.ts
+++ b/apps/backend/src/modules/auth/auth.routes.test.ts
@@ -198,4 +198,130 @@ describe("authRoutes", () => {
       expect(response.statusCode).toBe(401);
     });
   });
+
+  describe("POST /api/auth/refresh", () => {
+    it("should refresh session and return new access token with cookie", async () => {
+      const refreshExpiry = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+      mockRefreshSessionService.refresh.mockResolvedValue({
+        user: {
+          id: "507f1f77bcf86cd799439011",
+          email: "user@test.com",
+          name: "User",
+          createdAt: "2024-01-01T00:00:00.000Z",
+          updatedAt: "2024-01-01T00:00:00.000Z",
+        },
+        accessToken: "new-access-token",
+        refreshToken: "new-refresh-token",
+        expiresAt: refreshExpiry,
+      });
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/auth/refresh",
+        cookies: {
+          "refresh-token": "old-refresh-token",
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.headers["set-cookie"]).toContain(
+        "refresh-token=new-refresh-token",
+      );
+      expect(mockRefreshSessionService.refresh).toHaveBeenCalledWith(
+        "old-refresh-token",
+        expect.objectContaining({
+          ip: "127.0.0.1",
+          userAgent: "lightMyRequest",
+        }),
+      );
+      const body = JSON.parse(response.payload);
+      expect(body.user.email).toBe("user@test.com");
+      expect(body.token).toBe("new-access-token");
+    });
+
+    it("should return 401 when refresh cookie is missing", async () => {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/auth/refresh",
+      });
+
+      expect(response.statusCode).toBe(401);
+      const body = JSON.parse(response.payload);
+      expect(body.error).toBe("Invalid or expired token");
+      expect(mockRefreshSessionService.refresh).not.toHaveBeenCalled();
+    });
+
+    it("should return 401 when refresh service throws UnauthorizedError", async () => {
+      mockRefreshSessionService.refresh.mockRejectedValue(
+        new UnauthorizedError("Refresh token expired"),
+      );
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/auth/refresh",
+        cookies: {
+          "refresh-token": "expired-token",
+        },
+      });
+
+      expect(response.statusCode).toBe(401);
+      const body = JSON.parse(response.payload);
+      expect(body.error).toBe("Refresh token expired");
+    });
+  });
+
+  describe("POST /api/auth/logout", () => {
+    it("should logout and clear refresh cookie", async () => {
+      mockRefreshSessionService.logout.mockResolvedValue(undefined);
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/auth/logout",
+        cookies: {
+          "refresh-token": "valid-refresh-token",
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.headers["set-cookie"]).toContain("refresh-token=;");
+      expect(mockRefreshSessionService.logout).toHaveBeenCalledWith(
+        "valid-refresh-token",
+      );
+      const body = JSON.parse(response.payload);
+      expect(body.success).toBe(true);
+    });
+
+    it("should return 200 even without refresh cookie", async () => {
+      mockRefreshSessionService.logout.mockResolvedValue(undefined);
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/auth/logout",
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(mockRefreshSessionService.logout).toHaveBeenCalledWith(undefined);
+      const body = JSON.parse(response.payload);
+      expect(body.success).toBe(true);
+    });
+
+    it("should return 200 when token not found or already revoked", async () => {
+      mockRefreshSessionService.logout.mockResolvedValue(undefined);
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/auth/logout",
+        cookies: {
+          "refresh-token": "unknown-token",
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(mockRefreshSessionService.logout).toHaveBeenCalledWith(
+        "unknown-token",
+      );
+      const body = JSON.parse(response.payload);
+      expect(body.success).toBe(true);
+    });
+  });
 });

--- a/apps/backend/src/modules/auth/auth.routes.test.ts
+++ b/apps/backend/src/modules/auth/auth.routes.test.ts
@@ -154,7 +154,7 @@ describe("authRoutes", () => {
       const response = await app.inject({
         method: "POST",
         url: "/api/auth/login",
-        payload: { email: "wrong@test.com", password: "wrong" },
+        payload: { email: "wrong@test.com", password: "wrong10" },
       });
 
       expect(response.statusCode).toBe(401);

--- a/apps/backend/src/modules/auth/auth.routes.test.ts
+++ b/apps/backend/src/modules/auth/auth.routes.test.ts
@@ -15,6 +15,11 @@ describe("authRoutes", () => {
     register: vi.fn(),
     login: vi.fn(),
   };
+  const mockRefreshSessionService = {
+    create: vi.fn(),
+    refresh: vi.fn(),
+    logout: vi.fn(),
+  };
 
   let app: FastifyInstance;
 
@@ -23,12 +28,14 @@ describe("authRoutes", () => {
     app = await createTestApp();
     await app.register(authRoutes, {
       service: mockAuthService,
+      refreshSession: mockRefreshSessionService,
       prefix: "/api/auth",
     });
   });
 
   describe("POST /api/auth/register", () => {
     it("should register a new user and return 201", async () => {
+      const userId = "507f1f77bcf86cd799439011";
       const payload = {
         email: "new@test.com",
         password: "Password123!",
@@ -36,13 +43,18 @@ describe("authRoutes", () => {
       };
       mockAuthService.register.mockResolvedValue({
         user: {
-          id: "507f1f77bcf86cd799439011",
+          id: userId,
           email: payload.email,
           name: payload.name,
           createdAt: "2024-01-01T00:00:00.000Z",
           updatedAt: "2024-01-01T00:00:00.000Z",
         },
         token: "mock-jwt-token",
+      });
+      const refreshExpiry = new Date(Date.now() + 15 * 60 * 1000);
+      mockRefreshSessionService.create.mockResolvedValue({
+        refreshToken: "mock-refresh-token",
+        expiresAt: refreshExpiry,
       });
 
       const response = await app.inject({
@@ -52,7 +64,17 @@ describe("authRoutes", () => {
       });
 
       expect(response.statusCode).toBe(201);
+      expect(response.headers["set-cookie"]).toContain(
+        "refresh-token=mock-refresh-token",
+      );
       expect(mockAuthService.register).toHaveBeenCalledWith(payload);
+      expect(mockRefreshSessionService.create).toHaveBeenCalledWith(
+        userId,
+        expect.objectContaining({
+          ip: "127.0.0.1",
+          userAgent: "lightMyRequest",
+        }),
+      );
       const body = JSON.parse(response.payload);
       expect(body.user.email).toBe(payload.email);
       expect(body.token).toBe("mock-jwt-token");
@@ -107,15 +129,21 @@ describe("authRoutes", () => {
 
   describe("POST /api/auth/login", () => {
     it("should login and return 200 with token", async () => {
+      const userId = "507f1f77bcf86cd799439011";
       mockAuthService.login.mockResolvedValue({
         user: {
-          id: "507f1f77bcf86cd799439011",
+          id: userId,
           email: "user@test.com",
           name: "User",
           createdAt: "2024-01-01T00:00:00.000Z",
           updatedAt: "2024-01-01T00:00:00.000Z",
         },
         token: "mock-jwt-token",
+      });
+      const refreshExpiry = new Date(Date.now() + 15 * 60 * 1000);
+      mockRefreshSessionService.create.mockResolvedValue({
+        refreshToken: "mock-refresh-token",
+        expiresAt: refreshExpiry,
       });
 
       const response = await app.inject({
@@ -125,10 +153,20 @@ describe("authRoutes", () => {
       });
 
       expect(response.statusCode).toBe(200);
+      expect(response.headers["set-cookie"]).toContain(
+        "refresh-token=mock-refresh-token",
+      );
       expect(mockAuthService.login).toHaveBeenCalledWith({
         email: "user@test.com",
         password: "correct-password",
       });
+      expect(mockRefreshSessionService.create).toHaveBeenCalledWith(
+        userId,
+        expect.objectContaining({
+          ip: "127.0.0.1",
+          userAgent: "lightMyRequest",
+        }),
+      );
       const body = JSON.parse(response.payload);
       expect(body.user.email).toBe("user@test.com");
       expect(body.token).toBe("mock-jwt-token");

--- a/apps/backend/src/modules/auth/auth.routes.ts
+++ b/apps/backend/src/modules/auth/auth.routes.ts
@@ -3,18 +3,23 @@ import {
   loginInputSchema,
   registerInputSchema,
 } from "@recipes/shared";
-import type { FastifyPluginAsync } from "fastify";
+import type { FastifyPluginAsync, FastifyReply } from "fastify";
 import type { ZodTypeProvider } from "fastify-type-provider-zod";
 import { env } from "@/config/env.js";
 import type { AuthService } from "@/modules/auth/auth.service.js";
+import type { RefreshSessionService } from "./refresh-session.service.js";
 
 export interface AuthModuleOptions {
   service: AuthService;
+  refreshSession: RefreshSessionService;
 }
+
+const REFRESH_COOKIE_NAME =
+  env.NODE_ENV === "production" ? "__Host-refresh-token" : "refresh-token";
 
 export const authRoutes: FastifyPluginAsync<AuthModuleOptions> = async (
   fastify,
-  { service },
+  { service, refreshSession },
 ) => {
   fastify
     .withTypeProvider<ZodTypeProvider>()
@@ -38,6 +43,12 @@ export const authRoutes: FastifyPluginAsync<AuthModuleOptions> = async (
       },
       async (request, reply) => {
         const result = await service.register(request.body);
+        const refreshResult = await refreshSession.create(result.user.id, {
+          ip: request.ip,
+          userAgent: request.headers["user-agent"] ?? null,
+        });
+
+        setRefreshCookie(reply, refreshResult);
         return reply.status(201).send(result);
       },
     )
@@ -61,7 +72,26 @@ export const authRoutes: FastifyPluginAsync<AuthModuleOptions> = async (
       },
       async (request, reply) => {
         const result = await service.login(request.body);
+        const refreshResult = await refreshSession.create(result.user.id, {
+          ip: request.ip,
+          userAgent: request.headers["user-agent"] ?? null,
+        });
+
+        setRefreshCookie(reply, refreshResult);
         return reply.status(200).send(result);
       },
     );
 };
+
+function setRefreshCookie(
+  reply: FastifyReply,
+  session: { token: string; expiresAt: Date },
+) {
+  reply.cookie(REFRESH_COOKIE_NAME, session.token, {
+    path: "/",
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    expires: session.expiresAt,
+  });
+}

--- a/apps/backend/src/modules/auth/auth.routes.ts
+++ b/apps/backend/src/modules/auth/auth.routes.ts
@@ -5,6 +5,7 @@ import {
 } from "@recipes/shared";
 import type { FastifyPluginAsync, FastifyReply } from "fastify";
 import type { ZodTypeProvider } from "fastify-type-provider-zod";
+import z from "zod";
 import { UnauthorizedError } from "@/common/errors.js";
 import { env } from "@/config/env.js";
 import type { AuthService } from "@/modules/auth/auth.service.js";
@@ -118,6 +119,27 @@ export const authRoutes: FastifyPluginAsync<AuthModuleOptions> = async (
           token: result.accessToken,
         });
       },
+    )
+    .post(
+      "/logout",
+      {
+        schema: {
+          response: {
+            200: z.object({
+              success: z.literal(true),
+            }),
+          },
+          tags: ["Auth"],
+          summary: "Logout current session",
+        },
+      },
+      async (request, reply) => {
+        const refreshToken = request.cookies[REFRESH_COOKIE_NAME];
+        await refreshSession.logout(refreshToken);
+
+        clearRefreshCookie(reply);
+        return reply.status(200).send({ success: true });
+      },
     );
 };
 
@@ -128,7 +150,7 @@ function setRefreshCookie(
   reply.cookie(REFRESH_COOKIE_NAME, session.token, {
     path: "/",
     httpOnly: true,
-    secure: process.env.NODE_ENV === "production",
+    secure: env.NODE_ENV === "production",
     sameSite: "lax",
     expires: session.expiresAt,
   });

--- a/apps/backend/src/modules/auth/auth.routes.ts
+++ b/apps/backend/src/modules/auth/auth.routes.ts
@@ -5,6 +5,7 @@ import {
 } from "@recipes/shared";
 import type { FastifyPluginAsync, FastifyReply } from "fastify";
 import type { ZodTypeProvider } from "fastify-type-provider-zod";
+import { UnauthorizedError } from "@/common/errors.js";
 import { env } from "@/config/env.js";
 import type { AuthService } from "@/modules/auth/auth.service.js";
 import type { RefreshSessionService } from "./refresh-session.service.js";
@@ -48,7 +49,10 @@ export const authRoutes: FastifyPluginAsync<AuthModuleOptions> = async (
           userAgent: request.headers["user-agent"] ?? null,
         });
 
-        setRefreshCookie(reply, refreshResult);
+        setRefreshCookie(reply, {
+          token: refreshResult.refreshToken,
+          expiresAt: refreshResult.expiresAt,
+        });
         return reply.status(201).send(result);
       },
     )
@@ -77,8 +81,42 @@ export const authRoutes: FastifyPluginAsync<AuthModuleOptions> = async (
           userAgent: request.headers["user-agent"] ?? null,
         });
 
-        setRefreshCookie(reply, refreshResult);
+        setRefreshCookie(reply, {
+          token: refreshResult.refreshToken,
+          expiresAt: refreshResult.expiresAt,
+        });
         return reply.status(200).send(result);
+      },
+    )
+    .post(
+      "/refresh",
+      {
+        schema: {
+          response: {
+            200: authResponseSchema,
+          },
+          tags: ["Auth"],
+          summary: "Refresh a session",
+        },
+      },
+      async (request, reply) => {
+        const refreshToken = request.cookies[REFRESH_COOKIE_NAME];
+        if (!refreshToken)
+          throw new UnauthorizedError("Invalid or expired token");
+
+        const result = await refreshSession.refresh(refreshToken, {
+          ip: request.ip,
+          userAgent: request.headers["user-agent"] ?? null,
+        });
+
+        setRefreshCookie(reply, {
+          token: result.refreshToken,
+          expiresAt: result.expiresAt,
+        });
+        return reply.status(200).send({
+          user: result.user,
+          token: result.accessToken,
+        });
       },
     );
 };
@@ -93,5 +131,14 @@ function setRefreshCookie(
     secure: process.env.NODE_ENV === "production",
     sameSite: "lax",
     expires: session.expiresAt,
+  });
+}
+
+export function clearRefreshCookie(reply: FastifyReply) {
+  reply.clearCookie(REFRESH_COOKIE_NAME, {
+    path: "/",
+    httpOnly: true,
+    secure: env.NODE_ENV === "production",
+    sameSite: "lax",
   });
 }

--- a/apps/backend/src/modules/auth/auth.service.ts
+++ b/apps/backend/src/modules/auth/auth.service.ts
@@ -41,11 +41,6 @@ export function createAuthService(
         role: user.role,
       });
 
-      log.info(
-        { userId: user._id.toString(), email: user.email },
-        "User registered",
-      );
-
       return {
         user: toUserDetails(user),
         token,
@@ -69,11 +64,6 @@ export function createAuthService(
         email: user.email,
         role: user.role,
       });
-
-      log.info(
-        { userId: user._id.toString(), email: user.email },
-        "User logged in",
-      );
 
       return {
         user: toUserDetails(user),

--- a/apps/backend/src/modules/auth/auth.service.ts
+++ b/apps/backend/src/modules/auth/auth.service.ts
@@ -36,7 +36,7 @@ export function createAuthService(
         password,
       });
       const token = signToken({
-        userId: user._id.toString(),
+        id: user._id.toString(),
         email: user.email,
         role: user.role,
       });
@@ -65,7 +65,7 @@ export function createAuthService(
       }
 
       const token = signToken({
-        userId: user._id.toString(),
+        id: user._id.toString(),
         email: user.email,
         role: user.role,
       });

--- a/apps/backend/src/modules/auth/refresh-session.model.ts
+++ b/apps/backend/src/modules/auth/refresh-session.model.ts
@@ -71,7 +71,7 @@ const refreshSessionSchema = new Schema<
       default: null,
     },
     replacedBy: {
-      type: String,
+      type: Schema.Types.ObjectId,
       default: null,
     },
     userAgent: {

--- a/apps/backend/src/modules/auth/refresh-session.model.ts
+++ b/apps/backend/src/modules/auth/refresh-session.model.ts
@@ -1,0 +1,93 @@
+import type { Model, Types } from "mongoose";
+import { model, Schema } from "mongoose";
+import type { BaseDocumentWithoutUpdate } from "@/common/types/mongoose.js";
+
+export const revokeReasons = [
+  "logout",
+  "reuse-detected",
+  "admin",
+  "expired",
+] as const;
+export type RevokeReason = (typeof revokeReasons)[number];
+
+export interface RefreshSessionDocument extends BaseDocumentWithoutUpdate {
+  user: Types.ObjectId;
+  familyId: string;
+  tokenHash: string;
+
+  expiresAt: Date;
+  lastUsedAt: Date | null;
+
+  rotatedAt: Date | null;
+  replacedBy: Types.ObjectId | null;
+
+  revokedAt: Date | null;
+  revokeReason: RevokeReason | null;
+
+  userAgent: string | null;
+  ip: string | null;
+}
+
+export interface RefreshSessionModelType
+  extends Model<RefreshSessionDocument> {}
+
+const refreshSessionSchema = new Schema<
+  RefreshSessionDocument,
+  RefreshSessionModelType
+>(
+  {
+    user: {
+      type: Schema.Types.ObjectId,
+      required: true,
+    },
+    familyId: {
+      type: String,
+      required: true,
+    },
+    tokenHash: {
+      type: String,
+      required: true,
+    },
+    expiresAt: {
+      type: Date,
+      required: true,
+    },
+    lastUsedAt: {
+      type: Date,
+      default: null,
+    },
+    revokedAt: {
+      type: Date,
+      default: null,
+    },
+    revokeReason: {
+      type: String,
+      enum: [...revokeReasons, null],
+      default: null,
+    },
+    replacedBy: {
+      type: String,
+      default: null,
+    },
+    userAgent: {
+      type: String,
+      default: null,
+    },
+    ip: {
+      type: String,
+      default: null,
+    },
+  },
+  {
+    timestamps: { createdAt: true, updatedAt: false },
+    collection: "refreshSessions",
+  },
+);
+
+export const RefreshSessionModel = model<
+  RefreshSessionDocument,
+  RefreshSessionModelType
+>("RefreshSession", refreshSessionSchema);
+
+export const refreshSessionsCollectionName =
+  RefreshSessionModel.collection.name;

--- a/apps/backend/src/modules/auth/refresh-session.model.ts
+++ b/apps/backend/src/modules/auth/refresh-session.model.ts
@@ -7,6 +7,7 @@ export const revokeReasons = [
   "reuse-detected",
   "admin",
   "expired",
+  "user-not-found",
 ] as const;
 export type RevokeReason = (typeof revokeReasons)[number];
 

--- a/apps/backend/src/modules/auth/refresh-session.model.ts
+++ b/apps/backend/src/modules/auth/refresh-session.model.ts
@@ -66,6 +66,10 @@ const refreshSessionSchema = new Schema<
       enum: [...revokeReasons, null],
       default: null,
     },
+    rotatedAt: {
+      type: Date,
+      default: null,
+    },
     replacedBy: {
       type: String,
       default: null,

--- a/apps/backend/src/modules/auth/refresh-session.model.ts
+++ b/apps/backend/src/modules/auth/refresh-session.model.ts
@@ -8,6 +8,7 @@ export const revokeReasons = [
   "admin",
   "expired",
   "user-not-found",
+  "rotation-conflict",
 ] as const;
 export type RevokeReason = (typeof revokeReasons)[number];
 
@@ -48,7 +49,6 @@ const refreshSessionSchema = new Schema<
     tokenHash: {
       type: String,
       required: true,
-      unique: true,
     },
     expiresAt: {
       type: Date,

--- a/apps/backend/src/modules/auth/refresh-session.model.ts
+++ b/apps/backend/src/modules/auth/refresh-session.model.ts
@@ -48,6 +48,7 @@ const refreshSessionSchema = new Schema<
     tokenHash: {
       type: String,
       required: true,
+      unique: true,
     },
     expiresAt: {
       type: Date,
@@ -88,6 +89,10 @@ const refreshSessionSchema = new Schema<
     collection: "refreshSessions",
   },
 );
+
+refreshSessionSchema.index({ tokenHash: 1 }, { unique: true });
+refreshSessionSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+refreshSessionSchema.index({ familyId: 1 });
 
 export const RefreshSessionModel = model<
   RefreshSessionDocument,

--- a/apps/backend/src/modules/auth/refresh-session.repository.int.test.ts
+++ b/apps/backend/src/modules/auth/refresh-session.repository.int.test.ts
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { createDbUser } from "@/__tests__/db-factories.js";
+import { createObjectId } from "@/__tests__/helpers.js";
+import { RefreshSessionModel } from "./refresh-session.model.js";
+import { RefreshSessionRepository } from "./refresh-session.repository.js";
+
+describe("RefreshSessionRepository", () => {
+  const repository = new RefreshSessionRepository(RefreshSessionModel);
+
+  beforeEach(async () => {
+    await RefreshSessionModel.deleteMany({});
+  });
+
+  describe("create", () => {
+    it("should create a refresh session", async () => {
+      const user = await createDbUser();
+      const session = await repository.create({
+        user: user._id,
+        familyId: "test-family",
+        tokenHash: "abc123",
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      });
+
+      expect(session.user.toString()).toBe(user._id.toString());
+      expect(session.tokenHash).toBe("abc123");
+      expect(session.familyId).toBe("test-family");
+      expect(session.revokedAt).toBeNull();
+      expect(session.rotatedAt).toBeNull();
+    });
+  });
+
+  describe("findByTokenHash", () => {
+    it("should find a session by token hash", async () => {
+      const session = await repository.create({
+        user: createObjectId(),
+        familyId: "fam-1",
+        tokenHash: "find-me",
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      });
+
+      const found = await repository.findByTokenHash("find-me");
+
+      expect(found).not.toBeNull();
+      expect(found?._id.toString()).toBe(session._id.toString());
+    });
+
+    it("should return null for non-existing token hash", async () => {
+      const found = await repository.findByTokenHash("does-not-exist");
+
+      expect(found).toBeNull();
+    });
+  });
+
+  describe("markRotated", () => {
+    it("should mark session as rotated with replacedBy", async () => {
+      const session = await repository.create({
+        user: createObjectId(),
+        familyId: "fam-1",
+        tokenHash: "hash-1",
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      });
+      const newSessionId = createObjectId();
+
+      const rotated = await repository.markRotated(session._id, {
+        replacedBy: newSessionId,
+      });
+
+      expect(rotated).not.toBeNull();
+      expect(rotated?.rotatedAt).not.toBeNull();
+      expect(rotated?.lastUsedAt).not.toBeNull();
+      expect(rotated?.replacedBy?.toString()).toBe(newSessionId.toString());
+    });
+
+    it("should return null for already rotated session (concurrent access)", async () => {
+      const session = await repository.create({
+        user: createObjectId(),
+        familyId: "fam-1",
+        tokenHash: "hash-1",
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      });
+      const firstId = createObjectId();
+      const secondId = createObjectId();
+
+      await repository.markRotated(session._id, { replacedBy: firstId });
+      const second = await repository.markRotated(session._id, {
+        replacedBy: secondId,
+      });
+
+      expect(second).toBeNull();
+    });
+  });
+
+  describe("rotate", () => {
+    it("should create new session and mark old as rotated", async () => {
+      const user = await createDbUser();
+      const oldSession = await repository.create({
+        user: user._id,
+        familyId: "family-1",
+        tokenHash: "old-hash",
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      });
+
+      const newSession = await repository.rotate(oldSession, {
+        tokenHash: "new-hash",
+      });
+
+      expect(newSession).not.toBeNull();
+      expect(newSession?.tokenHash).toBe("new-hash");
+      expect(newSession?.familyId).toBe("family-1");
+      expect(newSession?.user.toString()).toBe(user._id.toString());
+
+      const updated = await RefreshSessionModel.findById(oldSession._id).lean();
+      expect(updated?.rotatedAt).not.toBeNull();
+      expect(updated?.lastUsedAt).not.toBeNull();
+      expect(updated?.replacedBy?.toString()).toBe(newSession?._id.toString());
+    });
+  });
+
+  describe("revokeById", () => {
+    it("should revoke a session by id", async () => {
+      const session = await repository.create({
+        user: createObjectId(),
+        familyId: "fam-1",
+        tokenHash: "hash-1",
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      });
+
+      await repository.revokeById(session._id, "logout");
+
+      const updated = await RefreshSessionModel.findById(session._id).lean();
+      expect(updated?.revokedAt).not.toBeNull();
+      expect(updated?.revokeReason).toBe("logout");
+    });
+  });
+
+  describe("revokeFamily", () => {
+    it("should revoke all sessions in a family", async () => {
+      const user = await createDbUser();
+      const familyId = "family-revoke";
+
+      await repository.create({
+        user: user._id,
+        familyId,
+        tokenHash: "hash-1",
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      });
+      await repository.create({
+        user: user._id,
+        familyId,
+        tokenHash: "hash-2",
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      });
+
+      await repository.revokeFamily(familyId, "reuse-detected");
+
+      const sessions = await RefreshSessionModel.find({ familyId }).lean();
+      expect(sessions).toHaveLength(2);
+      for (const s of sessions) {
+        expect(s.revokedAt).not.toBeNull();
+        expect(s.revokeReason).toBe("reuse-detected");
+      }
+    });
+  });
+});

--- a/apps/backend/src/modules/auth/refresh-session.repository.ts
+++ b/apps/backend/src/modules/auth/refresh-session.repository.ts
@@ -1,8 +1,11 @@
 import type { RequireKeys } from "@recipes/shared";
-import type { ObjectId, QueryFilter } from "mongoose";
+import type { Types } from "mongoose";
 import type { CreateInput, UpdateInput } from "@/common/base.repository.js";
 import { BaseRepository } from "@/common/base.repository.js";
-import type { RefreshSessionDocument } from "./refresh-session.model.js";
+import type {
+  RefreshSessionDocument,
+  RevokeReason,
+} from "./refresh-session.model.js";
 
 export type RefreshSessionCreateInput = RequireKeys<
   CreateInput<
@@ -37,20 +40,43 @@ export class RefreshSessionRepository extends BaseRepository<
   RefreshSessionCreateInput,
   RefreshSessionUpdateInput
 > {
-  async updateMany(
-    filter: QueryFilter<RefreshSessionDocument>,
-    data: RefreshSessionUpdateInput,
-  ) {
-    return this.model.updateMany(filter, data);
+  async findByTokenHash(
+    tokenHash: string,
+  ): Promise<RefreshSessionDocument | null> {
+    return this.model.findOne({ tokenHash }).lean();
   }
 
-  async rotateById(id: ObjectId, newSession: RefreshSessionDocument) {
+  async rotateById(
+    id: Types.ObjectId,
+    data: { replacedBy: Types.ObjectId },
+  ): Promise<RefreshSessionDocument | null> {
     return this.model
       .findByIdAndUpdate(id, {
         lastUsedAt: new Date(),
         rotatedAt: new Date(),
-        replacedBySessionId: newSession._id,
+        replacedBy: data.replacedBy,
       })
+      .lean();
+  }
+
+  async revokeById(id: Types.ObjectId, reason: RevokeReason): Promise<void> {
+    await this.model
+      .findByIdAndUpdate(id, {
+        revokedAt: new Date(),
+        revokeReason: reason,
+      })
+      .lean();
+  }
+
+  async revokeFamily(familyId: string, reason: RevokeReason): Promise<void> {
+    await this.model
+      .updateMany(
+        { familyId },
+        {
+          revokedAt: new Date(),
+          revokeReason: reason,
+        },
+      )
       .lean();
   }
 }

--- a/apps/backend/src/modules/auth/refresh-session.repository.ts
+++ b/apps/backend/src/modules/auth/refresh-session.repository.ts
@@ -54,10 +54,13 @@ export class RefreshSessionRepository extends BaseRepository<
       .findOneAndUpdate(
         { _id: id, rotatedAt: null, replacedBy: null, revokedAt: null },
         {
-          lastUsedAt: new Date(),
-          rotatedAt: new Date(),
-          replacedBy: data.replacedBy,
+          $set: {
+            lastUsedAt: new Date(),
+            rotatedAt: new Date(),
+            replacedBy: data.replacedBy,
+          },
         },
+        { returnDocument: "after", runValidators: true },
       )
       .lean();
   }
@@ -82,9 +85,14 @@ export class RefreshSessionRepository extends BaseRepository<
       userAgent: data.userAgent ?? null,
     });
 
-    await this.markRotated(session._id, {
+    const rotated = await this.markRotated(session._id, {
       replacedBy: newSession._id,
     });
+
+    if (!rotated) {
+      await this.revokeById(newSession._id, "rotation-conflict");
+      return null;
+    }
 
     return newSession;
   }

--- a/apps/backend/src/modules/auth/refresh-session.repository.ts
+++ b/apps/backend/src/modules/auth/refresh-session.repository.ts
@@ -46,17 +46,47 @@ export class RefreshSessionRepository extends BaseRepository<
     return this.model.findOne({ tokenHash }).lean();
   }
 
-  async rotateById(
+  async markRotated(
     id: Types.ObjectId,
     data: { replacedBy: Types.ObjectId },
   ): Promise<RefreshSessionDocument | null> {
     return this.model
-      .findByIdAndUpdate(id, {
-        lastUsedAt: new Date(),
-        rotatedAt: new Date(),
-        replacedBy: data.replacedBy,
-      })
+      .findOneAndUpdate(
+        { _id: id, rotatedAt: null, replacedBy: null, revokedAt: null },
+        {
+          lastUsedAt: new Date(),
+          rotatedAt: new Date(),
+          replacedBy: data.replacedBy,
+        },
+      )
       .lean();
+  }
+
+  async rotate(
+    session: Pick<
+      RefreshSessionDocument,
+      "_id" | "user" | "familyId" | "expiresAt"
+    >,
+    data: {
+      tokenHash: string;
+      ip?: string | null;
+      userAgent?: string | null;
+    },
+  ): Promise<RefreshSessionDocument | null> {
+    const newSession = await this.create({
+      user: session.user,
+      familyId: session.familyId,
+      tokenHash: data.tokenHash,
+      expiresAt: session.expiresAt,
+      ip: data.ip ?? null,
+      userAgent: data.userAgent ?? null,
+    });
+
+    await this.markRotated(session._id, {
+      replacedBy: newSession._id,
+    });
+
+    return newSession;
   }
 
   async revokeById(id: Types.ObjectId, reason: RevokeReason): Promise<void> {

--- a/apps/backend/src/modules/auth/refresh-session.repository.ts
+++ b/apps/backend/src/modules/auth/refresh-session.repository.ts
@@ -1,0 +1,56 @@
+import type { RequireKeys } from "@recipes/shared";
+import type { ObjectId, QueryFilter } from "mongoose";
+import type { CreateInput, UpdateInput } from "@/common/base.repository.js";
+import { BaseRepository } from "@/common/base.repository.js";
+import type { RefreshSessionDocument } from "./refresh-session.model.js";
+
+export type RefreshSessionCreateInput = RequireKeys<
+  CreateInput<
+    Omit<
+      RefreshSessionDocument,
+      | "lastUsedAt"
+      | "rotatedAt"
+      | "replacedBy"
+      | "revokedAt"
+      | "revokeReason"
+      | "createdAt"
+    >
+  >,
+  "familyId" | "tokenHash" | "expiresAt"
+>;
+
+export type RefreshSessionUpdateInput = UpdateInput<
+  Omit<
+    RefreshSessionDocument,
+    | "user"
+    | "familyId"
+    | "tokenHash"
+    | "expiresAt"
+    | "userAgent"
+    | "ip"
+    | "createdAt"
+  >
+>;
+
+export class RefreshSessionRepository extends BaseRepository<
+  RefreshSessionDocument,
+  RefreshSessionCreateInput,
+  RefreshSessionUpdateInput
+> {
+  async updateMany(
+    filter: QueryFilter<RefreshSessionDocument>,
+    data: RefreshSessionUpdateInput,
+  ) {
+    return this.model.updateMany(filter, data);
+  }
+
+  async rotateById(id: ObjectId, newSession: RefreshSessionDocument) {
+    return this.model
+      .findByIdAndUpdate(id, {
+        lastUsedAt: new Date(),
+        rotatedAt: new Date(),
+        replacedBySessionId: newSession._id,
+      })
+      .lean();
+  }
+}

--- a/apps/backend/src/modules/auth/refresh-session.service.test.ts
+++ b/apps/backend/src/modules/auth/refresh-session.service.test.ts
@@ -1,0 +1,335 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createObjectId,
+  createRefreshSessionDoc,
+  createUserDoc,
+} from "@/__tests__/helpers.js";
+import { UnauthorizedError } from "@/common/errors.js";
+import {
+  createRefreshSessionService,
+  exhaustiveCheck,
+  getRefreshSessionState,
+} from "./refresh-session.service.js";
+
+const { generateOpaqueToken, hashToken, signToken } = vi.hoisted(() => ({
+  generateOpaqueToken: vi.fn(),
+  hashToken: vi.fn(),
+  signToken: vi.fn(),
+}));
+
+vi.mock("@/common/utils/jwt.js", () => ({
+  generateOpaqueToken,
+  hashToken,
+  signToken,
+}));
+
+describe("createRefreshSessionService", () => {
+  const mockRefreshRepo = {
+    findByTokenHash: vi.fn(),
+    create: vi.fn(),
+    rotate: vi.fn(),
+    revokeById: vi.fn(),
+    revokeFamily: vi.fn(),
+  };
+  const mockUserRepo = {
+    findById: vi.fn(),
+  };
+  const service = createRefreshSessionService(mockRefreshRepo, mockUserRepo);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("create", () => {
+    it("should generate opaque token, hash it, store session and return raw token", async () => {
+      generateOpaqueToken.mockReturnValue("raw-opaque-token");
+      hashToken.mockReturnValue("hashed-token");
+      mockRefreshRepo.create.mockResolvedValue({ _id: "session-id" });
+
+      const result = await service.create("user-id", {
+        ip: "127.0.0.1",
+        userAgent: "Mozilla/5.0",
+      });
+
+      expect(generateOpaqueToken).toHaveBeenCalledTimes(1);
+      expect(hashToken).toHaveBeenCalledWith("raw-opaque-token");
+      expect(mockRefreshRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          user: "user-id",
+          tokenHash: "hashed-token",
+          ip: "127.0.0.1",
+          userAgent: "Mozilla/5.0",
+        }),
+      );
+      expect(result.refreshToken).toBe("raw-opaque-token");
+      expect(result.expiresAt).toBeInstanceOf(Date);
+    });
+  });
+
+  describe("refresh", () => {
+    it("should rotate session and return new tokens for valid refresh", async () => {
+      const user = createUserDoc({ email: "user@test.com" });
+      const session = createRefreshSessionDoc({
+        user: user._id,
+        familyId: "family-1",
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      });
+
+      hashToken
+        .mockReturnValueOnce("hashed-old")
+        .mockReturnValueOnce("hashed-new");
+      mockRefreshRepo.findByTokenHash.mockResolvedValue(session);
+      mockUserRepo.findById.mockResolvedValue(user);
+      generateOpaqueToken.mockReturnValue("new-raw-token");
+      mockRefreshRepo.rotate.mockResolvedValue({
+        _id: "new-session",
+        tokenHash: "hashed-new",
+      });
+      signToken.mockReturnValue("new-access-token");
+
+      const result = await service.refresh("old-raw-token", {
+        ip: "127.0.0.1",
+        userAgent: "Mozilla/5.0",
+      });
+
+      expect(mockRefreshRepo.findByTokenHash).toHaveBeenCalledWith(
+        "hashed-old",
+      );
+      expect(mockRefreshRepo.rotate).toHaveBeenCalledWith(
+        session,
+        expect.objectContaining({
+          tokenHash: "hashed-new",
+          ip: "127.0.0.1",
+          userAgent: "Mozilla/5.0",
+        }),
+      );
+      expect(signToken).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: user._id.toString(),
+          email: user.email,
+          role: user.role,
+        }),
+      );
+      expect(result.user.email).toBe("user@test.com");
+      expect(result.accessToken).toBe("new-access-token");
+      expect(result.refreshToken).toBe("new-raw-token");
+    });
+
+    it("should throw UnauthorizedError when token not found", async () => {
+      hashToken.mockReturnValue("unknown-hash");
+      mockRefreshRepo.findByTokenHash.mockResolvedValue(null);
+
+      await expect(service.refresh("unknown-token", {})).rejects.toThrow(
+        UnauthorizedError,
+      );
+      await expect(service.refresh("unknown-token", {})).rejects.toThrow(
+        "Invalid refresh token",
+      );
+    });
+
+    it("should throw UnauthorizedError when session is revoked", async () => {
+      const session = createRefreshSessionDoc({
+        revokedAt: new Date(),
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      });
+
+      hashToken.mockReturnValue("hashed");
+      mockRefreshRepo.findByTokenHash.mockResolvedValue(session);
+
+      await expect(service.refresh("token", {})).rejects.toThrow(
+        UnauthorizedError,
+      );
+      await expect(service.refresh("token", {})).rejects.toThrow(
+        "Refresh session revoked",
+      );
+    });
+
+    it("should revoke and throw when session is expired", async () => {
+      const session = createRefreshSessionDoc({
+        expiresAt: new Date(Date.now() - 1000),
+      });
+
+      hashToken.mockReturnValue("hashed");
+      mockRefreshRepo.findByTokenHash.mockResolvedValue(session);
+
+      await expect(service.refresh("token", {})).rejects.toThrow(
+        UnauthorizedError,
+      );
+      await expect(service.refresh("token", {})).rejects.toThrow(
+        "Refresh token expired",
+      );
+      expect(mockRefreshRepo.revokeById).toHaveBeenCalledWith(
+        session._id,
+        "expired",
+      );
+    });
+
+    it("should revoke family and throw when token is reused", async () => {
+      const session = createRefreshSessionDoc({
+        familyId: "family-1",
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+        rotatedAt: new Date(),
+      });
+
+      hashToken.mockReturnValue("hashed");
+      mockRefreshRepo.findByTokenHash.mockResolvedValue(session);
+
+      await expect(service.refresh("token", {})).rejects.toThrow(
+        UnauthorizedError,
+      );
+      await expect(service.refresh("token", {})).rejects.toThrow(
+        "Refresh token reuse detected",
+      );
+      expect(mockRefreshRepo.revokeFamily).toHaveBeenCalledWith(
+        "family-1",
+        "reuse-detected",
+      );
+    });
+
+    it("should revoke family and throw when user not found", async () => {
+      const session = createRefreshSessionDoc({
+        familyId: "family-1",
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      });
+
+      hashToken.mockReturnValue("hashed");
+      mockRefreshRepo.findByTokenHash.mockResolvedValue(session);
+      mockUserRepo.findById.mockResolvedValue(null);
+
+      await expect(service.refresh("token", {})).rejects.toThrow(
+        UnauthorizedError,
+      );
+      await expect(service.refresh("token", {})).rejects.toThrow(
+        "User not found",
+      );
+      expect(mockRefreshRepo.revokeFamily).toHaveBeenCalledWith(
+        "family-1",
+        "user-not-found",
+      );
+    });
+
+    it("should throw rotation conflict when rotate returns null", async () => {
+      const user = createUserDoc();
+      const session = createRefreshSessionDoc({
+        familyId: "family-1",
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      });
+
+      hashToken.mockReturnValue("hashed");
+      mockRefreshRepo.findByTokenHash.mockResolvedValue(session);
+      mockUserRepo.findById.mockResolvedValue(user);
+      generateOpaqueToken.mockReturnValue("new-token");
+      mockRefreshRepo.rotate.mockResolvedValue(null);
+
+      await expect(service.refresh("token", {})).rejects.toThrow(
+        UnauthorizedError,
+      );
+      await expect(service.refresh("token", {})).rejects.toThrow(
+        "Refresh token rotation conflict",
+      );
+    });
+  });
+
+  describe("logout", () => {
+    it("should revoke session when valid token provided", async () => {
+      const session = createRefreshSessionDoc({});
+
+      hashToken.mockReturnValue("hashed");
+      mockRefreshRepo.findByTokenHash.mockResolvedValue(session);
+
+      await service.logout("raw-token");
+
+      expect(mockRefreshRepo.revokeById).toHaveBeenCalledWith(
+        session._id,
+        "logout",
+      );
+    });
+
+    it("should do nothing when no token provided", async () => {
+      await service.logout();
+
+      expect(mockRefreshRepo.findByTokenHash).not.toHaveBeenCalled();
+    });
+
+    it("should do nothing when token not found", async () => {
+      hashToken.mockReturnValue("hashed");
+      mockRefreshRepo.findByTokenHash.mockResolvedValue(null);
+
+      await service.logout("unknown-token");
+
+      expect(mockRefreshRepo.revokeById).not.toHaveBeenCalled();
+    });
+
+    it("should do nothing when session already revoked", async () => {
+      const session = createRefreshSessionDoc({
+        revokedAt: new Date(),
+      });
+
+      hashToken.mockReturnValue("hashed");
+      mockRefreshRepo.findByTokenHash.mockResolvedValue(session);
+
+      await service.logout("raw-token");
+
+      expect(mockRefreshRepo.revokeById).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("getRefreshSessionState", () => {
+  it("should return 'revoked' when revokedAt is set", () => {
+    const state = getRefreshSessionState({
+      revokedAt: new Date(),
+      expiresAt: new Date(Date.now() + 1000),
+      rotatedAt: null,
+      replacedBy: null,
+    });
+    expect(state).toBe("revoked");
+  });
+
+  it("should return 'expired' when expiresAt is in the past", () => {
+    const state = getRefreshSessionState({
+      revokedAt: null,
+      expiresAt: new Date(Date.now() - 1000),
+      rotatedAt: null,
+      replacedBy: null,
+    });
+    expect(state).toBe("expired");
+  });
+
+  it("should return 'reused' when rotatedAt is set", () => {
+    const state = getRefreshSessionState({
+      revokedAt: null,
+      expiresAt: new Date(Date.now() + 1000),
+      rotatedAt: new Date(),
+      replacedBy: null,
+    });
+    expect(state).toBe("reused");
+  });
+
+  it("should return 'reused' when replacedBy is set", () => {
+    const state = getRefreshSessionState({
+      revokedAt: null,
+      expiresAt: new Date(Date.now() + 1000),
+      rotatedAt: null,
+      replacedBy: createObjectId(),
+    });
+    expect(state).toBe("reused");
+  });
+
+  it("should return 'valid' for active non-expired session", () => {
+    const state = getRefreshSessionState({
+      revokedAt: null,
+      expiresAt: new Date(Date.now() + 1000),
+      rotatedAt: null,
+      replacedBy: null,
+    });
+    expect(state).toBe("valid");
+  });
+});
+
+describe("exhaustiveCheck", () => {
+  it("should throw AppError for any value", () => {
+    expect(() => exhaustiveCheck("unexpected" as never)).toThrow();
+    expect(() => exhaustiveCheck(42 as never)).toThrow();
+  });
+});

--- a/apps/backend/src/modules/auth/refresh-session.service.ts
+++ b/apps/backend/src/modules/auth/refresh-session.service.ts
@@ -1,0 +1,56 @@
+import crypto from "node:crypto";
+import type { UserDetails } from "@recipes/shared";
+import { generateOpaqueToken, hashToken } from "@/common/utils/jwt.js";
+import { env } from "@/config/env.js";
+import type { RefreshSessionRepository } from "./refresh-session.repository.js";
+
+export type CreateSessionContext = {
+  ip?: string | null;
+  userAgent?: string | null;
+};
+
+export type CreateSessionResult = {
+  token: string;
+  expiresAt: Date;
+};
+
+export interface RefreshSessionService {
+  create(
+    userId: UserDetails["id"],
+    context: CreateSessionContext,
+  ): Promise<CreateSessionResult>;
+}
+
+type RefreshSessionRepositoryPort = Pick<
+  RefreshSessionRepository,
+  "create" | "updateMany" | "rotateById"
+>;
+
+export function createRefreshSessionService(
+  refreshSessionRepository: RefreshSessionRepositoryPort,
+): RefreshSessionService {
+  return {
+    async create(userId, { ip, userAgent }) {
+      const token = generateOpaqueToken();
+      const tokenHash = hashToken(token);
+      const expiresAt = new Date(
+        Date.now() + env.SESSION_EXPIRES_IN_DAYS * 24 * 60 * 60 * 1000,
+      );
+      const familyId = crypto.randomUUID();
+
+      await refreshSessionRepository.create({
+        user: userId,
+        familyId,
+        tokenHash,
+        expiresAt,
+        ip,
+        userAgent,
+      });
+
+      return {
+        token,
+        expiresAt,
+      };
+    },
+  };
+}

--- a/apps/backend/src/modules/auth/refresh-session.service.ts
+++ b/apps/backend/src/modules/auth/refresh-session.service.ts
@@ -40,7 +40,7 @@ export interface RefreshSessionService {
 
 type RefreshSessionRepositoryPort = Pick<
   RefreshSessionRepository,
-  "findByTokenHash" | "create" | "rotateById" | "revokeById" | "revokeFamily"
+  "findByTokenHash" | "create" | "rotate" | "revokeById" | "revokeFamily"
 >;
 type UserRepositoryPort = Pick<UserRepository, "findById">;
 
@@ -73,7 +73,6 @@ export function createRefreshSessionService(
     },
 
     async refresh(refreshToken, { ip, userAgent }) {
-      console.log(refreshToken);
       const refreshTokenHash = hashToken(refreshToken);
 
       const currentSession =
@@ -117,19 +116,11 @@ export function createRefreshSessionService(
 
       const newRefreshToken = generateOpaqueToken();
       const newRefreshTokenHash = hashToken(newRefreshToken);
-      const expiresAt = currentSession.expiresAt;
 
-      const newSession = await refreshSessionRepository.create({
-        user: currentSession.user,
-        familyId: currentSession.familyId,
+      await refreshSessionRepository.rotate(currentSession, {
         tokenHash: newRefreshTokenHash,
-        expiresAt,
         ip: ip ?? null,
         userAgent: userAgent ?? null,
-      });
-
-      await refreshSessionRepository.rotateById(currentSession._id, {
-        replacedBy: newSession._id,
       });
 
       const accessToken = signToken({
@@ -142,7 +133,7 @@ export function createRefreshSessionService(
         user: toUserDetails(user),
         accessToken,
         refreshToken: newRefreshToken,
-        expiresAt,
+        expiresAt: currentSession.expiresAt,
       };
     },
   };

--- a/apps/backend/src/modules/auth/refresh-session.service.ts
+++ b/apps/backend/src/modules/auth/refresh-session.service.ts
@@ -118,11 +118,14 @@ export function createRefreshSessionService(
       const newRefreshToken = generateOpaqueToken();
       const newRefreshTokenHash = hashToken(newRefreshToken);
 
-      await refreshSessionRepository.rotate(currentSession, {
+      const newSession = await refreshSessionRepository.rotate(currentSession, {
         tokenHash: newRefreshTokenHash,
         ip: ip ?? null,
         userAgent: userAgent ?? null,
       });
+      if (!newSession) {
+        throw new UnauthorizedError("Refresh token rotation conflict");
+      }
 
       const accessToken = signToken({
         id: user._id.toString(),

--- a/apps/backend/src/modules/auth/refresh-session.service.ts
+++ b/apps/backend/src/modules/auth/refresh-session.service.ts
@@ -1,33 +1,52 @@
 import crypto from "node:crypto";
 import type { UserDetails } from "@recipes/shared";
-import { generateOpaqueToken, hashToken } from "@/common/utils/jwt.js";
+import { AppError, UnauthorizedError } from "@/common/errors.js";
+import {
+  generateOpaqueToken,
+  hashToken,
+  signToken,
+} from "@/common/utils/jwt.js";
 import { env } from "@/config/env.js";
+import { toUserDetails } from "@/modules/users/user.mapper.js";
+import type { UserRepository } from "@/modules/users/user.repository.js";
+import type { RefreshSessionDocument } from "./refresh-session.model.js";
 import type { RefreshSessionRepository } from "./refresh-session.repository.js";
 
-export type CreateSessionContext = {
+type SessionContext = {
   ip?: string | null;
   userAgent?: string | null;
 };
 
-export type CreateSessionResult = {
-  token: string;
+type CreateSessionResult = {
+  refreshToken: string;
   expiresAt: Date;
+};
+
+type RefreshSessionResult = CreateSessionResult & {
+  user: UserDetails;
+  accessToken: string;
 };
 
 export interface RefreshSessionService {
   create(
     userId: UserDetails["id"],
-    context: CreateSessionContext,
+    context: SessionContext,
   ): Promise<CreateSessionResult>;
+  refresh(
+    refreshToken: string,
+    context: SessionContext,
+  ): Promise<RefreshSessionResult>;
 }
 
 type RefreshSessionRepositoryPort = Pick<
   RefreshSessionRepository,
-  "create" | "updateMany" | "rotateById"
+  "findByTokenHash" | "create" | "rotateById" | "revokeById" | "revokeFamily"
 >;
+type UserRepositoryPort = Pick<UserRepository, "findById">;
 
 export function createRefreshSessionService(
   refreshSessionRepository: RefreshSessionRepositoryPort,
+  userRepository: UserRepositoryPort,
 ): RefreshSessionService {
   return {
     async create(userId, { ip, userAgent }) {
@@ -48,9 +67,99 @@ export function createRefreshSessionService(
       });
 
       return {
-        token,
+        refreshToken: token,
+        expiresAt: expiresAt,
+      };
+    },
+
+    async refresh(refreshToken, { ip, userAgent }) {
+      console.log(refreshToken);
+      const refreshTokenHash = hashToken(refreshToken);
+
+      const currentSession =
+        await refreshSessionRepository.findByTokenHash(refreshTokenHash);
+      if (!currentSession) {
+        throw new UnauthorizedError("Invalid refresh token");
+      }
+
+      const sessionState = getRefreshSessionState(currentSession);
+      switch (sessionState) {
+        case "revoked":
+          throw new UnauthorizedError("Refresh session revoked");
+        case "expired":
+          await refreshSessionRepository.revokeById(
+            currentSession._id,
+            "expired",
+          );
+          throw new UnauthorizedError("Refresh token expired");
+        case "reused":
+          await refreshSessionRepository.revokeFamily(
+            currentSession.familyId,
+            "reuse-detected",
+          );
+          throw new UnauthorizedError("Refresh token reuse detected");
+        case "valid":
+          break;
+        default:
+          exhaustiveCheck(sessionState);
+      }
+
+      const user = await userRepository.findById(
+        currentSession.user.toHexString(),
+      );
+      if (!user) {
+        await refreshSessionRepository.revokeFamily(
+          currentSession.familyId,
+          "user-not-found",
+        );
+        throw new UnauthorizedError("User not found");
+      }
+
+      const newRefreshToken = generateOpaqueToken();
+      const newRefreshTokenHash = hashToken(newRefreshToken);
+      const expiresAt = currentSession.expiresAt;
+
+      const newSession = await refreshSessionRepository.create({
+        user: currentSession.user,
+        familyId: currentSession.familyId,
+        tokenHash: newRefreshTokenHash,
+        expiresAt,
+        ip: ip ?? null,
+        userAgent: userAgent ?? null,
+      });
+
+      await refreshSessionRepository.rotateById(currentSession._id, {
+        replacedBy: newSession._id,
+      });
+
+      const accessToken = signToken({
+        id: user._id.toString(),
+        email: user.email,
+        role: user.role,
+      });
+
+      return {
+        user: toUserDetails(user),
+        accessToken,
+        refreshToken: newRefreshToken,
         expiresAt,
       };
     },
   };
+}
+
+export function getRefreshSessionState(
+  session: Pick<
+    RefreshSessionDocument,
+    "revokedAt" | "expiresAt" | "rotatedAt" | "replacedBy"
+  >,
+) {
+  if (session.revokedAt) return "revoked";
+  if (session.expiresAt.getTime() <= Date.now()) return "expired";
+  if (session.rotatedAt || session.replacedBy) return "reused";
+  return "valid";
+}
+
+export function exhaustiveCheck(value: never): never {
+  throw new AppError(`Unhandled value ${value}`);
 }

--- a/apps/backend/src/modules/auth/refresh-session.service.ts
+++ b/apps/backend/src/modules/auth/refresh-session.service.ts
@@ -36,6 +36,7 @@ export interface RefreshSessionService {
     refreshToken: string,
     context: SessionContext,
   ): Promise<RefreshSessionResult>;
+  logout(refreshToken?: string): Promise<void>;
 }
 
 type RefreshSessionRepositoryPort = Pick<
@@ -135,6 +136,22 @@ export function createRefreshSessionService(
         refreshToken: newRefreshToken,
         expiresAt: currentSession.expiresAt,
       };
+    },
+
+    async logout(refreshToken?: string) {
+      if (!refreshToken) {
+        return;
+      }
+
+      const tokenHash = hashToken(refreshToken);
+      const session = await refreshSessionRepository.findByTokenHash(tokenHash);
+      if (!session) {
+        return;
+      }
+
+      if (!session.revokedAt) {
+        return refreshSessionRepository.revokeById(session._id, "logout");
+      }
     },
   };
 }

--- a/apps/backend/src/modules/categories/category.routes.test.ts
+++ b/apps/backend/src/modules/categories/category.routes.test.ts
@@ -34,13 +34,13 @@ describe("categoryRoutes", () => {
   };
 
   const testJwtPayload = {
-    userId,
+    id: userId,
     email: "user@test.com",
     role: "user",
   } as const;
 
   const testAdminJwtPayload = {
-    userId: adminId,
+    id: adminId,
     email: "admin@test.com",
     role: "admin",
   } as const;
@@ -122,7 +122,7 @@ describe("categoryRoutes", () => {
           image: { url: "https://example.com/desserts.jpg" },
         },
         initiator: {
-          id: testAdminJwtPayload.userId,
+          id: testAdminJwtPayload.id,
           role: testAdminJwtPayload.role,
         },
       });
@@ -181,7 +181,7 @@ describe("categoryRoutes", () => {
       expect(response.statusCode).toBe(204);
       expect(mockCategoryService.deleteById).toHaveBeenCalledWith(categoryId, {
         initiator: {
-          id: testAdminJwtPayload.userId,
+          id: testAdminJwtPayload.id,
           role: testAdminJwtPayload.role,
         },
       });

--- a/apps/backend/src/modules/categories/category.routes.ts
+++ b/apps/backend/src/modules/categories/category.routes.ts
@@ -40,7 +40,7 @@ export const categoryRoutes: FastifyPluginAsync<CategoryModuleOptions> = async (
       async (request, reply) => {
         const { value, cache } = await service.findAll({
           query: request.query,
-          initiator: { id: request.user?.userId, role: request.user?.role },
+          initiator: { id: request.user?.id, role: request.user?.role },
         });
 
         reply.applyCacheHeaders(cache);
@@ -66,7 +66,7 @@ export const categoryRoutes: FastifyPluginAsync<CategoryModuleOptions> = async (
 
         const category = await service.create({
           data: request.body,
-          initiator: { id: request.user.userId, role: request.user.role },
+          initiator: { id: request.user.id, role: request.user.role },
         });
         return reply.status(201).send(category);
       },
@@ -86,7 +86,7 @@ export const categoryRoutes: FastifyPluginAsync<CategoryModuleOptions> = async (
         assertAuthenticated(request);
 
         await service.deleteById(request.params.id, {
-          initiator: { id: request.user.userId, role: request.user.role },
+          initiator: { id: request.user.id, role: request.user.role },
         });
         return reply.status(204).send();
       },

--- a/apps/backend/src/modules/favorites/favorite.routes.test.ts
+++ b/apps/backend/src/modules/favorites/favorite.routes.test.ts
@@ -21,7 +21,7 @@ describe("favoriteRoutes", () => {
   const recipeId = "507f1f77bcf86cd799439033";
 
   const testJwtPayload = {
-    userId,
+    id: userId,
     email: "user@test.com",
     role: "user",
   } as const;
@@ -52,7 +52,7 @@ describe("favoriteRoutes", () => {
       const body = JSON.parse(response.payload);
       expect(body.favorited).toBe(true);
       expect(mockFavoriteService.isFavorited).toHaveBeenCalledWith(recipeId, {
-        initiator: { id: testJwtPayload.userId, role: testJwtPayload.role },
+        initiator: { id: testJwtPayload.id, role: testJwtPayload.role },
       });
     });
 
@@ -93,7 +93,7 @@ describe("favoriteRoutes", () => {
       const body = JSON.parse(response.payload);
       expect(body.favorited).toBe(true);
       expect(mockFavoriteService.add).toHaveBeenCalledWith(recipeId, {
-        initiator: { id: testJwtPayload.userId, role: testJwtPayload.role },
+        initiator: { id: testJwtPayload.id, role: testJwtPayload.role },
       });
     });
 
@@ -122,7 +122,7 @@ describe("favoriteRoutes", () => {
       const body = JSON.parse(response.payload);
       expect(body.favorited).toBe(false);
       expect(mockFavoriteService.remove).toHaveBeenCalledWith(recipeId, {
-        initiator: { id: testJwtPayload.userId, role: testJwtPayload.role },
+        initiator: { id: testJwtPayload.id, role: testJwtPayload.role },
       });
     });
 

--- a/apps/backend/src/modules/favorites/favorite.routes.ts
+++ b/apps/backend/src/modules/favorites/favorite.routes.ts
@@ -36,7 +36,7 @@ export const favoriteRoutes: FastifyPluginAsync<FavoriteModuleOptions> = async (
         assertAuthenticated(request);
 
         const favorited = await service.isFavorited(request.params.id, {
-          initiator: { id: request.user.userId, role: request.user.role },
+          initiator: { id: request.user.id, role: request.user.role },
         });
         return reply.send({ favorited });
       },
@@ -59,7 +59,7 @@ export const favoriteRoutes: FastifyPluginAsync<FavoriteModuleOptions> = async (
         assertAuthenticated(request);
 
         const result = await service.add(request.params.id, {
-          initiator: { id: request.user.userId, role: request.user.role },
+          initiator: { id: request.user.id, role: request.user.role },
         });
         return reply.send(result);
       },
@@ -82,7 +82,7 @@ export const favoriteRoutes: FastifyPluginAsync<FavoriteModuleOptions> = async (
         assertAuthenticated(request);
 
         const result = await service.remove(request.params.id, {
-          initiator: { id: request.user.userId, role: request.user.role },
+          initiator: { id: request.user.id, role: request.user.role },
         });
         return reply.send(result);
       },

--- a/apps/backend/src/modules/recipe-ratings/recipe-rating.routes.test.ts
+++ b/apps/backend/src/modules/recipe-ratings/recipe-rating.routes.test.ts
@@ -19,7 +19,7 @@ describe("recipeRatingRoutes", () => {
   const recipeId = "507f1f77bcf86cd799439033";
 
   const testJwtPayload = {
-    userId,
+    id: userId,
     email: "user@test.com",
     role: "user",
   } as const;
@@ -52,7 +52,7 @@ describe("recipeRatingRoutes", () => {
       expect(body.value).toBe(5);
       expect(mockRecipeRatingService.rate).toHaveBeenCalledWith(recipeId, {
         data: { value: 5 },
-        initiator: { id: testJwtPayload.userId, role: testJwtPayload.role },
+        initiator: { id: testJwtPayload.id, role: testJwtPayload.role },
       });
     });
 
@@ -108,7 +108,7 @@ describe("recipeRatingRoutes", () => {
 
       expect(response.statusCode).toBe(204);
       expect(mockRecipeRatingService.remove).toHaveBeenCalledWith(recipeId, {
-        initiator: { id: testJwtPayload.userId, role: testJwtPayload.role },
+        initiator: { id: testJwtPayload.id, role: testJwtPayload.role },
       });
     });
 

--- a/apps/backend/src/modules/recipe-ratings/recipe-rating.routes.ts
+++ b/apps/backend/src/modules/recipe-ratings/recipe-rating.routes.ts
@@ -38,7 +38,7 @@ export const recipeRatingRoutes: FastifyPluginAsync<
 
         const result = await service.rate(request.params.id, {
           data: request.body,
-          initiator: { id: request.user.userId, role: request.user.role },
+          initiator: { id: request.user.id, role: request.user.role },
         });
         return reply.send(result);
       },
@@ -61,7 +61,7 @@ export const recipeRatingRoutes: FastifyPluginAsync<
         assertAuthenticated(request);
 
         await service.remove(request.params.id, {
-          initiator: { id: request.user.userId, role: request.user.role },
+          initiator: { id: request.user.id, role: request.user.role },
         });
         return reply.status(204).send();
       },

--- a/apps/backend/src/modules/recipes/recipe.routes.test.ts
+++ b/apps/backend/src/modules/recipes/recipe.routes.test.ts
@@ -81,7 +81,7 @@ describe("recipeRoutes", () => {
   };
 
   const testJwtPayload = {
-    userId,
+    id: userId,
     email: "user@test.com",
     role: "user",
   } as const;
@@ -147,7 +147,7 @@ describe("recipeRoutes", () => {
       expect(mockRecipeService.findAll).toHaveBeenCalledWith({
         query: expect.any(Object),
         initiator: {
-          id: testJwtPayload.userId,
+          id: testJwtPayload.id,
           role: testJwtPayload.role,
         },
       });
@@ -250,7 +250,7 @@ describe("recipeRoutes", () => {
       expect(mockRecipeService.create).toHaveBeenCalledWith({
         data: payload,
         initiator: {
-          id: testJwtPayload.userId,
+          id: testJwtPayload.id,
           role: testJwtPayload.role,
         },
       });
@@ -301,7 +301,7 @@ describe("recipeRoutes", () => {
       expect(mockRecipeService.update).toHaveBeenCalledWith(recipeId, {
         data: { title: "Updated", isPublic: true },
         initiator: {
-          id: testJwtPayload.userId,
+          id: testJwtPayload.id,
           role: testJwtPayload.role,
         },
       });
@@ -345,7 +345,7 @@ describe("recipeRoutes", () => {
       expect(response.statusCode).toBe(204);
       expect(mockRecipeService.delete).toHaveBeenCalledWith(recipeId, {
         initiator: {
-          id: testJwtPayload.userId,
+          id: testJwtPayload.id,
           role: testJwtPayload.role,
         },
       });
@@ -405,7 +405,7 @@ describe("recipeRoutes", () => {
         text: "Great!",
         recipe: { id: recipeId, title: "Test" },
         author: {
-          id: testJwtPayload.userId,
+          id: testJwtPayload.id,
           email: testJwtPayload.email,
           name: "User",
         },
@@ -424,7 +424,7 @@ describe("recipeRoutes", () => {
       expect(mockCommentService.create).toHaveBeenCalledWith(recipeId, {
         data: { text: "Great!" },
         initiator: {
-          id: testJwtPayload.userId,
+          id: testJwtPayload.id,
           role: testJwtPayload.role,
         },
       });
@@ -455,7 +455,7 @@ describe("recipeRoutes", () => {
       expect(response.statusCode).toBe(204);
       expect(mockCommentService.delete).toHaveBeenCalledWith(commentId, {
         initiator: {
-          id: testJwtPayload.userId,
+          id: testJwtPayload.id,
           role: testJwtPayload.role,
         },
       });

--- a/apps/backend/src/modules/recipes/recipe.routes.ts
+++ b/apps/backend/src/modules/recipes/recipe.routes.ts
@@ -48,7 +48,7 @@ export const recipeRoutes: FastifyPluginAsync<RecipeModuleOptions> = async (
       async (request, reply) => {
         const { value, cache } = await service.findAll({
           query: request.query,
-          initiator: { id: request.user?.userId, role: request.user?.role },
+          initiator: { id: request.user?.id, role: request.user?.role },
         });
 
         reply.applyCacheHeaders(cache);
@@ -70,7 +70,7 @@ export const recipeRoutes: FastifyPluginAsync<RecipeModuleOptions> = async (
       },
       async (request, reply) => {
         const { value, cache } = await service.findById(request.params.id, {
-          initiator: { id: request.user?.userId, role: request.user?.role },
+          initiator: { id: request.user?.id, role: request.user?.role },
         });
 
         reply.applyCacheHeaders(cache);
@@ -96,7 +96,7 @@ export const recipeRoutes: FastifyPluginAsync<RecipeModuleOptions> = async (
 
         const recipe = await service.create({
           data: request.body,
-          initiator: { id: request.user.userId, role: request.user.role },
+          initiator: { id: request.user.id, role: request.user.role },
         });
         return reply.status(201).send(recipe);
       },
@@ -121,7 +121,7 @@ export const recipeRoutes: FastifyPluginAsync<RecipeModuleOptions> = async (
 
         const recipe = await service.update(request.params.id, {
           data: request.body,
-          initiator: { id: request.user.userId, role: request.user.role },
+          initiator: { id: request.user.id, role: request.user.role },
         });
         return reply.send(recipe);
       },
@@ -141,7 +141,7 @@ export const recipeRoutes: FastifyPluginAsync<RecipeModuleOptions> = async (
         assertAuthenticated(request);
 
         await service.delete(request.params.id, {
-          initiator: { id: request.user.userId, role: request.user.role },
+          initiator: { id: request.user.id, role: request.user.role },
         });
         return reply.status(204).send();
       },
@@ -163,7 +163,7 @@ export const recipeRoutes: FastifyPluginAsync<RecipeModuleOptions> = async (
       async (request, reply) => {
         const result = await commentService.findByRecipe(request.params.id, {
           query: request.query,
-          initiator: { id: request.user?.userId, role: request.user?.role },
+          initiator: { id: request.user?.id, role: request.user?.role },
         });
         return reply.send(result);
       },
@@ -188,7 +188,7 @@ export const recipeRoutes: FastifyPluginAsync<RecipeModuleOptions> = async (
 
         const comment = await commentService.create(request.params.id, {
           data: request.body,
-          initiator: { id: request.user.userId, role: request.user.role },
+          initiator: { id: request.user.id, role: request.user.role },
         });
         return reply.status(201).send(comment);
       },
@@ -208,7 +208,7 @@ export const recipeRoutes: FastifyPluginAsync<RecipeModuleOptions> = async (
         assertAuthenticated(request);
 
         await commentService.delete(request.params.id, {
-          initiator: { id: request.user.userId, role: request.user.role },
+          initiator: { id: request.user.id, role: request.user.role },
         });
         return reply.status(204).send();
       },

--- a/apps/backend/src/modules/reviews/review.routes.test.ts
+++ b/apps/backend/src/modules/reviews/review.routes.test.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { authHeader, createTestApp } from "@/__tests__/build-test-app.js";
+import { JwtPayload } from "@/common/utils/jwt.js";
 import { reviewRoutes } from "@/modules/reviews/review.routes.js";
 
 const { verifyToken } = vi.hoisted(() => ({
@@ -35,7 +36,7 @@ describe("reviewRoutes", () => {
   };
 
   const testJwtPayload = {
-    userId,
+    id: userId,
     email: "user@test.com",
     role: "user",
   } as const;
@@ -120,7 +121,7 @@ describe("reviewRoutes", () => {
       expect(response.statusCode).toBe(201);
       expect(mockReviewService.create).toHaveBeenCalledWith({
         data: { text: "Great platform!", rating: 5 },
-        initiator: { id: testJwtPayload.userId, role: testJwtPayload.role },
+        initiator: { id: testJwtPayload.id, role: testJwtPayload.role },
       });
     });
 
@@ -153,10 +154,10 @@ describe("reviewRoutes", () => {
   describe("GET /api/reviews", () => {
     it("should return paginated reviews when admin", async () => {
       verifyToken.mockReturnValue({
-        userId: adminId,
+        id: adminId,
         email: "admin@test.com",
         role: "admin",
-      });
+      } satisfies JwtPayload);
       mockReviewService.findAll.mockResolvedValue({
         items: [validReview],
         pagination: {
@@ -173,7 +174,7 @@ describe("reviewRoutes", () => {
         method: "GET",
         url: "/api/reviews",
         headers: authHeader({
-          userId: adminId,
+          id: adminId,
           email: "admin@test.com",
           role: "admin",
         }),
@@ -224,7 +225,7 @@ describe("reviewRoutes", () => {
       expect(response.statusCode).toBe(200);
       expect(mockReviewService.update).toHaveBeenCalledWith(reviewId, {
         data: { text: "Updated" },
-        initiator: { id: testJwtPayload.userId, role: testJwtPayload.role },
+        initiator: { id: testJwtPayload.id, role: testJwtPayload.role },
       });
     });
 
@@ -255,10 +256,10 @@ describe("reviewRoutes", () => {
   describe("PATCH /api/reviews/:id/feature", () => {
     it("should feature review when admin", async () => {
       verifyToken.mockReturnValue({
-        userId: adminId,
+        id: adminId,
         email: "admin@test.com",
         role: "admin",
-      });
+      } satisfies JwtPayload);
       mockReviewService.feature.mockResolvedValue({
         ...validReview,
         isFeatured: true,
@@ -269,7 +270,7 @@ describe("reviewRoutes", () => {
         url: `/api/reviews/${reviewId}/feature`,
         payload: { isFeatured: true },
         headers: authHeader({
-          userId: adminId,
+          id: adminId,
           email: "admin@test.com",
           role: "admin",
         }),
@@ -320,7 +321,7 @@ describe("reviewRoutes", () => {
 
       expect(response.statusCode).toBe(204);
       expect(mockReviewService.delete).toHaveBeenCalledWith(reviewId, {
-        initiator: { id: testJwtPayload.userId, role: testJwtPayload.role },
+        initiator: { id: testJwtPayload.id, role: testJwtPayload.role },
       });
     });
 

--- a/apps/backend/src/modules/reviews/review.routes.test.ts
+++ b/apps/backend/src/modules/reviews/review.routes.test.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { authHeader, createTestApp } from "@/__tests__/build-test-app.js";
-import { JwtPayload } from "@/common/utils/jwt.js";
+import type { JwtPayload } from "@/common/utils/jwt.js";
 import { reviewRoutes } from "@/modules/reviews/review.routes.js";
 
 const { verifyToken } = vi.hoisted(() => ({

--- a/apps/backend/src/modules/reviews/review.routes.ts
+++ b/apps/backend/src/modules/reviews/review.routes.ts
@@ -80,7 +80,7 @@ export const reviewRoutes: FastifyPluginAsync<ReviewModuleOptions> = async (
 
         const review = await service.create({
           data: request.body,
-          initiator: { id: request.user.userId, role: request.user.role },
+          initiator: { id: request.user.id, role: request.user.role },
         });
         return reply.status(201).send(review);
       },
@@ -104,7 +104,7 @@ export const reviewRoutes: FastifyPluginAsync<ReviewModuleOptions> = async (
 
         const result = await service.findAll({
           query: request.query,
-          initiator: { id: request.user.userId, role: request.user.role },
+          initiator: { id: request.user.id, role: request.user.role },
         });
         return reply.send(result);
       },
@@ -129,7 +129,7 @@ export const reviewRoutes: FastifyPluginAsync<ReviewModuleOptions> = async (
 
         const review = await service.update(request.params.id, {
           data: request.body,
-          initiator: { id: request.user.userId, role: request.user.role },
+          initiator: { id: request.user.id, role: request.user.role },
         });
         return reply.send(review);
       },
@@ -155,7 +155,7 @@ export const reviewRoutes: FastifyPluginAsync<ReviewModuleOptions> = async (
         const review = await service.feature(
           request.params.id,
           {
-            initiator: { id: request.user.userId, role: request.user.role },
+            initiator: { id: request.user.id, role: request.user.role },
           },
           request.body.isFeatured,
         );
@@ -177,7 +177,7 @@ export const reviewRoutes: FastifyPluginAsync<ReviewModuleOptions> = async (
         assertAuthenticated(request);
 
         await service.delete(request.params.id, {
-          initiator: { id: request.user.userId, role: request.user.role },
+          initiator: { id: request.user.id, role: request.user.role },
         });
         return reply.status(204).send();
       },

--- a/apps/backend/src/modules/users/user.routes.test.ts
+++ b/apps/backend/src/modules/users/user.routes.test.ts
@@ -19,7 +19,7 @@ describe("userRoutes", () => {
   const userId = "507f1f77bcf86cd799439011";
 
   const testJwtPayload = {
-    userId,
+    id: userId,
     email: "user@test.com",
     role: "user",
   } as const;
@@ -39,7 +39,7 @@ describe("userRoutes", () => {
     it("should return current user when authenticated", async () => {
       verifyToken.mockReturnValue(testJwtPayload);
       mockUserService.getCurrentUser.mockResolvedValue({
-        id: testJwtPayload.userId,
+        id: testJwtPayload.id,
         email: testJwtPayload.email,
         name: "Test User",
         createdAt: "2024-01-01T00:00:00.000Z",
@@ -54,7 +54,7 @@ describe("userRoutes", () => {
 
       expect(response.statusCode).toBe(200);
       expect(mockUserService.getCurrentUser).toHaveBeenCalledWith(
-        testJwtPayload.userId,
+        testJwtPayload.id,
       );
       const body = JSON.parse(response.payload);
       expect(body.email).toBe(testJwtPayload.email);
@@ -96,7 +96,7 @@ describe("userRoutes", () => {
         userId,
         expect.objectContaining({
           query: expect.any(Object),
-          initiator: { id: testJwtPayload.userId, role: testJwtPayload.role },
+          initiator: { id: testJwtPayload.id, role: testJwtPayload.role },
         }),
       );
     });
@@ -137,7 +137,7 @@ describe("userRoutes", () => {
         userId,
         expect.objectContaining({
           query: expect.any(Object),
-          initiator: { id: testJwtPayload.userId, role: testJwtPayload.role },
+          initiator: { id: testJwtPayload.id, role: testJwtPayload.role },
         }),
       );
     });

--- a/apps/backend/src/modules/users/user.routes.ts
+++ b/apps/backend/src/modules/users/user.routes.ts
@@ -40,7 +40,7 @@ export const userRoutes: FastifyPluginAsync<UserPluginOptions> = async (
       async (request, reply) => {
         assertAuthenticated(request);
 
-        const user = await service.getCurrentUser(request.user.userId);
+        const user = await service.getCurrentUser(request.user.id);
         return reply.send(user);
       },
     )
@@ -61,9 +61,9 @@ export const userRoutes: FastifyPluginAsync<UserPluginOptions> = async (
       async (request, reply) => {
         assertAuthenticated(request);
 
-        const result = await service.getFavorites(request.user.userId, {
+        const result = await service.getFavorites(request.user.id, {
           query: request.query,
-          initiator: { id: request.user.userId, role: request.user.role },
+          initiator: { id: request.user.id, role: request.user.role },
         });
         return reply.send(result);
       },
@@ -85,9 +85,9 @@ export const userRoutes: FastifyPluginAsync<UserPluginOptions> = async (
       async (request, reply) => {
         assertAuthenticated(request);
 
-        const result = await service.getComments(request.user.userId, {
+        const result = await service.getComments(request.user.id, {
           query: request.query,
-          initiator: { id: request.user.userId, role: request.user.role },
+          initiator: { id: request.user.id, role: request.user.role },
         });
         return reply.send(result);
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
 
   apps/backend:
     dependencies:
+      '@fastify/cookie':
+        specifier: ^11.0.2
+        version: 11.0.2
       '@fastify/cors':
         specifier: ^10.1.0
         version: 10.1.0
@@ -639,6 +642,9 @@ packages:
 
   '@fastify/ajv-compiler@4.0.5':
     resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
+
+  '@fastify/cookie@11.0.2':
+    resolution: {integrity: sha512-GWdwdGlgJxyvNv+QcKiGNevSspMQXncjMZ1J8IvuDQk0jvkzgWWZFNC2En3s+nHndZBGV8IbLwOI/sxCZw/mzA==}
 
   '@fastify/cors@10.1.0':
     resolution: {integrity: sha512-MZyBCBJtII60CU9Xme/iE4aEy8G7QpzGR8zkdXZkDFt7ElEMachbE61tfhAG/bvSaULlqlf0huMT12T7iqEmdQ==}
@@ -3690,6 +3696,11 @@ snapshots:
       ajv-formats: 3.0.1(ajv@8.18.0)
       fast-uri: 3.1.0
 
+  '@fastify/cookie@11.0.2':
+    dependencies:
+      cookie: 1.1.1
+      fastify-plugin: 5.1.0
+
   '@fastify/cors@10.1.0':
     dependencies:
       fastify-plugin: 5.1.0
@@ -4168,7 +4179,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.0.2)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@24.12.2)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.5(@types/node@25.5.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.0.2)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -4222,7 +4233,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.0.2)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@24.12.2)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.5(@types/node@25.5.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.0.2)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/utils@4.1.5':
     dependencies:


### PR DESCRIPTION
## Related Issues

<!-- Link related issues: Closes #123, Refs #456 -->

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [x] Tests
- [ ] Other

## Description

This PR implements a secure refresh token system for the backend authentication layer.

### What's New

- **Opaque refresh tokens**: `crypto.randomBytes(48)` tokens, SHA-256 hashed before storage in MongoDB. Raw tokens are never stored.
- **Token rotation**: Every refresh invalidates the old token and issues a new pair (access + refresh). Prevents replay attacks.
- **Reuse detection**: If a rotated (old) refresh token is used again, the entire token family is revoked immediately — a strong signal of token theft.
- **HTTP-only cookies**: Refresh tokens are sent via `Secure` `HttpOnly` `SameSite=Lax` cookies. The `__Host-` prefix is used in production.
- **New endpoints**:
  - `POST /api/auth/refresh` — cookie-based, no auth guard. Returns new access token + sets new refresh cookie.
  - `POST /api/auth/logout` — revokes current session and clears the cookie.
- **Session tracking**: Each refresh session stores `ip`, `userAgent`, `expiresAt`, `rotatedAt`, `replacedBy`, `revokedAt`, `revokeReason` for full auditability.
- **TTL index**: `expiresAt` has a TTL index so MongoDB auto-deletes expired sessions.
- **Unique index**: `tokenHash` is unique to prevent accidental collisions.

### Architecture

```
Auth Routes → RefreshSessionService → RefreshSessionRepository → MongoDB
                          ↓
                    UserRepository → MongoDB
```

### Files Added

- `refresh-session.model.ts` — Mongoose schema with TTL and indexes
- `refresh-session.repository.ts` — `create`, `findByTokenHash`, `markRotated`, `rotate`, `revokeById`, `revokeFamily`
- `refresh-session.service.ts` — business logic with state machine (`valid` → `reused`/`expired`/`revoked`)
- `refresh-session.repository.int.test.ts` — 8 integration tests
- `refresh-session.service.test.ts` — 18 unit tests (including reuse detection, rotation conflict, race condition)

### Files Modified

- `auth.routes.ts` — `login`/`register` now set refresh cookies; new `/refresh` and `/logout` endpoints
- `auth.service.ts` — `login`/`register` now return user data only (access token still in response body)
- `auth.routes.test.ts` — updated to verify `Set-Cookie` header
- `jwt.ts` — added `generateOpaqueToken()` and `hashToken()` helpers
- `app.ts` — registered `@fastify/cookie`, updated CORS with `credentials: true`
- `env.ts` — added `SESSION_EXPIRES_IN_DAYS` (default 7)
- Various route files — updated `authGuard` import path (relative → absolute)

## Screenshots

<!-- N/A — backend only -->

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes (414 tests)
- [x] Added/updated tests for new functionality
- [ ] Updated documentation (if needed)