### PR TITLE
refactor(query): split sort and order filters

### DIFF
--- a/apps/backend/src/common/utils/stages.test.ts
+++ b/apps/backend/src/common/utils/stages.test.ts
@@ -56,8 +56,10 @@ describe("paginate", () => {
 });
 
 describe("sort", () => {
-  it("should create a sort stage from a string", () => {
-    expect(sort("-createdAt")).toEqual({ $sort: { createdAt: -1 } });
+  it("should create a sort stage from sort options", () => {
+    expect(sort({ sort: "createdAt", order: "desc" })).toEqual({
+      $sort: { createdAt: -1 },
+    });
   });
 
   it("should create a sort stage from an object", () => {
@@ -180,7 +182,11 @@ describe("cond", () => {
 describe("paginated", () => {
   it("should create facet + project stages with sort and pagination", () => {
     const [facet, projectStage] = paginated(
-      { sort: "-createdAt", page: 2, limit: 10 },
+      {
+        sort: { sort: "createdAt", order: "desc" },
+        page: 2,
+        limit: 10,
+      },
       match({ isPublic: true }),
     );
 

--- a/apps/backend/src/common/utils/stages.ts
+++ b/apps/backend/src/common/utils/stages.ts
@@ -1,3 +1,4 @@
+import type { SortOrder } from "@recipes/shared/query";
 import { getSortObject } from "@recipes/shared/query";
 import type {
   AnyExpression,
@@ -60,14 +61,28 @@ export function paginate(
   return [{ $skip: (page - 1) * limit }, { $limit: limit }];
 }
 
-export type SortStage = string | Record<string, 1 | -1>;
-export function sort(sort: SortStage = { createdAt: -1 }): PipelineStage.Sort {
-  if (typeof sort === "string") {
-    return { $sort: getSortObject(sort) };
+export type SortOptions = {
+  sort: string;
+  order: SortOrder;
+};
+export type SortStage = SortOptions | Record<string, 1 | -1>;
+
+function isSortOptions(sortStage: SortStage): sortStage is SortOptions {
+  return (
+    typeof sortStage.sort === "string" &&
+    (sortStage.order === "asc" || sortStage.order === "desc")
+  );
+}
+
+export function sort(
+  sortStage: SortStage = { sort: "createdAt", order: "desc" },
+): PipelineStage.Sort {
+  if (isSortOptions(sortStage)) {
+    return { $sort: getSortObject(sortStage) };
   }
 
   return {
-    $sort: sort,
+    $sort: sortStage,
   };
 }
 

--- a/apps/backend/src/modules/categories/category.cache.ts
+++ b/apps/backend/src/modules/categories/category.cache.ts
@@ -6,6 +6,7 @@ export const categoryCache = {
     list: (filters: CategoryQuery) =>
       `list:${hashFilters({
         sort: filters.sort,
+        order: filters.order,
         page: filters.page,
         limit: filters.limit,
       })}`,

--- a/apps/backend/src/modules/categories/category.repository.int.test.ts
+++ b/apps/backend/src/modules/categories/category.repository.int.test.ts
@@ -22,6 +22,7 @@ describe("CategoryRepository", () => {
 
       const [items, total] = await repository.findMany({
         sort: "name",
+        order: "asc",
         page: 1,
         limit: 10,
       });
@@ -39,6 +40,7 @@ describe("CategoryRepository", () => {
     it("should return empty result when no categories exist", async () => {
       const [items, total] = await repository.findMany({
         sort: "name",
+        order: "asc",
         page: 1,
         limit: 10,
       });
@@ -54,6 +56,7 @@ describe("CategoryRepository", () => {
 
       const [items, total] = await repository.findMany({
         sort: "name",
+        order: "asc",
         page: 2,
         limit: 1,
       });
@@ -70,6 +73,7 @@ describe("CategoryRepository", () => {
 
       const [items] = await repository.findMany({
         sort: "name",
+        order: "asc",
         page: 1,
         limit: 10,
       });
@@ -83,7 +87,8 @@ describe("CategoryRepository", () => {
       await createDbCategory({ name: "Mango" });
 
       const [items] = await repository.findMany({
-        sort: "-name",
+        sort: "name",
+        order: "desc",
         page: 1,
         limit: 10,
       });

--- a/apps/backend/src/modules/categories/category.repository.ts
+++ b/apps/backend/src/modules/categories/category.repository.ts
@@ -41,7 +41,7 @@ export class CategoryRepository extends BaseRepository<
       stages.project({ recipes: 0 }),
       stages.paginated(
         {
-          sort: query.sort,
+          sort: { sort: query.sort, order: query.order },
           page: query.page,
           limit: query.limit,
         },

--- a/apps/backend/src/modules/categories/category.service.test.ts
+++ b/apps/backend/src/modules/categories/category.service.test.ts
@@ -62,7 +62,12 @@ describe("categoryService", () => {
       ];
       mockCategoryRepository.findMany.mockResolvedValue([docs, 2]);
 
-      const query = { sort: "name" as const, page: 1, limit: 10 };
+      const query = {
+        sort: "name" as const,
+        order: "asc" as const,
+        page: 1,
+        limit: 10,
+      };
       const result = await service.findAll({
         query,
         initiator: noInitiator(),
@@ -85,7 +90,12 @@ describe("categoryService", () => {
     it("should return empty paginated result when no categories exist", async () => {
       mockCategoryRepository.findMany.mockResolvedValue([[], 0]);
 
-      const query = { sort: "name" as const, page: 1, limit: 10 };
+      const query = {
+        sort: "name" as const,
+        order: "asc" as const,
+        page: 1,
+        limit: 10,
+      };
       const result = await service.findAll({
         query,
         initiator: noInitiator(),
@@ -105,7 +115,12 @@ describe("categoryService", () => {
       ];
       mockCategoryRepository.findMany.mockResolvedValue([docs, 1]);
 
-      const query = { sort: "name" as const, page: 1, limit: 10 };
+      const query = {
+        sort: "name" as const,
+        order: "asc" as const,
+        page: 1,
+        limit: 10,
+      };
       await service.findAll({
         query,
         initiator: noInitiator(),

--- a/apps/backend/src/modules/comments/comment.repository.int.test.ts
+++ b/apps/backend/src/modules/comments/comment.repository.int.test.ts
@@ -28,7 +28,7 @@ describe("CommentRepository", () => {
       const [comments, total] = await repository.findByRecipe(
         recipe._id.toString(),
         {
-          query: { page: 1, limit: 10 },
+          query: { page: 1, limit: 10, sort: "createdAt", order: "desc" },
           initiator: noInitiator(),
         },
       );
@@ -55,7 +55,7 @@ describe("CommentRepository", () => {
       const [comments, total] = await repository.findByRecipe(
         recipe._id.toString(),
         {
-          query: { page: 1, limit: 10 },
+          query: { page: 1, limit: 10, sort: "createdAt", order: "desc" },
           initiator: noInitiator(),
         },
       );
@@ -79,7 +79,7 @@ describe("CommentRepository", () => {
       const [comments, total] = await repository.findByRecipe(
         recipe._id.toString(),
         {
-          query: { page: 1, limit: 10 },
+          query: { page: 1, limit: 10, sort: "createdAt", order: "desc" },
           initiator: {
             id: author._id.toString(),
             role: "user",
@@ -107,7 +107,7 @@ describe("CommentRepository", () => {
       const [comments, total] = await repository.findByRecipe(
         recipe._id.toString(),
         {
-          query: { page: 1, limit: 10 },
+          query: { page: 1, limit: 10, sort: "createdAt", order: "desc" },
           initiator: {
             id: admin._id.toString(),
             role: "admin",
@@ -140,7 +140,7 @@ describe("CommentRepository", () => {
       const [comments, total] = await repository.findByRecipe(
         recipe._id.toString(),
         {
-          query: { page: 2, limit: 1 },
+          query: { page: 2, limit: 1, sort: "createdAt", order: "desc" },
           initiator: noInitiator(),
         },
       );
@@ -164,7 +164,7 @@ describe("CommentRepository", () => {
       const [comments, total] = await repository.findByAuthor(
         author._id.toString(),
         {
-          query: { page: 1, limit: 10 },
+          query: { page: 1, limit: 10, sort: "createdAt", order: "desc" },
           initiator: noInitiator(),
         },
       );
@@ -192,7 +192,7 @@ describe("CommentRepository", () => {
       const [comments, total] = await repository.findByAuthor(
         author._id.toString(),
         {
-          query: { page: 1, limit: 10 },
+          query: { page: 1, limit: 10, sort: "createdAt", order: "desc" },
           initiator: noInitiator(),
         },
       );
@@ -217,7 +217,7 @@ describe("CommentRepository", () => {
       const [comments, total] = await repository.findByAuthor(
         author._id.toString(),
         {
-          query: { page: 1, limit: 10 },
+          query: { page: 1, limit: 10, sort: "createdAt", order: "desc" },
           initiator: {
             id: author._id.toString(),
             role: "user",

--- a/apps/backend/src/modules/comments/comment.repository.ts
+++ b/apps/backend/src/modules/comments/comment.repository.ts
@@ -1,3 +1,4 @@
+import type { CommentQuery } from "@recipes/shared/comments";
 import type { Merge, RequireKeys } from "@recipes/shared/core";
 import type { CreateInput, UpdateInput } from "@/common/base.repository.js";
 import { BaseRepository } from "@/common/base.repository.js";
@@ -44,7 +45,7 @@ export class CommentRepository extends BaseRepository<
 > {
   async findByRecipe(
     recipeId: string,
-    { query, initiator }: QueryMethodParams,
+    { query, initiator }: QueryMethodParams<CommentQuery>,
   ): Promise<[CommentDocumentPopulated[], number]> {
     const pipeline = [
       stages.match<CommentDocument>({
@@ -54,7 +55,7 @@ export class CommentRepository extends BaseRepository<
       withAuthor(),
       withRecipe(initiator),
       stages.paginated({
-        sort: { sort: "createdAt", order: "desc" },
+        sort: { sort: query.sort, order: query.order },
         page: query.page,
         limit: query.limit,
       }),
@@ -70,7 +71,7 @@ export class CommentRepository extends BaseRepository<
 
   async findByAuthor(
     authorId: string,
-    { query, initiator }: QueryMethodParams,
+    { query, initiator }: QueryMethodParams<CommentQuery>,
   ): Promise<[CommentDocumentPopulated[], number]> {
     const pipeline = [
       stages.match<CommentDocument>({
@@ -80,7 +81,7 @@ export class CommentRepository extends BaseRepository<
       withAuthor(),
       withRecipe(initiator),
       stages.paginated({
-        sort: { sort: "createdAt", order: "desc" },
+        sort: { sort: query.sort, order: query.order },
         page: query.page,
         limit: query.limit,
       }),

--- a/apps/backend/src/modules/comments/comment.repository.ts
+++ b/apps/backend/src/modules/comments/comment.repository.ts
@@ -54,7 +54,7 @@ export class CommentRepository extends BaseRepository<
       withAuthor(),
       withRecipe(initiator),
       stages.paginated({
-        sort: "-createdAt",
+        sort: { sort: "createdAt", order: "desc" },
         page: query.page,
         limit: query.limit,
       }),
@@ -80,7 +80,7 @@ export class CommentRepository extends BaseRepository<
       withAuthor(),
       withRecipe(initiator),
       stages.paginated({
-        sort: "-createdAt",
+        sort: { sort: "createdAt", order: "desc" },
         page: query.page,
         limit: query.limit,
       }),

--- a/apps/backend/src/modules/comments/comment.service.test.ts
+++ b/apps/backend/src/modules/comments/comment.service.test.ts
@@ -1,18 +1,29 @@
+import type { CommentQuery } from "@recipes/shared/comments";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createCommentDoc,
   createObjectId,
   initiator,
-  queryParams,
 } from "@/__tests__/helpers.js";
 import {
   BadRequestError,
   ForbiddenError,
   NotFoundError,
 } from "@/common/errors.js";
+import type { QueryMethodParams } from "@/common/types/methods.js";
 import { createCommentService } from "@/modules/comments/comment.service.js";
 
 describe("commentService", () => {
+  const commentQueryParams = (): QueryMethodParams<CommentQuery> => ({
+    query: {
+      page: 1,
+      limit: 10,
+      sort: "createdAt",
+      order: "desc",
+    },
+    initiator: initiator(),
+  });
+
   const mockCommentRepository = {
     findByRecipe: vi.fn(),
     findByAuthor: vi.fn(),
@@ -63,7 +74,7 @@ describe("commentService", () => {
 
       const result = await service.findByRecipe(
         recipeId.toString(),
-        queryParams(),
+        commentQueryParams(),
       );
 
       expect(result.items).toHaveLength(1);
@@ -73,7 +84,7 @@ describe("commentService", () => {
 
     it("should throw BadRequestError for invalid recipe ID", async () => {
       await expect(
-        service.findByRecipe("invalid-id", queryParams()),
+        service.findByRecipe("invalid-id", commentQueryParams()),
       ).rejects.toThrow(BadRequestError);
     });
 
@@ -81,7 +92,7 @@ describe("commentService", () => {
       mockRecipeRepository.exists.mockResolvedValue(null);
 
       await expect(
-        service.findByRecipe(createObjectId().toString(), queryParams()),
+        service.findByRecipe(createObjectId().toString(), commentQueryParams()),
       ).rejects.toThrow(NotFoundError);
     });
 
@@ -91,7 +102,7 @@ describe("commentService", () => {
 
       const result = await service.findByRecipe(
         createObjectId().toString(),
-        queryParams(),
+        commentQueryParams(),
       );
 
       expect(result.items).toEqual([]);
@@ -117,7 +128,7 @@ describe("commentService", () => {
 
       const result = await service.findByAuthor(
         authorId.toString(),
-        queryParams(),
+        commentQueryParams(),
       );
 
       expect(result.items).toHaveLength(1);
@@ -126,7 +137,7 @@ describe("commentService", () => {
 
     it("should throw BadRequestError for invalid author ID", async () => {
       await expect(
-        service.findByAuthor("invalid-id", queryParams()),
+        service.findByAuthor("invalid-id", commentQueryParams()),
       ).rejects.toThrow(BadRequestError);
     });
   });

--- a/apps/backend/src/modules/comments/comment.service.ts
+++ b/apps/backend/src/modules/comments/comment.service.ts
@@ -1,5 +1,6 @@
 import type {
   CommentDetails,
+  CommentQuery,
   CreateCommentInput,
 } from "@recipes/shared/comments";
 import type { Paginated } from "@recipes/shared/core";
@@ -20,11 +21,11 @@ import type { CommentRepository } from "./comment.repository.js";
 export interface CommentService {
   findByRecipe(
     recipeId: string,
-    params: QueryMethodParams,
+    params: QueryMethodParams<CommentQuery>,
   ): Promise<Paginated<CommentDetails>>;
   findByAuthor(
     authorId: string,
-    params: QueryMethodParams,
+    params: QueryMethodParams<CommentQuery>,
   ): Promise<Paginated<CommentDetails>>;
   create(
     recipeId: string,

--- a/apps/backend/src/modules/cuisines/cuisine.cache.ts
+++ b/apps/backend/src/modules/cuisines/cuisine.cache.ts
@@ -6,6 +6,7 @@ export const cuisineCache = {
     list: (query: CuisineQuery) =>
       `list:${hashFilters({
         sort: query.sort,
+        order: query.order,
         page: query.page,
         limit: query.limit,
       })}`,

--- a/apps/backend/src/modules/cuisines/cuisine.repository.int.test.ts
+++ b/apps/backend/src/modules/cuisines/cuisine.repository.int.test.ts
@@ -22,6 +22,7 @@ describe("CuisineRepository", () => {
 
       const [items, total] = await repository.findMany({
         sort: "name",
+        order: "asc",
         page: 1,
         limit: 10,
       });
@@ -39,6 +40,7 @@ describe("CuisineRepository", () => {
     it("should return empty result when no cuisines exist", async () => {
       const [items, total] = await repository.findMany({
         sort: "name",
+        order: "asc",
         page: 1,
         limit: 10,
       });
@@ -54,6 +56,7 @@ describe("CuisineRepository", () => {
 
       const [items, total] = await repository.findMany({
         sort: "name",
+        order: "asc",
         page: 2,
         limit: 1,
       });
@@ -70,6 +73,7 @@ describe("CuisineRepository", () => {
 
       const [items] = await repository.findMany({
         sort: "name",
+        order: "asc",
         page: 1,
         limit: 10,
       });
@@ -83,7 +87,8 @@ describe("CuisineRepository", () => {
       await createDbCuisine({ name: "Mango" });
 
       const [items] = await repository.findMany({
-        sort: "-name",
+        sort: "name",
+        order: "desc",
         page: 1,
         limit: 10,
       });

--- a/apps/backend/src/modules/cuisines/cuisine.repository.ts
+++ b/apps/backend/src/modules/cuisines/cuisine.repository.ts
@@ -42,7 +42,7 @@ export class CuisineRepository extends BaseRepository<
       stages.project({ recipes: 0 }),
       stages.paginated(
         {
-          sort: query.sort,
+          sort: { sort: query.sort, order: query.order },
           page: query.page,
           limit: query.limit,
         },

--- a/apps/backend/src/modules/cuisines/cuisine.service.test.ts
+++ b/apps/backend/src/modules/cuisines/cuisine.service.test.ts
@@ -62,7 +62,12 @@ describe("cuisineService", () => {
       ];
       mockCuisineRepository.findMany.mockResolvedValue([docs, 2]);
 
-      const query = { sort: "name" as const, page: 1, limit: 10 };
+      const query = {
+        sort: "name" as const,
+        order: "asc" as const,
+        page: 1,
+        limit: 10,
+      };
       const result = await service.findAll({
         query,
         initiator: noInitiator(),
@@ -85,7 +90,12 @@ describe("cuisineService", () => {
     it("should return empty paginated result when no cuisines exist", async () => {
       mockCuisineRepository.findMany.mockResolvedValue([[], 0]);
 
-      const query = { sort: "name" as const, page: 1, limit: 10 };
+      const query = {
+        sort: "name" as const,
+        order: "asc" as const,
+        page: 1,
+        limit: 10,
+      };
       const result = await service.findAll({
         query,
         initiator: noInitiator(),
@@ -105,7 +115,12 @@ describe("cuisineService", () => {
       ];
       mockCuisineRepository.findMany.mockResolvedValue([docs, 1]);
 
-      const query = { sort: "name" as const, page: 1, limit: 10 };
+      const query = {
+        sort: "name" as const,
+        order: "asc" as const,
+        page: 1,
+        limit: 10,
+      };
       await service.findAll({
         query,
         initiator: noInitiator(),

--- a/apps/backend/src/modules/favorites/favorite.repository.ts
+++ b/apps/backend/src/modules/favorites/favorite.repository.ts
@@ -51,7 +51,7 @@ export class FavoriteRepository extends BaseRepository<
       stages.unset<FavoriteDocument>("__v", "user"),
       withRecipe(initiator),
       stages.paginated({
-        sort: "-createdAt",
+        sort: { sort: "createdAt", order: "desc" },
         page: query.page,
         limit: query.limit,
       }),

--- a/apps/backend/src/modules/recipes/recipe.cache.ts
+++ b/apps/backend/src/modules/recipes/recipe.cache.ts
@@ -9,6 +9,7 @@ export const recipeCache = {
         category: filters.category,
         difficulty: filters.difficulty,
         sort: filters.sort,
+        order: filters.order,
         minCookingTime: filters.minCookingTime,
         maxCookingTime: filters.maxCookingTime,
       })}`,

--- a/apps/backend/src/modules/recipes/recipe.repository.int.test.ts
+++ b/apps/backend/src/modules/recipes/recipe.repository.int.test.ts
@@ -32,7 +32,7 @@ describe("RecipeRepository", () => {
       });
 
       const [recipes, total] = await repository.aggregateSearch({
-        query: { page: 1, limit: 10, sort: "-createdAt" },
+        query: { page: 1, limit: 10, sort: "createdAt", order: "desc" },
         initiator: { id: undefined, role: undefined },
       });
 
@@ -56,7 +56,7 @@ describe("RecipeRepository", () => {
       });
 
       const [recipes, total] = await repository.aggregateSearch({
-        query: { page: 1, limit: 10, sort: "-createdAt" },
+        query: { page: 1, limit: 10, sort: "createdAt", order: "desc" },
         initiator: { id: undefined, role: undefined },
       });
 
@@ -75,7 +75,7 @@ describe("RecipeRepository", () => {
       });
 
       const [recipes, total] = await repository.aggregateSearch({
-        query: { page: 1, limit: 10, sort: "-createdAt" },
+        query: { page: 1, limit: 10, sort: "createdAt", order: "desc" },
         initiator: {
           id: author._id.toString(),
           role: "user",
@@ -97,7 +97,7 @@ describe("RecipeRepository", () => {
       });
 
       const [, total] = await repository.aggregateSearch({
-        query: { page: 1, limit: 10, sort: "-createdAt" },
+        query: { page: 1, limit: 10, sort: "createdAt", order: "desc" },
         initiator: {
           id: admin._id.toString(),
           role: "admin",
@@ -128,7 +128,8 @@ describe("RecipeRepository", () => {
         query: {
           page: 1,
           limit: 10,
-          sort: "-createdAt",
+          sort: "createdAt",
+          order: "desc",
           categoryId: catA._id.toString(),
         },
         initiator: { id: undefined, role: undefined },
@@ -158,7 +159,8 @@ describe("RecipeRepository", () => {
         query: {
           page: 1,
           limit: 10,
-          sort: "-createdAt",
+          sort: "createdAt",
+          order: "desc",
           difficulty: "hard",
         },
         initiator: { id: undefined, role: undefined },
@@ -183,7 +185,8 @@ describe("RecipeRepository", () => {
         query: {
           page: 1,
           limit: 10,
-          sort: "-createdAt",
+          sort: "createdAt",
+          order: "desc",
           isFavorited: true,
         },
         initiator: {
@@ -218,7 +221,8 @@ describe("RecipeRepository", () => {
         query: {
           page: 1,
           limit: 10,
-          sort: "-createdAt",
+          sort: "createdAt",
+          order: "desc",
           minCookingTime: 15 as Minutes,
         },
         initiator: noInitiator(),
@@ -250,7 +254,8 @@ describe("RecipeRepository", () => {
         query: {
           page: 1,
           limit: 10,
-          sort: "-createdAt",
+          sort: "createdAt",
+          order: "desc",
           maxCookingTime: 15 as Minutes,
         },
         initiator: noInitiator(),
@@ -289,7 +294,8 @@ describe("RecipeRepository", () => {
         query: {
           page: 1,
           limit: 10,
-          sort: "-createdAt",
+          sort: "createdAt",
+          order: "desc",
           minCookingTime: 15 as Minutes,
           maxCookingTime: 25 as Minutes,
         },
@@ -352,7 +358,8 @@ describe("RecipeRepository", () => {
           query: {
             page: 1,
             limit: 10,
-            sort: "-createdAt",
+            sort: "createdAt",
+            order: "desc",
             mealType,
           },
           initiator: noInitiator(),
@@ -394,7 +401,8 @@ describe("RecipeRepository", () => {
         query: {
           page: 1,
           limit: 10,
-          sort: "-createdAt",
+          sort: "createdAt",
+          order: "desc",
           cuisineId: italian._id.toString(),
         },
         initiator: noInitiator(),
@@ -418,7 +426,7 @@ describe("RecipeRepository", () => {
       });
 
       const [recipes] = await repository.aggregateSearch({
-        query: { page: 1, limit: 10, sort: "-createdAt" },
+        query: { page: 1, limit: 10, sort: "createdAt", order: "desc" },
         initiator: noInitiator(),
       });
 
@@ -457,7 +465,7 @@ describe("RecipeRepository", () => {
       });
 
       const [recipes] = await repository.aggregateSearch({
-        query: { page: 1, limit: 10, sort: "-createdAt" },
+        query: { page: 1, limit: 10, sort: "createdAt", order: "desc" },
         initiator: {
           id: user._id.toString(),
           role: "user",
@@ -486,7 +494,7 @@ describe("RecipeRepository", () => {
       });
 
       const [recipes, total] = await repository.aggregateSearch({
-        query: { page: 2, limit: 1, sort: "-createdAt" },
+        query: { page: 2, limit: 1, sort: "createdAt", order: "desc" },
         initiator: { id: undefined, role: undefined },
       });
 
@@ -541,7 +549,7 @@ describe("RecipeRepository", () => {
       });
 
       const [recipes] = await repository.aggregateSearch({
-        query: { page: 1, limit: 10, sort: "-popularity" },
+        query: { page: 1, limit: 10, sort: "popularity", order: "desc" },
         initiator: noInitiator(),
       });
 
@@ -598,7 +606,7 @@ describe("RecipeRepository", () => {
       });
 
       const [recipes] = await repository.aggregateSearch({
-        query: { page: 1, limit: 10, sort: "popularity" },
+        query: { page: 1, limit: 10, sort: "popularity", order: "asc" },
         initiator: noInitiator(),
       });
 

--- a/apps/backend/src/modules/recipes/recipe.repository.ts
+++ b/apps/backend/src/modules/recipes/recipe.repository.ts
@@ -90,6 +90,7 @@ export class RecipeRepository extends BaseRepository<
       page,
       limit,
       sort,
+      order,
       isFavorited,
       search,
       categoryId,
@@ -100,10 +101,7 @@ export class RecipeRepository extends BaseRepository<
       maxCookingTime,
     } = query;
 
-    const sortWithPopularityReplaced = sort.replace(
-      "popularity",
-      "stats.popularity",
-    );
+    const sortField = sort === "popularity" ? "stats.popularity" : sort;
 
     const pipeline = [
       stages.match<RecipeDocument>({
@@ -125,7 +123,7 @@ export class RecipeRepository extends BaseRepository<
 
       stages.paginated(
         {
-          sort: sortWithPopularityReplaced,
+          sort: { sort: sortField, order },
           page,
           limit,
         },

--- a/apps/backend/src/modules/recipes/recipe.routes.test.ts
+++ b/apps/backend/src/modules/recipes/recipe.routes.test.ts
@@ -109,7 +109,7 @@ describe("recipeRoutes", () => {
         value: paginatedResult,
         cache: {
           status: "miss",
-          key: "recipes:list:page=1:limit=10:sort=-createdAt",
+          key: "recipes:list:page=1:limit=10:sort=createdAt:order=desc",
           ttl: 120,
         },
       });

--- a/apps/backend/src/modules/recipes/recipe.service.test.ts
+++ b/apps/backend/src/modules/recipes/recipe.service.test.ts
@@ -88,7 +88,8 @@ describe("recipeService", () => {
       const query = {
         page: 1,
         limit: 10,
-        sort: "-createdAt",
+        sort: "createdAt",
+        order: "desc",
       } satisfies RecipeQuery;
       const result = await service.findAll({
         query,
@@ -112,7 +113,8 @@ describe("recipeService", () => {
       const query = {
         page: 1,
         limit: 10,
-        sort: "-createdAt",
+        sort: "createdAt",
+        order: "desc",
       } satisfies RecipeQuery;
       const result = await service.findAll({
         query,
@@ -128,7 +130,8 @@ describe("recipeService", () => {
       const query = {
         page: 1,
         limit: 10,
-        sort: "-createdAt",
+        sort: "createdAt",
+        order: "desc",
         isFavorited: true,
       } satisfies RecipeQuery;
       const result = await service.findAll({
@@ -162,7 +165,8 @@ describe("recipeService", () => {
       const query = {
         page: 1,
         limit: 10,
-        sort: "-createdAt",
+        sort: "createdAt",
+        order: "desc",
       } satisfies RecipeQuery;
       const result = await service.findAll({
         query,
@@ -181,7 +185,8 @@ describe("recipeService", () => {
       const query = {
         page: 1,
         limit: 10,
-        sort: "-createdAt",
+        sort: "createdAt",
+        order: "desc",
       } satisfies RecipeQuery;
       const result = await service.findAll({
         query,

--- a/apps/backend/src/modules/reviews/review.repository.int.test.ts
+++ b/apps/backend/src/modules/reviews/review.repository.int.test.ts
@@ -75,7 +75,7 @@ describe("ReviewRepository", () => {
       await createDbReview({ author: user2._id, text: "Second", rating: 4 });
 
       const [reviews, total] = await repository.findAll({
-        query: { page: 1, limit: 10, sort: "-createdAt" },
+        query: { page: 1, limit: 10, sort: "createdAt", order: "desc" },
         initiator: { id: undefined, role: undefined },
       });
 
@@ -92,7 +92,13 @@ describe("ReviewRepository", () => {
       await createDbReview({ author: user2._id, isFeatured: false });
 
       const [reviews, total] = await repository.findAll({
-        query: { page: 1, limit: 10, sort: "-createdAt", isFeatured: true },
+        query: {
+          page: 1,
+          limit: 10,
+          sort: "createdAt",
+          order: "desc",
+          isFeatured: true,
+        },
         initiator: { id: undefined, role: undefined },
       });
 
@@ -109,7 +115,7 @@ describe("ReviewRepository", () => {
       await createDbReview({ author: user2._id, text: "Second" });
 
       const [reviews, total] = await repository.findAll({
-        query: { page: 2, limit: 1, sort: "-createdAt" },
+        query: { page: 2, limit: 1, sort: "createdAt", order: "desc" },
         initiator: { id: undefined, role: undefined },
       });
 

--- a/apps/backend/src/modules/reviews/review.repository.ts
+++ b/apps/backend/src/modules/reviews/review.repository.ts
@@ -40,7 +40,7 @@ export class ReviewRepository extends BaseRepository<
       stages.match<ReviewDocument>({ isFeatured: true }),
       stages.unset<ReviewDocument>("__v"),
       withAuthor(),
-      stages.sort("-createdAt"),
+      stages.sort({ sort: "createdAt", order: "desc" }),
       stages.limit(limit),
     ].flat();
 
@@ -64,7 +64,7 @@ export class ReviewRepository extends BaseRepository<
       stages.unset<ReviewDocument>("__v"),
       withAuthor(),
       stages.paginated({
-        sort: query.sort,
+        sort: { sort: query.sort, order: query.order },
         page: query.page,
         limit: query.limit,
       }),

--- a/apps/backend/src/modules/reviews/review.service.test.ts
+++ b/apps/backend/src/modules/reviews/review.service.test.ts
@@ -191,7 +191,7 @@ describe("reviewService", () => {
       mockReviewRepository.findAll.mockResolvedValue([[review], 1]);
 
       const result = await service.findAll({
-        query: { page: 1, limit: 10, sort: "-createdAt" },
+        query: { page: 1, limit: 10, sort: "createdAt", order: "desc" },
         initiator: initiator(),
       });
 

--- a/apps/backend/src/modules/users/user.service.test.ts
+++ b/apps/backend/src/modules/users/user.service.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createObjectId,
   createUserDoc,
+  initiator,
   queryParams,
 } from "@/__tests__/helpers.js";
 import { NotFoundError } from "@/common/errors.js";
@@ -94,10 +95,15 @@ describe("userService", () => {
       };
       mockCommentService.findByAuthor.mockResolvedValue(expected);
 
-      const result = await service.getComments(
-        createObjectId().toString(),
-        queryParams(),
-      );
+      const result = await service.getComments(createObjectId().toString(), {
+        query: {
+          page: 1,
+          limit: 10,
+          sort: "createdAt",
+          order: "desc",
+        },
+        initiator: initiator(),
+      });
 
       expect(mockCommentService.findByAuthor).toHaveBeenCalled();
       expect(result).toBe(expected);

--- a/apps/backend/src/modules/users/user.service.ts
+++ b/apps/backend/src/modules/users/user.service.ts
@@ -1,4 +1,4 @@
-import type { CommentDetails } from "@recipes/shared/comments";
+import type { CommentDetails, CommentQuery } from "@recipes/shared/comments";
 import type { Paginated } from "@recipes/shared/core";
 import type { PaginationQuery } from "@recipes/shared/query";
 import type { RecipeListItem } from "@recipes/shared/recipes";
@@ -21,7 +21,7 @@ export interface UserService {
   ): Promise<Paginated<RecipeListItem>>;
   getComments(
     userId: string,
-    params: QueryMethodParams<PaginationQuery, DefaultInitiator>,
+    params: QueryMethodParams<CommentQuery, DefaultInitiator>,
   ): Promise<Paginated<CommentDetails>>;
 }
 

--- a/apps/frontend/src/pages/index.vue
+++ b/apps/frontend/src/pages/index.vue
@@ -23,7 +23,7 @@ const {
   isLoading: isCategoriesLoading,
   error: categoriesError,
 } = useQuery(
-  categoryListOptions({ sort: "-recipeCount", limit: CATEGORIES_LIMIT }),
+  categoryListOptions({ sort: "recipeCount", order: "desc", limit: CATEGORIES_LIMIT }),
 );
 
 const { data: testimonials, isLoading: isTestimonialsLoading } = useQuery(
@@ -36,7 +36,7 @@ const {
   isLoading: isPopularRecipesLoading,
   error: popularRecipesError,
 } = useQuery(
-  recipeListOptions({ sort: "-popularity", limit: POPULAR_RECIPES_LIMIT }),
+  recipeListOptions({ sort: "popularity", order: "desc", limit: POPULAR_RECIPES_LIMIT }),
 );
 
 const authStore = useAuthStore();

--- a/packages/shared/src/categories/category.query.ts
+++ b/packages/shared/src/categories/category.query.ts
@@ -1,9 +1,10 @@
 import { z } from "zod";
-import { createSortSchema, paginationQuerySchema } from "../query/index.js";
+import { paginationQuerySchema, sortOrderSchema } from "../query/index.js";
 
 export const categoryQuerySchema = z
   .object({
-    sort: createSortSchema(["name", "recipeCount"]).default("name"),
+    sort: z.enum(["name", "recipeCount"]).default("name"),
+    order: sortOrderSchema.default("asc"),
   })
   .extend(paginationQuerySchema.shape);
 

--- a/packages/shared/src/comments/comment.query.ts
+++ b/packages/shared/src/comments/comment.query.ts
@@ -1,6 +1,11 @@
-import type { z } from "zod";
-import { paginationQuerySchema } from "../query/index.js";
+import { z } from "zod";
+import { paginationQuerySchema, sortOrderSchema } from "../query/index.js";
 
-export const commentQuerySchema = paginationQuerySchema;
+export const commentQuerySchema = z
+  .object({
+    sort: z.enum(["createdAt"]).default("createdAt"),
+    order: sortOrderSchema.default("desc"),
+  })
+  .extend(paginationQuerySchema.shape);
 
 export type CommentQuery = z.infer<typeof commentQuerySchema>;

--- a/packages/shared/src/cuisines/cuisine.query.ts
+++ b/packages/shared/src/cuisines/cuisine.query.ts
@@ -1,9 +1,10 @@
 import { z } from "zod";
-import { createSortSchema, paginationQuerySchema } from "../query/index.js";
+import { paginationQuerySchema, sortOrderSchema } from "../query/index.js";
 
 export const cuisineQuerySchema = z
   .object({
-    sort: createSortSchema(["name", "recipeCount"]).default("name"),
+    sort: z.enum(["name", "recipeCount"]).default("name"),
+    order: sortOrderSchema.default("asc"),
   })
   .extend(paginationQuerySchema.shape);
 

--- a/packages/shared/src/query/schema.test.ts
+++ b/packages/shared/src/query/schema.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { categoryQuerySchema } from "../categories/category.query";
+import { cuisineQuerySchema } from "../cuisines/cuisine.query";
+import { recipeQuerySchema } from "../recipes/recipe.query";
+import { reviewQuerySchema } from "../reviews/review.query";
+
+describe("query sort defaults", () => {
+  it("defaults category queries to name ascending", () => {
+    expect(categoryQuerySchema.parse({})).toMatchObject({
+      sort: "name",
+      order: "asc",
+    });
+  });
+
+  it("defaults cuisine queries to name ascending", () => {
+    expect(cuisineQuerySchema.parse({})).toMatchObject({
+      sort: "name",
+      order: "asc",
+    });
+  });
+
+  it("defaults recipe queries to createdAt descending", () => {
+    expect(recipeQuerySchema.parse({})).toMatchObject({
+      sort: "createdAt",
+      order: "desc",
+    });
+  });
+
+  it("defaults review queries to createdAt descending", () => {
+    expect(reviewQuerySchema.parse({})).toMatchObject({
+      sort: "createdAt",
+      order: "desc",
+    });
+  });
+});

--- a/packages/shared/src/query/schema.test.ts
+++ b/packages/shared/src/query/schema.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { categoryQuerySchema } from "../categories/category.query";
+import { commentQuerySchema } from "../comments/comment.query";
 import { cuisineQuerySchema } from "../cuisines/cuisine.query";
 import { recipeQuerySchema } from "../recipes/recipe.query";
 import { reviewQuerySchema } from "../reviews/review.query";
@@ -28,6 +29,13 @@ describe("query sort defaults", () => {
 
   it("defaults review queries to createdAt descending", () => {
     expect(reviewQuerySchema.parse({})).toMatchObject({
+      sort: "createdAt",
+      order: "desc",
+    });
+  });
+
+  it("defaults comment queries to createdAt descending", () => {
+    expect(commentQuerySchema.parse({})).toMatchObject({
       sort: "createdAt",
       order: "desc",
     });

--- a/packages/shared/src/query/sort.test.ts
+++ b/packages/shared/src/query/sort.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { getSortObject } from "./sort";
+
+describe("getSortObject", () => {
+  it("returns ascending MongoDB sort object", () => {
+    expect(getSortObject({ sort: "createdAt", order: "asc" })).toEqual({
+      createdAt: 1,
+    });
+  });
+
+  it("returns descending MongoDB sort object", () => {
+    expect(getSortObject({ sort: "createdAt", order: "desc" })).toEqual({
+      createdAt: -1,
+    });
+  });
+});

--- a/packages/shared/src/query/sort.ts
+++ b/packages/shared/src/query/sort.ts
@@ -1,51 +1,27 @@
 import { z } from "zod";
 
-/**
- * Extracts the sort name and sort order from a sort string.
- *
- * @param sort - The sort string.
- * @returns An array containing the sort name and sort order.
- *
- * @example
- * getSortDetails("name"); // ["name", 1]
- * getSortDetails("-name"); // ["name", -1]
- */
-export function getSortDetails<const T extends string>(sort: T): [T, 1 | -1] {
-  const desc = sort.startsWith("-");
-  const sortName = desc ? (sort.slice(1) as T) : sort;
-  const sortOrder = desc ? -1 : 1;
+export const sortOrderSchema = z.enum(["asc", "desc"]);
 
-  return [sortName, sortOrder];
-}
+export type SortOrder = z.infer<typeof sortOrderSchema>;
 
 /**
- * Converts a sort string to a MongoDB compatible sort object.
+ * Converts a sort field and order to a MongoDB compatible sort object.
  *
- * @param sort - The sort string.
+ * @param options - The sort field and order.
  * @returns A MongoDB sort object.
  *
  * @example
- * getSortObject("name"); // { name: 1 }
- * getSortObject("-name"); // { name: -1 }
+ * getSortObject({ sort: "name", order: "asc" }); // { name: 1 }
+ * getSortObject({ sort: "name", order: "desc" }); // { name: -1 }
  */
-export function getSortObject<const T extends string>(sort: T) {
-  const [name, order] = getSortDetails(sort);
+export function getSortObject<const T extends string>({
+  sort,
+  order,
+}: {
+  sort: T;
+  order: SortOrder;
+}): Record<T, 1 | -1> {
+  const sortOrder: 1 | -1 = order === "desc" ? -1 : 1;
 
-  return { [name]: order };
-}
-
-/**
- * Creates a Zod schema for sorting by a given list of fields.
- *
- * @param fields - The list of fields to sort by.
- * @returns A Zod schema for sorting by the given fields.
- *
- * @example
- * createSortSchema(["name", "createdAt"]); // z.enum(["name", "createdAt", "-name", "-createdAt"])
- */
-export function createSortSchema<const T extends string>(
-  fields: readonly [T, ...T[]],
-) {
-  const variants = fields.flatMap((f) => [f, `-${f}`] as const);
-  return z.enum(variants);
+  return { [sort]: sortOrder } as Record<T, 1 | -1>;
 }

--- a/packages/shared/src/recipes/recipe.query.ts
+++ b/packages/shared/src/recipes/recipe.query.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
 import {
-  createSortSchema,
   paginationQuerySchema,
   searchQuerySchema,
+  sortOrderSchema,
 } from "../query/index.js";
 import {
   difficultySchema,
@@ -12,9 +12,10 @@ import {
 
 export const recipeQuerySchema = z
   .object({
-    sort: createSortSchema(["createdAt", "cookingTime", "popularity"]).default(
-      "-createdAt",
-    ),
+    sort: z
+      .enum(["createdAt", "cookingTime", "popularity"])
+      .default("createdAt"),
+    order: sortOrderSchema.default("desc"),
     category: z.string().trim().optional(),
     cuisine: z.string().trim().optional(),
     difficulty: difficultySchema.optional(),

--- a/packages/shared/src/reviews/review.query.ts
+++ b/packages/shared/src/reviews/review.query.ts
@@ -1,9 +1,10 @@
 import { z } from "zod";
-import { createSortSchema, paginationQuerySchema } from "../query/index.js";
+import { paginationQuerySchema, sortOrderSchema } from "../query/index.js";
 
 export const reviewQuerySchema = z
   .object({
-    sort: createSortSchema(["createdAt", "rating"]).default("-createdAt"),
+    sort: z.enum(["createdAt", "rating"]).default("createdAt"),
+    order: sortOrderSchema.default("desc"),
     isFeatured: z.coerce.boolean().optional(),
   })
   .extend(paginationQuerySchema.shape);


### PR DESCRIPTION
## Related Issues

<!-- Link related issues: Closes #123, Refs #456 -->

## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring
- [x] Tests
- [ ] Other

## Description

Splits query sorting from the previous signed string format (`sort=-createdAt`) into explicit `sort` and `order` fields across the shared query contract and app usage. Query schemas now expose allowed field names through `sort` and use `order=asc|desc` for direction, while backend aggregation helpers convert that pair into Mongo sort objects.

Main changes:

- Replaces signed sort parsing with explicit `sort` + `order` handling in shared query helpers.
- Updates recipe, category, cuisine, and review query contracts and backend/frontend call sites to use the new shape.
- Adds `order` to list cache keys so ascending and descending results are cached separately.
- Extends comments with the same `sort=createdAt` + `order=desc` contract, replacing hardcoded repository sorting.
- Updates tests and removes stale signed-sort expectations.

Validation run:

- `pnpm --filter @recipes/shared test`
- `pnpm --filter @recipes/shared build`
- `pnpm --filter @recipes/backend test:unit -- src/modules/recipes/recipe.routes.test.ts src/modules/comments/comment.service.test.ts src/modules/users/user.service.test.ts src/common/utils/stages.test.ts`
- `pnpm typecheck`
- `pnpm check`

## Screenshots

Not applicable.

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Added/updated tests for new functionality
- [ ] Updated documentation (if needed)
