### PR TITLE
refactor(recipe): filter recipe by category slug instead of id

### DIFF
--- a/apps/backend/src/modules/recipes/recipe.cache.ts
+++ b/apps/backend/src/modules/recipes/recipe.cache.ts
@@ -6,7 +6,7 @@ export const recipeCache = {
     byId: (id: string) => `id:${id}`,
     list: (filters: RecipeQuery) =>
       `list:${filters.page}:${filters.limit}:${hashFilters({
-        categoryId: filters.categoryId,
+        category: filters.category,
         difficulty: filters.difficulty,
         sort: filters.sort,
       })}`,

--- a/apps/backend/src/modules/recipes/recipe.repository.ts
+++ b/apps/backend/src/modules/recipes/recipe.repository.ts
@@ -67,8 +67,9 @@ type RecipeDocumentListItem = Omit<
 > &
   RecipeComputed;
 
-export type SearchRecipeQuery = Omit<RecipeQuery, "cuisineId"> & {
+export type SearchRecipeQuery = Omit<RecipeQuery, "cuisine" | "category"> & {
   cuisineId?: string;
+  categoryId?: string;
 };
 
 export class RecipeRepository extends BaseRepository<

--- a/apps/backend/src/modules/recipes/recipe.service.test.ts
+++ b/apps/backend/src/modules/recipes/recipe.service.test.ts
@@ -37,6 +37,7 @@ describe("recipeService", () => {
   };
   const mockCategoryRepository = {
     exists: vi.fn(),
+    findOne: vi.fn(),
     modelName: "Category",
   };
   const mockCuisineRepository = {

--- a/apps/backend/src/modules/recipes/recipe.service.ts
+++ b/apps/backend/src/modules/recipes/recipe.service.ts
@@ -58,7 +58,10 @@ type RecipeRepositoryPort = Pick<
 >;
 type UserRepositoryPort = Pick<UserRepository, "exists" | "modelName">;
 type FavoriteRepositoryPort = Pick<FavoriteRepository, "exists">;
-type CategoryRepositoryPort = Pick<CategoryRepository, "exists" | "modelName">;
+type CategoryRepositoryPort = Pick<
+  CategoryRepository,
+  "exists" | "findOne" | "modelName"
+>;
 type CuisineRepositoryPort = Pick<
   CuisineRepository,
   "exists" | "findOne" | "modelName"
@@ -105,9 +108,21 @@ export function createRecipeService(
           cuisineId = cuisine._id.toString();
         }
 
+        let categoryId: string | undefined;
+        if (query.category) {
+          const category = await categoryRepository.findOne({
+            slug: query.category,
+          });
+          if (!category) {
+            return withPagination([], 0, query.page, query.limit);
+          }
+          categoryId = category._id.toString();
+        }
+
         const enrichedQuery = {
           ...query,
           cuisineId,
+          categoryId,
         };
 
         const [recipes, total] = await repository.aggregateSearch({

--- a/apps/frontend/src/entities/recipe/api/recipe.api.ts
+++ b/apps/frontend/src/entities/recipe/api/recipe.api.ts
@@ -16,15 +16,7 @@ import { apiClient } from "@/shared/api/client";
  */
 export function getRecipes(filters: Partial<RecipeQuery> = {}) {
   return apiClient<Paginated<RecipeListItem>>("/api/recipes", {
-    query: {
-      page: filters.page,
-      limit: filters.limit,
-      search: filters.search,
-      categoryId: filters.categoryId,
-      difficulty: filters.difficulty,
-      isFavorited: filters.isFavorited,
-      sort: filters.sort,
-    },
+    query: filters,
   });
 }
 

--- a/packages/shared/src/recipes/recipe.schema.ts
+++ b/packages/shared/src/recipes/recipe.schema.ts
@@ -23,7 +23,7 @@ export const recipeQuerySchema = z
     sort: createSortSchema(["createdAt", "cookingTime", "popularity"]).default(
       "-createdAt",
     ),
-    categoryId: z.string().optional(),
+    category: z.string().trim().optional(),
     cuisine: z.string().trim().optional(),
     difficulty: difficultySchema.optional(),
     isFavorited: z.stringbool().optional(),


### PR DESCRIPTION
## Related Issues

<!-- Link related issues: Closes #123, Refs #456 -->

## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring
- [ ] Tests
- [ ] Other

## Description

Replaced `categoryId` in recipe query filters with `category` slug for easier and more straightforward client use.

Recipe service now calls `categoryRepository.findOne` with category slug to get its id.

## Screenshots

<!-- If applicable, add screenshots or recordings of the changes -->

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Added/updated tests for new functionality
- [ ] Updated documentation (if needed)
