### PR TITLE
feat(recipe): add SEO-friendly slug to recipes

### DIFF
--- a/apps/backend/src/__tests__/db-factories.ts
+++ b/apps/backend/src/__tests__/db-factories.ts
@@ -5,6 +5,7 @@ import type {
   RecipeStats,
 } from "@recipes/shared";
 import type { Types } from "mongoose";
+import { slugify } from "@/common/utils/slug.js";
 import { RefreshSessionModel } from "@/modules/auth/refresh-session.model.js";
 import { CategoryModel } from "@/modules/categories/category.model.js";
 import { CommentModel } from "@/modules/comments/comment.model.js";
@@ -79,6 +80,7 @@ export async function createDbRecipe(
   overrides: Partial<{
     title: string;
     description: string;
+    slug: string;
     ingredients: { name: string; quantity: number; unit: string }[];
     instructions: string[];
     category: Types.ObjectId;
@@ -93,9 +95,12 @@ export async function createDbRecipe(
     stats: RecipeStats;
   }> = {},
 ) {
+  const title = overrides.title ?? unique("recipe");
+
   return RecipeModel.create({
-    title: unique("recipe"),
+    title,
     description: "A test recipe",
+    slug: slugify(title),
     ingredients: [{ name: "Flour", quantity: 200, unit: "g" }],
     instructions: ["Mix ingredients"],
     category: createObjectId(),

--- a/apps/backend/src/__tests__/helpers.ts
+++ b/apps/backend/src/__tests__/helpers.ts
@@ -120,6 +120,7 @@ export function createRecipeDoc(
     _id,
     title: "Test Recipe",
     description: "A test recipe",
+    slug: "test-recipe",
     ingredients: [{ name: "Flour", quantity: 200, unit: "g" }],
     instructions: ["Mix ingredients"],
     category: createObjectId(),

--- a/apps/backend/src/common/utils/slug.bench.ts
+++ b/apps/backend/src/common/utils/slug.bench.ts
@@ -1,0 +1,14 @@
+import { bench, describe } from "vitest";
+import { slugify, transliterate } from "./slug.js";
+
+describe("slugify functions performance", () => {
+  bench("slugify", () => {
+    slugify("Борщ з квашеною капустою".repeat(100));
+  });
+});
+
+describe("transliterate functions performance", () => {
+  bench("transliterate", () => {
+    transliterate("Борщ з квашеною капустою".repeat(100));
+  });
+});

--- a/apps/backend/src/common/utils/slug.test.ts
+++ b/apps/backend/src/common/utils/slug.test.ts
@@ -1,0 +1,99 @@
+import { Types } from "mongoose";
+import { describe, expect, it } from "vitest";
+import {
+  generateRecipeSlug,
+  slugify,
+  transliterate,
+} from "@/common/utils/slug.js";
+
+describe("transliterate", () => {
+  it("should transliterate lowercase Ukrainian letters", () => {
+    expect(transliterate("банан")).toBe("banan");
+    expect(transliterate("борщ")).toBe("borshch");
+    expect(transliterate("щука")).toBe("shchuka");
+  });
+
+  it("should transliterate uppercase Ukrainian letters", () => {
+    expect(transliterate("Борщ")).toBe("Borshch");
+    expect(transliterate("Європа")).toBe("Ievropa");
+  });
+
+  it("should handle mixed Ukrainian and Latin text", () => {
+    expect(transliterate("recipe Борщ")).toBe("recipe Borshch");
+  });
+
+  it("should leave non-Ukrainian characters unchanged", () => {
+    expect(transliterate("hello world 123")).toBe("hello world 123");
+    expect(transliterate("café résumé")).toBe("café résumé");
+  });
+
+  it("should return empty string for empty input", () => {
+    expect(transliterate("")).toBe("");
+  });
+});
+
+describe("slugify", () => {
+  it("should convert English title to slug", () => {
+    expect(slugify("Classic American Pancakes")).toBe(
+      "classic-american-pancakes",
+    );
+  });
+
+  it("should convert Ukrainian title to slug", () => {
+    expect(slugify("Борщ з квашеною капустою")).toBe(
+      "borshch-z-kvashenoiu-kapustoiu",
+    );
+  });
+
+  it("should remove special characters", () => {
+    expect(slugify("Pancakes!!! (with syrup)")).toBe("pancakes-with-syrup");
+  });
+
+  it("should collapse multiple spaces and hyphens", () => {
+    expect(slugify("too   many    spaces")).toBe("too-many-spaces");
+    expect(slugify("double--hyphens")).toBe("double-hyphens");
+  });
+
+  it("should trim leading and trailing hyphens", () => {
+    expect(slugify("-leading")).toBe("leading");
+    expect(slugify("trailing-")).toBe("trailing");
+    expect(slugify("-both-")).toBe("both");
+  });
+
+  it("should handle underscores like spaces", () => {
+    expect(slugify("hello_world")).toBe("hello-world");
+  });
+
+  it("should return empty string for empty input", () => {
+    expect(slugify("")).toBe("");
+  });
+});
+
+describe("generateRecipeSlug", () => {
+  it("should generate slug with last 6 hex chars of ObjectId", () => {
+    const objectId = new Types.ObjectId("507f1f77bcf86cd799439033");
+    const result = generateRecipeSlug("Classic American Pancakes", objectId);
+
+    expect(result).toBe("classic-american-pancakes-439033");
+  });
+
+  it("should work with string hex ObjectId", () => {
+    const result = generateRecipeSlug("Борщ", "507f1f77bcf86cd799439011");
+
+    expect(result).toBe("borshch-439011");
+  });
+
+  it("should handle titles with special characters", () => {
+    const objectId = new Types.ObjectId("507f1f77bcf86cd799439022");
+    const result = generateRecipeSlug("Pancakes!!! (super)", objectId);
+
+    expect(result).toBe("pancakes-super-439022");
+  });
+
+  it("should handle empty title", () => {
+    const objectId = new Types.ObjectId("507f1f77bcf86cd799439033");
+    const result = generateRecipeSlug("", objectId);
+
+    expect(result).toBe("-439033");
+  });
+});

--- a/apps/backend/src/common/utils/slug.ts
+++ b/apps/backend/src/common/utils/slug.ts
@@ -1,0 +1,97 @@
+import type { Types } from "mongoose";
+
+const UKRAINIAN_MAP: Record<string, string> = {
+  а: "a",
+  б: "b",
+  в: "v",
+  г: "h",
+  ґ: "g",
+  д: "d",
+  е: "e",
+  є: "ie",
+  ж: "zh",
+  з: "z",
+  и: "y",
+  і: "i",
+  ї: "yi",
+  й: "i",
+  к: "k",
+  л: "l",
+  м: "m",
+  н: "n",
+  о: "o",
+  п: "p",
+  р: "r",
+  с: "s",
+  т: "t",
+  у: "u",
+  ф: "f",
+  х: "kh",
+  ц: "ts",
+  ч: "ch",
+  ш: "sh",
+  щ: "shch",
+  ь: "",
+  ю: "iu",
+  я: "ia",
+};
+
+/**
+ * Transliterate Ukrainian Cyrillic text to Latin characters.
+ *
+ * Uses the official Ukrainian romanization standard (Resolution 55 of 2010).
+ */
+export function transliterate(text: string): string {
+  return text
+    .split("")
+    .map((char) => {
+      const replacement = UKRAINIAN_MAP[char.toLowerCase()];
+
+      if (replacement === undefined) {
+        return char;
+      }
+
+      return char === char.toUpperCase()
+        ? replacement.charAt(0).toUpperCase() + replacement.slice(1)
+        : replacement;
+    })
+    .join("");
+}
+
+/**
+ * Convert arbitrary text into a URL-friendly slug.
+ *
+ * Steps:
+ * 1. Transliterate Ukrainian characters.
+ * 2. Lowercase.
+ * 3. Replace non-alphanumeric characters with hyphens.
+ * 4. Collapse consecutive hyphens.
+ * 5. Trim leading/trailing hyphens.
+ */
+export function slugify(input: string): string {
+  return transliterate(input)
+    .trim()
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-");
+}
+
+/**
+ * Generate a unique recipe slug by appending the last 6 hex characters
+ * of a MongoDB ObjectId to the title-based slug.
+ *
+ * This guarantees uniqueness without querying the database.
+ */
+export function generateRecipeSlug(
+  title: string,
+  objectId: Types.ObjectId | string,
+): string {
+  const hex = typeof objectId === "string" ? objectId : objectId.toHexString();
+  const suffix = hex.slice(-6);
+  const base = slugify(title);
+
+  return `${base}-${suffix}`;
+}

--- a/apps/backend/src/modules/comments/comment.mapper.test.ts
+++ b/apps/backend/src/modules/comments/comment.mapper.test.ts
@@ -9,7 +9,7 @@ describe("toCommentDetails", () => {
     const doc = {
       ...createCommentDoc({ text: "Nice!" }),
       author: { _id: authorId, name: "User", email: "user@test.com" },
-      recipe: { _id: recipeId, title: "Pasta" },
+      recipe: { _id: recipeId, title: "Pasta", slug: "pasta" },
     };
 
     const result = toCommentDetails(doc);
@@ -23,6 +23,7 @@ describe("toCommentDetails", () => {
     expect(result.recipe).toEqual({
       id: recipeId.toString(),
       title: "Pasta",
+      slug: "pasta",
     });
   });
 });

--- a/apps/backend/src/modules/comments/comment.model.ts
+++ b/apps/backend/src/modules/comments/comment.model.ts
@@ -1,24 +1,12 @@
-import type { Replace } from "@recipes/shared";
 import type { Model, Types } from "mongoose";
 import { model, Schema } from "mongoose";
 import type { BaseDocument } from "@/common/types/mongoose.js";
-import type { RecipeDocument } from "@/modules/recipes/recipe.model.js";
-import type { UserDocument } from "@/modules/users/user.model.js";
 
 export interface CommentDocument extends BaseDocument {
   text: string;
   recipe: Types.ObjectId;
   author: Types.ObjectId;
 }
-
-export interface CommentDocumentPopulated
-  extends Replace<
-    CommentDocument,
-    {
-      author: Pick<UserDocument, "_id" | "name" | "email">;
-      recipe: Pick<RecipeDocument, "_id" | "title">;
-    }
-  > {}
 
 export type CommentModelType = Model<CommentDocument>;
 

--- a/apps/backend/src/modules/comments/comment.repository.ts
+++ b/apps/backend/src/modules/comments/comment.repository.ts
@@ -1,4 +1,4 @@
-import type { RequireKeys } from "@recipes/shared";
+import type { Merge, RequireKeys } from "@recipes/shared";
 import type { CreateInput, UpdateInput } from "@/common/base.repository.js";
 import { BaseRepository } from "@/common/base.repository.js";
 import type {
@@ -15,10 +15,7 @@ import {
 import type { RecipeDocument } from "@/modules/recipes/recipe.model.js";
 import { recipesCollectionName } from "@/modules/recipes/recipe.model.js";
 import type { UserDocument } from "@/modules/users/user.model.js";
-import type {
-  CommentDocument,
-  CommentDocumentPopulated,
-} from "./comment.model.js";
+import type { CommentDocument } from "./comment.model.js";
 
 export type CommentCreateInput = RequireKeys<
   CreateInput<CommentDocument>,
@@ -27,8 +24,17 @@ export type CommentCreateInput = RequireKeys<
 export type CommentUpdateInput = UpdateInput<CommentDocument>;
 export type CommentDefaultPopulate = {
   author: Pick<UserDocument, "_id" | "name" | "email">;
-  recipe: Pick<RecipeDocument, "_id" | "title">;
+  recipe: Pick<RecipeDocument, "_id" | "title" | "slug">;
 };
+
+export interface CommentDocumentPopulated
+  extends Merge<
+    CommentDocument,
+    {
+      author: Pick<UserDocument, "_id" | "name" | "email">;
+      recipe: Pick<RecipeDocument, "_id" | "title" | "slug">;
+    }
+  > {}
 
 export class CommentRepository extends BaseRepository<
   CommentDocument,
@@ -91,7 +97,7 @@ export class CommentRepository extends BaseRepository<
   protected override getDefaultPopulate() {
     return [
       { path: "author", select: "_id name email" },
-      { path: "recipe", select: "_id title" },
+      { path: "recipe", select: "_id title slug" },
     ];
   }
 }
@@ -109,6 +115,7 @@ function withRecipe(initiator: OptionalInitiator) {
         stages.project({
           _id: 1,
           title: 1,
+          slug: 1,
         }),
       ],
       as: "recipe",

--- a/apps/backend/src/modules/favorites/favorite.routes.ts
+++ b/apps/backend/src/modules/favorites/favorite.routes.ts
@@ -6,7 +6,10 @@ import {
   authGuard,
 } from "@/common/middleware/auth.guard.js";
 import type { FavoriteService } from "@/modules/favorites/favorite.service.js";
-import { recipeParamsSchema } from "@/modules/recipes/recipe.schema.js";
+import {
+  parseRecipeRef,
+  recipeParamsSchema,
+} from "@/modules/recipes/recipe.routes.js";
 
 export interface FavoriteModuleOptions {
   service: FavoriteService;
@@ -19,7 +22,7 @@ export const favoriteRoutes: FastifyPluginAsync<FavoriteModuleOptions> = async (
   fastify
     .withTypeProvider<ZodTypeProvider>()
     .get(
-      "/:id/favorite",
+      "/:ref/favorite",
       {
         schema: {
           params: recipeParamsSchema,
@@ -35,14 +38,17 @@ export const favoriteRoutes: FastifyPluginAsync<FavoriteModuleOptions> = async (
       async (request, reply) => {
         assertAuthenticated(request);
 
-        const favorited = await service.isFavorited(request.params.id, {
+        const { id } = parseRecipeRef(request.params.ref);
+
+        const favorited = await service.isFavorited(id, {
           initiator: { id: request.user.id, role: request.user.role },
         });
+
         return reply.send({ favorited });
       },
     )
     .post(
-      "/:id/favorite",
+      "/:ref/favorite",
       {
         schema: {
           params: recipeParamsSchema,
@@ -58,14 +64,16 @@ export const favoriteRoutes: FastifyPluginAsync<FavoriteModuleOptions> = async (
       async (request, reply) => {
         assertAuthenticated(request);
 
-        const result = await service.add(request.params.id, {
+        const { id } = parseRecipeRef(request.params.ref);
+
+        const result = await service.add(id, {
           initiator: { id: request.user.id, role: request.user.role },
         });
         return reply.send(result);
       },
     )
     .delete(
-      "/:id/favorite",
+      "/:ref/favorite",
       {
         schema: {
           params: recipeParamsSchema,
@@ -81,7 +89,9 @@ export const favoriteRoutes: FastifyPluginAsync<FavoriteModuleOptions> = async (
       async (request, reply) => {
         assertAuthenticated(request);
 
-        const result = await service.remove(request.params.id, {
+        const { id } = parseRecipeRef(request.params.ref);
+
+        const result = await service.remove(id, {
           initiator: { id: request.user.id, role: request.user.role },
         });
         return reply.send(result);

--- a/apps/backend/src/modules/recipe-ratings/recipe-rating.routes.ts
+++ b/apps/backend/src/modules/recipe-ratings/recipe-rating.routes.ts
@@ -7,7 +7,10 @@ import {
   authGuard,
 } from "@/common/middleware/auth.guard.js";
 import type { RecipeRatingService } from "@/modules/recipe-ratings/recipe-rating.service.js";
-import { recipeParamsSchema } from "@/modules/recipes/recipe.schema.js";
+import {
+  parseRecipeRef,
+  recipeParamsSchema,
+} from "@/modules/recipes/recipe.routes.js";
 
 export interface RecipeRatingModuleOptions {
   service: RecipeRatingService;
@@ -19,7 +22,7 @@ export const recipeRatingRoutes: FastifyPluginAsync<
   fastify
     .withTypeProvider<ZodTypeProvider>()
     .put(
-      "/:id/rating",
+      "/:ref/rating",
       {
         schema: {
           params: recipeParamsSchema,
@@ -36,7 +39,9 @@ export const recipeRatingRoutes: FastifyPluginAsync<
       async (request, reply) => {
         assertAuthenticated(request);
 
-        const result = await service.rate(request.params.id, {
+        const { id } = parseRecipeRef(request.params.ref);
+
+        const result = await service.rate(id, {
           data: request.body,
           initiator: { id: request.user.id, role: request.user.role },
         });
@@ -44,7 +49,7 @@ export const recipeRatingRoutes: FastifyPluginAsync<
       },
     )
     .delete(
-      "/:id/rating",
+      "/:ref/rating",
       {
         schema: {
           params: recipeParamsSchema,
@@ -60,7 +65,9 @@ export const recipeRatingRoutes: FastifyPluginAsync<
       async (request, reply) => {
         assertAuthenticated(request);
 
-        await service.remove(request.params.id, {
+        const { id } = parseRecipeRef(request.params.ref);
+
+        await service.remove(id, {
           initiator: { id: request.user.id, role: request.user.role },
         });
         return reply.status(204).send();

--- a/apps/backend/src/modules/recipes/recipe.mapper.test.ts
+++ b/apps/backend/src/modules/recipes/recipe.mapper.test.ts
@@ -13,6 +13,7 @@ describe("toRecipeSummary", () => {
     const doc = {
       _id: createObjectId(),
       title: "Pasta Carbonara",
+      slug: "pasta-carbonara",
     };
 
     const result = toRecipeSummary(doc);
@@ -20,6 +21,7 @@ describe("toRecipeSummary", () => {
     expect(result).toEqual({
       id: doc._id.toString(),
       title: "Pasta Carbonara",
+      slug: "pasta-carbonara",
     });
   });
 });
@@ -31,6 +33,7 @@ describe("toRecipeListItem", () => {
     const doc = {
       _id: createObjectId(),
       title: "Pasta",
+      slug: "pasta",
       image: { url: "https://example.com/pasta.jpg" },
       difficulty: "easy" as const,
       mealType: "breakfast" as const,
@@ -62,6 +65,7 @@ describe("toRecipeListItem", () => {
 
     expect(result.id).toBe(doc._id.toString());
     expect(result.title).toBe("Pasta");
+    expect(result.slug).toBe("pasta");
     expect(result.isFavorited).toBe(true);
     expect(result.userRating).toBe(4);
     expect(result.image).toEqual({
@@ -94,6 +98,7 @@ describe("toRecipeListItem", () => {
     const doc = {
       _id: createObjectId(),
       title: "Soup",
+      slug: "soup",
       image: { url: "https://example.com/soup.jpg" },
       difficulty: "easy" as const,
       mealType: "breakfast" as const,
@@ -129,6 +134,7 @@ describe("toRecipeListItem", () => {
     const doc = {
       _id: createObjectId(),
       title: "Salad",
+      slug: "salad",
       image: { url: "https://example.com/salad.jpg" },
       difficulty: "medium" as const,
       mealType: "dinner" as const,
@@ -165,6 +171,7 @@ describe("toRecipeDetails", () => {
     const doc = {
       ...createRecipeDoc({
         title: "Pasta",
+        slug: "pasta",
         description: "Delicious pasta",
         difficulty: "easy",
         cookingTime: 30 as Minutes,
@@ -199,6 +206,7 @@ describe("toRecipeDetails", () => {
 
     expect(result.id).toBe(doc._id.toString());
     expect(result.title).toBe("Pasta");
+    expect(result.slug).toBe("pasta");
     expect(result.isFavorited).toBe(doc.isFavorited);
     expect(result.category).toEqual({
       id: categoryId.toString(),

--- a/apps/backend/src/modules/recipes/recipe.mapper.ts
+++ b/apps/backend/src/modules/recipes/recipe.mapper.ts
@@ -24,6 +24,7 @@ export type IngredientView = {
 export type RecipeSummaryView = {
   _id: string | { toString(): string };
   title: string;
+  slug: string;
 };
 
 export type RecipeListItemView = RecipeSummaryView & {
@@ -52,6 +53,7 @@ export function toRecipeSummary(view: RecipeSummaryView): RecipeSummary {
   return {
     id: view._id.toString(),
     title: view.title,
+    slug: view.slug,
   };
 }
 

--- a/apps/backend/src/modules/recipes/recipe.model.ts
+++ b/apps/backend/src/modules/recipes/recipe.model.ts
@@ -26,6 +26,7 @@ export type RecipeImage = RequireKeys<Image, "url">;
 export interface RecipeDocument extends BaseDocument {
   title: string;
   description: string;
+  slug: string;
   ingredients: IngredientDocument[];
   instructions: string[];
   category: Types.ObjectId;
@@ -85,6 +86,12 @@ const recipeSchema = new Schema<RecipeDocument>(
   {
     title: { type: String, required: true, trim: true },
     description: { type: String, required: true, trim: true },
+    slug: {
+      type: String,
+      required: true,
+      trim: true,
+      lowercase: true,
+    },
     ingredients: {
       type: [ingredientSchema],
       required: true,

--- a/apps/backend/src/modules/recipes/recipe.repository.int.test.ts
+++ b/apps/backend/src/modules/recipes/recipe.repository.int.test.ts
@@ -864,6 +864,7 @@ describe("RecipeRepository", () => {
       const created = await repository.create({
         title: "New Recipe",
         description: "Desc",
+        slug: "new-recipe",
         ingredients: [{ name: "Flour", quantity: 100, unit: "g" }],
         instructions: ["Mix"],
         category: category._id.toString(),
@@ -889,6 +890,7 @@ describe("RecipeRepository", () => {
       const created = await repository.create({
         title: "To Delete",
         description: "Desc",
+        slug: "to-delete",
         ingredients: [{ name: "Flour", quantity: 100, unit: "g" }],
         instructions: ["Mix"],
         category: category._id.toString(),

--- a/apps/backend/src/modules/recipes/recipe.repository.ts
+++ b/apps/backend/src/modules/recipes/recipe.repository.ts
@@ -53,6 +53,7 @@ export type RecipeCreateInput = RequireKeys<
   | "servings"
   | "isPublic"
   | "image"
+  | "slug"
 >;
 export type RecipeUpdateInput = UpdateInput<Omit<RecipeDocument, "author">>;
 export type RecipeDefaultPopulate = {

--- a/apps/backend/src/modules/recipes/recipe.routes.test.ts
+++ b/apps/backend/src/modules/recipes/recipe.routes.test.ts
@@ -1,3 +1,5 @@
+import type { Minutes, RecipeDetails } from "@recipes/shared";
+import { buildRecipeRef } from "@recipes/shared";
 import type { FastifyInstance } from "fastify";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { authHeader, createTestApp } from "@/__tests__/build-test-app.js";
@@ -35,6 +37,7 @@ describe("recipeRoutes", () => {
     id: recipeId,
     title: "Test Recipe",
     description: "A delicious test recipe",
+    slug: "test-recipe",
     ingredients: [{ name: "Flour", quantity: 200, unit: "g" }],
     instructions: ["Mix ingredients", "Bake it well"],
     category: {
@@ -49,7 +52,7 @@ describe("recipeRoutes", () => {
     author: { id: userId, email: "chef@test.com", name: "Chef" },
     difficulty: "easy" as const,
     mealType: "breakfast" as const,
-    cookingTime: 30,
+    cookingTime: 30 as Minutes,
     servings: 4,
     isPublic: true,
     createdAt: "2024-01-01T00:00:00.000Z",
@@ -68,7 +71,7 @@ describe("recipeRoutes", () => {
     },
     isFavorited: false,
     userRating: null,
-  };
+  } satisfies RecipeDetails;
 
   const paginatedResult = {
     items: [validRecipe],
@@ -183,7 +186,7 @@ describe("recipeRoutes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: `/api/recipes/${recipeId}`,
+        url: `/api/recipes/${buildRecipeRef({ id: recipeId, slug: validRecipe.slug })}`,
       });
 
       expect(response.statusCode).toBe(200);
@@ -406,7 +409,11 @@ describe("recipeRoutes", () => {
       mockCommentService.create.mockResolvedValue({
         id: commentId,
         text: "Great!",
-        recipe: { id: recipeId, title: "Test" },
+        recipe: {
+          id: recipeId,
+          title: "Test",
+          slug: buildRecipeRef({ id: recipeId, slug: "test" }),
+        },
         author: {
           id: testJwtPayload.id,
           email: testJwtPayload.email,

--- a/apps/backend/src/modules/recipes/recipe.routes.ts
+++ b/apps/backend/src/modules/recipes/recipe.routes.ts
@@ -11,6 +11,9 @@ import {
 } from "@recipes/shared";
 import type { FastifyPluginAsync } from "fastify";
 import type { ZodTypeProvider } from "fastify-type-provider-zod";
+import { isObjectIdOrHexString } from "mongoose";
+import { z } from "zod";
+import { BadRequestError } from "@/common/errors.js";
 import {
   assertAuthenticated,
   authGuard,
@@ -18,13 +21,16 @@ import {
 } from "@/common/middleware/auth.guard.js";
 import { commentParamsSchema } from "@/modules/comments/comment.schema.js";
 import type { CommentService } from "@/modules/comments/comment.service.js";
-import { recipeParamsSchema } from "@/modules/recipes/recipe.schema.js";
 import type { RecipeService } from "@/modules/recipes/recipe.service.js";
 
 export interface RecipeModuleOptions {
   service: RecipeService;
   commentService: CommentService;
 }
+
+export const recipeParamsSchema = z.object({
+  ref: z.string().trim().min(24),
+});
 
 export const recipeRoutes: FastifyPluginAsync<RecipeModuleOptions> = async (
   fastify,
@@ -56,7 +62,7 @@ export const recipeRoutes: FastifyPluginAsync<RecipeModuleOptions> = async (
       },
     )
     .get(
-      "/:id",
+      "/:ref",
       {
         schema: {
           params: recipeParamsSchema,
@@ -69,7 +75,9 @@ export const recipeRoutes: FastifyPluginAsync<RecipeModuleOptions> = async (
         onRequest: optionalAuth,
       },
       async (request, reply) => {
-        const { value, cache } = await service.findById(request.params.id, {
+        const { id } = parseRecipeRef(request.params.ref);
+
+        const { value, cache } = await service.findById(id, {
           initiator: { id: request.user?.id, role: request.user?.role },
         });
 
@@ -102,7 +110,7 @@ export const recipeRoutes: FastifyPluginAsync<RecipeModuleOptions> = async (
       },
     )
     .patch(
-      "/:id",
+      "/:ref",
       {
         schema: {
           params: recipeParamsSchema,
@@ -119,15 +127,18 @@ export const recipeRoutes: FastifyPluginAsync<RecipeModuleOptions> = async (
       async (request, reply) => {
         assertAuthenticated(request);
 
-        const recipe = await service.update(request.params.id, {
+        const { id } = parseRecipeRef(request.params.ref);
+
+        const recipe = await service.update(id, {
           data: request.body,
           initiator: { id: request.user.id, role: request.user.role },
         });
+
         return reply.send(recipe);
       },
     )
     .delete(
-      "/:id",
+      "/:ref",
       {
         schema: {
           params: recipeParamsSchema,
@@ -140,14 +151,17 @@ export const recipeRoutes: FastifyPluginAsync<RecipeModuleOptions> = async (
       async (request, reply) => {
         assertAuthenticated(request);
 
-        await service.delete(request.params.id, {
+        const { id } = parseRecipeRef(request.params.ref);
+
+        await service.delete(id, {
           initiator: { id: request.user.id, role: request.user.role },
         });
+
         return reply.status(204).send();
       },
     )
     .get(
-      "/:id/comments",
+      "/:ref/comments",
       {
         schema: {
           params: recipeParamsSchema,
@@ -161,7 +175,9 @@ export const recipeRoutes: FastifyPluginAsync<RecipeModuleOptions> = async (
         onRequest: optionalAuth,
       },
       async (request, reply) => {
-        const result = await commentService.findByRecipe(request.params.id, {
+        const { id } = parseRecipeRef(request.params.ref);
+
+        const result = await commentService.findByRecipe(id, {
           query: request.query,
           initiator: { id: request.user?.id, role: request.user?.role },
         });
@@ -169,7 +185,7 @@ export const recipeRoutes: FastifyPluginAsync<RecipeModuleOptions> = async (
       },
     )
     .post(
-      "/:id/comments",
+      "/:ref/comments",
       {
         schema: {
           params: recipeParamsSchema,
@@ -186,7 +202,9 @@ export const recipeRoutes: FastifyPluginAsync<RecipeModuleOptions> = async (
       async (request, reply) => {
         assertAuthenticated(request);
 
-        const comment = await commentService.create(request.params.id, {
+        const { id } = parseRecipeRef(request.params.ref);
+
+        const comment = await commentService.create(id, {
           data: request.body,
           initiator: { id: request.user.id, role: request.user.role },
         });
@@ -214,3 +232,19 @@ export const recipeRoutes: FastifyPluginAsync<RecipeModuleOptions> = async (
       },
     );
 };
+
+export function parseRecipeRef(input: string) {
+  const id = input.slice(0, 24);
+
+  if (!isObjectIdOrHexString(id)) {
+    throw new BadRequestError("Invalid recipe id");
+  }
+
+  const rest = input.slice(24);
+  const slug = rest.startsWith("-") ? rest.slice(1) : null;
+
+  return {
+    id,
+    slug: slug || null,
+  };
+}

--- a/apps/backend/src/modules/recipes/recipe.schema.ts
+++ b/apps/backend/src/modules/recipes/recipe.schema.ts
@@ -1,6 +1,0 @@
-import { z } from "zod";
-import { idParamSchema } from "@/common/schemas.js";
-
-export const recipeParamsSchema = z.object({
-  id: idParamSchema,
-});

--- a/apps/backend/src/modules/recipes/recipe.service.test.ts
+++ b/apps/backend/src/modules/recipes/recipe.service.test.ts
@@ -12,6 +12,7 @@ import {
   ForbiddenError,
   NotFoundError,
 } from "@/common/errors.js";
+import { slugify } from "@/common/utils/slug.js";
 import { recipeCache } from "@/modules/recipes/recipe.cache.js";
 import { createRecipeService } from "@/modules/recipes/recipe.service.js";
 
@@ -351,6 +352,7 @@ describe("recipeService", () => {
 
       expect(mockRecipeRepository.create).toHaveBeenCalledWith({
         ...createData,
+        slug: slugify(createData.title),
         category: categoryId.toString(),
         author: authorId.toString(),
         mealType,

--- a/apps/backend/src/modules/recipes/recipe.service.ts
+++ b/apps/backend/src/modules/recipes/recipe.service.ts
@@ -22,6 +22,7 @@ import type {
   QueryMethodParams,
   UpdateMethodParams,
 } from "@/common/types/methods.js";
+import { slugify } from "@/common/utils/slug.js";
 import { assertExists, assertValidId } from "@/common/utils/validation.js";
 import type { CategoryRepository } from "@/modules/categories/category.repository.js";
 import type { CuisineRepository } from "@/modules/cuisines/cuisine.repository.js";
@@ -203,6 +204,7 @@ export function createRecipeService(
       const recipe = await repository.create({
         ...data,
         author: initiator.id,
+        slug: slugify(data.title),
       });
 
       await cache.deletePattern(recipeCache.keys.listPattern());

--- a/apps/backend/src/seed/index.ts
+++ b/apps/backend/src/seed/index.ts
@@ -3,6 +3,7 @@ import type { Minutes } from "@recipes/shared";
 import { hashSync } from "bcryptjs";
 import { logger } from "@/common/logger.js";
 import { toObjectId } from "@/common/utils/mongo.js";
+import { slugify } from "@/common/utils/slug.js";
 import { connectDatabase, disconnectDatabase } from "@/config/database.js";
 import { env } from "@/config/env.js";
 import { CategoryModel } from "@/modules/categories/category.model.js";
@@ -134,6 +135,7 @@ async function seed(): Promise<void> {
     const created = await RecipeModel.create({
       title: recipe.title,
       description: recipe.description,
+      slug: slugify(recipe.title),
       ingredients: recipe.ingredients,
       instructions: recipe.instructions,
       category: toObjectId(categoryId),

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -17,6 +17,7 @@ export * from "./comments/comment.input.schema.js";
 export * from "./comments/comment.schema.js";
 export * from "./comments/comment.response.schema.js";
 
+export * from "./recipes/utils.js";
 export * from "./recipes/recipe.primitives.schema.js";
 export * from "./recipes/recipe.input.schema.js";
 export * from "./recipes/recipe.schema.js";

--- a/packages/shared/src/recipes/recipe.response.schema.ts
+++ b/packages/shared/src/recipes/recipe.response.schema.ts
@@ -12,11 +12,9 @@ export const recipeComputedSchema = z.object({
 });
 
 export const recipeSummarySchema = createRecipeInputSchema
-  .extend(persistenceFieldsSchema.shape)
-  .pick({
-    id: true,
-    title: true,
-  });
+  .pick({ title: true })
+  .extend(persistenceFieldsSchema.pick({ id: true }).shape)
+  .extend({ slug: z.string() });
 
 export const recipeListItemSchema = createRecipeInputSchema
   .pick({
@@ -32,7 +30,8 @@ export const recipeListItemSchema = createRecipeInputSchema
   .extend({ stats: recipeStatsSchema })
   .extend({ category: categorySummarySchema })
   .extend({ cuisine: cuisineSummarySchema.nullable() })
-  .extend({ author: userSummarySchema });
+  .extend({ author: userSummarySchema })
+  .extend({ slug: z.string() });
 
 export const recipeDetailsSchema = createRecipeInputSchema
   .extend(persistenceFieldsSchema.shape)
@@ -40,7 +39,8 @@ export const recipeDetailsSchema = createRecipeInputSchema
   .extend({ stats: recipeStatsSchema })
   .extend({ category: categorySummarySchema })
   .extend({ cuisine: cuisineSummarySchema.nullable() })
-  .extend({ author: userSummarySchema });
+  .extend({ author: userSummarySchema })
+  .extend({ slug: z.string() });
 
 export type RecipeComputed = z.infer<typeof recipeComputedSchema>;
 export type RecipeSummary = z.infer<typeof recipeSummarySchema>;

--- a/packages/shared/src/recipes/utils.ts
+++ b/packages/shared/src/recipes/utils.ts
@@ -1,0 +1,6 @@
+export function buildRecipeRef(recipe: {
+  id: string | { toString(): string };
+  slug: string;
+}) {
+  return `${recipe.id.toString()}-${recipe.slug}` as const;
+}


### PR DESCRIPTION
## Related Issues

<!-- Link related issues: Closes #123, Refs #456 -->

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Tests
- [ ] Other

## Description

Generate a URL-friendly `slug` field for every recipe to support SEO-friendly frontend routes.

### Backend changes
- Added `slug` field to `RecipeDocument` schema (required, lowercase).
- Added `slug` to shared Zod response schemas (`RecipeSummary`, `RecipeListItem`, `RecipeDetails`).
- Mapped `slug` through recipe DTO mappers.
- Created `slugify()` utility with Ukrainian transliteration support.
- `create` service now auto-generates slug from title.
- `update` service preserves existing slug (immutable for SEO stability).
- Refactored recipe routes to accept `:ref` param (`id` or `id-slug`) and parse the real `id`.
- Added `buildRecipeRef` shared helper to construct `id-slug` references.
- Seed script generates slug from title for seeded recipes.
- Added comprehensive unit tests for slug utilities.

### Frontend (not in scope)
Frontend routing changes will be handled in a follow-up PR.

## Checklist

- [x] `pnpm lint` passes (backend & shared)
- [x] `pnpm test` passes (backend: 470/470)
- [x] Added/updated tests for new functionality
- [ ] Updated documentation (if needed)